### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ type_definition ::= <product_definition> | <sum_definition> | <record_definition
 
 // Product
 product_definition ::= '(' 'product' <product_body>')'
-product_body ::= symbol <element_definition>...
+product_body ::= symbol <type_ref>...
 
 // Record
 record_definition ::= '(' 'record' <record_body> ')'


### PR DESCRIPTION
There is no `element_definition` defined elsewhere in the grammar.  It should be `type_ref` instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
