### PR TITLE
Revise product element naming syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,11 +362,7 @@ a single Ion annotation that prefixes the element definition.  For example, give
     last_name::(l symbol))
 ```
 
-Note that identifiers only need to be specified if the name of an element in the generated code should be different
-than in its s-expression representation.  If unspecified (as is 'mi' element above), element's identifier defaults 
-to the tag.
-
-An example s-expression representation would be
+An example s-expression representation would be:
 
 ```
 (person (f James) (mi T) (l Kirk))
@@ -382,8 +378,12 @@ class Person(
 ): ...
 ```
 
-Note that the second property has the `mi` name which was used because the identifier was not specified for the `mi`
+That the second property has the `mi` name which was used because the identifier was not specified for the `mi`
 field in the record definition. 
+
+Note that identifiers only need to be specified if the name of an element in the generated code should be different
+than the tag s-expression representation.  If unspecified (as is 'mi' element above), element's identifier defaults 
+to the tag.
 
 Unlike record elements, product element defintions must include identifiers. 
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ to simply as "domain".
 - `permuted domain`: A type domain that permutes a copy of another domain by removing types, adding types or altering 
 sum types, creating a new, independent domain. 
 - `data type`: All of Ion's data types plus sum and product types which are composed of other data types.
-- `product type`: also known as n-tuple.  Similar to an array, but the elements of the product types may have. 
-different data types.  In this respect it is also similar to a struct in C, but the members do not have names. 
+- `product` : also known as n-tuple.  Similar to an array, but the elements of the product types may have. 
+different data types.  The s-expression representations of products do not have names, however names are
+required for code generation of target languages that do not have native support for unnamed tuples.  
 - `sum type`: a.k.a. [tagged union](https://en.wikipedia.org/wiki/Tagged_union).
 - `record`: a product or variant with named elements.
 - `variant`: An element of a sum type which consists of a name and zero or more types.
@@ -67,33 +68,30 @@ transformation code.
 ### Example Type Universe
 
 ```
-// Define type domain for a language named "toy".  
-// Toy has literals, variables, basic arithmetic and functions that accept a single argument.
+// This is an AST (abstract syntax tree) for a simple hypothetical programming language named "Toy".
+// Toy has literals, variables, basic arithmetic and functions that accept a single argument. 
 
 (define toy_lang
-    (domain 
+    (domain
         (sum expr
-            (product lit (value ion))
-            (product variable (name symbol))
-            (product not (expr expr))
-            (product plus (operands (* expr 2)))
-            (product minus (operands (* expr 2)))
-            (product times (operands (* expr 2)))
-            (product divide (operands (* expr 2)))
-            (product modulo (operands (* expr 2)))
-            (product call (func expr) (arg expr))
-            (product let (name symbol) (value expr) (body expr))
-            (product function (arg_name symbol) (body (expr))))
+            (lit value::ion)
+            (variable name::symbol)
+            (not expr::expr)
+            (apply op operands::(* expr 2))
+            (call name::symbol argument::expr)
+            (let name::symbol value::expr body::expr)
+            (function var_name::symbol body::expr))
+        (sum op (plus) (minus) (times) (divide))
+))
 
 // Define another type domain which is the same as "toy_lang" but replaces variable names with DeBruijn indices:
-
 (define toy_lang_nameless
-    (permute_domain toy_lang
-        (with expr
-            (exclude variable let)
-            (include 
-                (product variable (index int))
-                (product let (index int) (value expr) (body expr))))))
+  (permute_domain toy_lang
+    (with expr
+      (exclude variable let)
+      (include
+        (variable index::int)
+        (let index::int value::expr body::expr)))))
 ```
 
 ### Generated Kotlin Domain Model Sample
@@ -175,14 +173,20 @@ type_universe ::= '(' 'define' symbol <domain_definition> ')'...
 // Domain
 domain_definition ::= <domain> | <permute_domain>
 domain ::= '(' 'domain' <type_definition>... ')'
-type_definition ::= <tuple> | <sum>
+type_definition ::= <product_definition> | <sum_definition> | <record_definition>
 
-// Tuples
-tuple ::= '(' ('product' | 'record') symbol <tuple_element>...')'
-tuple_element ::= '(' symbol <type_ref> ')'
+// Product
+product_definition ::= '(' 'product' <product_body>')'
+product_body ::= symbol ( symbol::<type_ref> )...
+
+// Record
+record_definition ::= '(' 'record' <record_body> ')'
+record_body ::= symbol ('(' symbol ( [symbol::]<field_definition> )... ')')
+field_definition ::= '(' symbol <type_ref> ')'
 
 // Sum
-sum ::= '(' 'sum' symbol <tuple>...')'
+sum_definition ::= '(' 'sum' symbol <variant_definition>...')'
+variant_definition ::= '(' symbol (<product_body> | <record_body>) ')'
 
 // Domain permutation
 permute_domain ::=
@@ -199,7 +203,7 @@ with ::=
     '(' 'with' symbol 
         (
               '(' 'exclude' symbol... ')' 
-            | '(' 'include' ( '(' <tuple> ')' )... ')' 
+            | '(' 'include' ( '(' <product_body> ')' )... ')' 
         )...
     ')'
 
@@ -210,7 +214,6 @@ type_ref ::= ion_type
            | '(' '*' symbol int ')'
     
 ion_type ::= 'int' | 'symbol' | 'bool' | 'ion'     
-
 ```
 
 #### PIG Phases
@@ -219,7 +222,7 @@ The processing phases of PIG are:
 
 - Parsing of type universe Ion file into an `IonElement`.
 - Transformation to target language neutral domain objects (`TypeUniverse`, et al)
-- Check for errors in type domain (undefined names, etc)
+- Check for errors in type domain (undefined or duplicate names, etc)
 - Apply all permutations to domains by cloning the domain being permuted while applying the `include` and 
 `exclude` entries.
 - Conversion to target language specific domain objects (`KotlinTypeUniverse`, et al)
@@ -323,7 +326,7 @@ An example of a sum variant record:
         ...
         (sum expr
             ...
-            (record select
+            (select
                 (project projection)
                 (from from_source)
                 (where (? expr))
@@ -333,6 +336,61 @@ An example of a sum variant record:
             ...)
         ...)))
 ```
+
+##### Naming Conventions
+
+All nameable components (type domains, types, elements, etc) of a type universe file should be named using the  
+[`snake_case`](https://en.wikipedia.org/wiki/Snake_case) naming convention.
+
+The language target may convert this to another naming convention.  For instance, the Kotlin target converts
+`snake_case` to [`camelCase` or `PascalCase`](https://en.wikipedia.org/wiki/Camel_case) as appropriate to 
+the context in order to provide an idiomatic API to the generated code.
+
+Future language targets may perform similar conversions.
+
+##### Element Naming
+
+Two types of names exist for the elements of products and records: *identifiers* and *tags*.  Tags are used
+by records as a field key in the s-expression representation of a record, while identifiers are used in the 
+generated code of both records and products.  For both records and products: an identifier can be specified with 
+a single Ion annotation that prefixes the element definition.  For example, given following type definitions:
+
+```
+(record person
+    first_name::(f symbol)
+    (mi (? symbol)) 
+    last_name::(l symbol))
+```
+
+Note that identifiers only need to be specified if the name of an element in the generated code should be different
+than in its s-expression representation.  If unspecified (as is 'mi' element above), element's identifier defaults 
+to the tag.
+
+An example s-expression representation would be
+
+```
+(person (f James) (mi T) (l Kirk))
+```
+
+While the generated Kotlin class is:
+
+```Kotlin
+class Person(
+    val firstName: SymbolPrimitive,
+    val mi: SymbolPrimitive?,
+    val lastName: SymbolPrimitive
+): ...
+```
+
+Note that the second property has the `mi` name which was used because the identifier was not specified for the `mi`
+field in the record definition. 
+
+Unlike record elements, product element defintions must include identifiers. 
+
+```      
+(product int_pair first::int second::int)
+```
+
 
 #### Using PIG In Your Project
 

--- a/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
@@ -29,7 +29,7 @@ class ToyLang private constructor() {
         fun lit(
             value: IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Lit =
             ToyLang.Expr.Lit(
                 value = value,
                 metas = metas)
@@ -38,7 +38,7 @@ class ToyLang private constructor() {
         fun variable(
             name: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Variable =
             ToyLang.Expr.Variable(
                 name = name.asPrimitive(),
                 metas = metas)
@@ -46,7 +46,7 @@ class ToyLang private constructor() {
         fun variable_(
             name: SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Variable =
             ToyLang.Expr.Variable(
                 name = name,
                 metas = metas)
@@ -55,7 +55,7 @@ class ToyLang private constructor() {
         fun not(
             expr: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Not =
             ToyLang.Expr.Not(
                 expr = expr,
                 metas = metas)
@@ -64,7 +64,7 @@ class ToyLang private constructor() {
         fun plus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Plus =
             ToyLang.Expr.Plus(
                 operands = operands,
                 metas = metas)
@@ -74,7 +74,7 @@ class ToyLang private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Plus =
             ToyLang.Expr.Plus(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -83,7 +83,7 @@ class ToyLang private constructor() {
         fun minus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Minus =
             ToyLang.Expr.Minus(
                 operands = operands,
                 metas = metas)
@@ -93,7 +93,7 @@ class ToyLang private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Minus =
             ToyLang.Expr.Minus(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -102,7 +102,7 @@ class ToyLang private constructor() {
         fun times(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Times =
             ToyLang.Expr.Times(
                 operands = operands,
                 metas = metas)
@@ -112,7 +112,7 @@ class ToyLang private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Times =
             ToyLang.Expr.Times(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -121,7 +121,7 @@ class ToyLang private constructor() {
         fun divide(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Divide =
             ToyLang.Expr.Divide(
                 operands = operands,
                 metas = metas)
@@ -131,7 +131,7 @@ class ToyLang private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Divide =
             ToyLang.Expr.Divide(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -140,7 +140,7 @@ class ToyLang private constructor() {
         fun modulo(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Modulo =
             ToyLang.Expr.Modulo(
                 operands = operands,
                 metas = metas)
@@ -150,7 +150,7 @@ class ToyLang private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Modulo =
             ToyLang.Expr.Modulo(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -158,22 +158,22 @@ class ToyLang private constructor() {
         
         fun call(
             name: String,
-            operands: Expr,
+            argument: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Call =
             ToyLang.Expr.Call(
                 name = name.asPrimitive(),
-                operands = operands,
+                argument = argument,
                 metas = metas)
         
         fun call_(
             name: SymbolPrimitive,
-            operands: Expr,
+            argument: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Call =
             ToyLang.Expr.Call(
                 name = name,
-                operands = operands,
+                argument = argument,
                 metas = metas)
         
         
@@ -182,7 +182,7 @@ class ToyLang private constructor() {
             value: Expr,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Let =
             ToyLang.Expr.Let(
                 name = name.asPrimitive(),
                 value = value,
@@ -194,7 +194,7 @@ class ToyLang private constructor() {
             value: Expr,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Let =
             ToyLang.Expr.Let(
                 name = name,
                 value = value,
@@ -206,7 +206,7 @@ class ToyLang private constructor() {
             varName: String,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Function =
             ToyLang.Expr.Function(
                 varName = varName.asPrimitive(),
                 body = body,
@@ -216,7 +216,7 @@ class ToyLang private constructor() {
             varName: SymbolPrimitive,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLang.Expr.Function =
             ToyLang.Expr.Function(
                 varName = varName,
                 body = body,
@@ -528,21 +528,21 @@ class ToyLang private constructor() {
     
         class Call(
             val name: SymbolPrimitive,
-            val operands: Expr,
+            val argument: Expr,
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
             override fun withMeta(metaKey: String, metaValue: Any): Call =
                 Call(
                     name = name,
-                    operands = operands,
+                    argument = argument,
                     metas = metas + metaContainerOf(metaKey to metaValue))
         
             override fun toIonElement(): SexpElement {
                 val elements = ionSexpOf(
                     ionSymbol("call"),
                     name.toIonElement(),
-                    operands.toIonElement(),
+                    argument.toIonElement(),
                     metas = metas)
                 return elements
             }
@@ -554,13 +554,13 @@ class ToyLang private constructor() {
         
                 other as Call
                 if (name != other.name) return false
-                if (operands != other.operands) return false
+                if (argument != other.argument) return false
                 return true
             }
         
             private val myHashCode by lazy(LazyThreadSafetyMode.NONE) {
                 var hc = name.hashCode()
-                hc = 31 * hc + operands.hashCode()
+                hc = 31 * hc + argument.hashCode()
                 hc
             }
         
@@ -727,10 +727,10 @@ class ToyLang private constructor() {
                 "call" -> {
                     sexp.requireArityOrMalformed(IntRange(2, 2))
                     val name = sexp.getRequired(0).toSymbolPrimitive()
-                    val operands = sexp.getRequired(1).transformExpect<Expr>()
+                    val argument = sexp.getRequired(1).transformExpect<Expr>()
                     ToyLang.Expr.Call(
                         name,
-                        operands,
+                        argument,
                         metas = sexp.metas)
                 }
                 "let" -> {
@@ -779,7 +779,7 @@ class ToyLangNameless private constructor() {
         fun lit(
             value: IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Lit =
             ToyLangNameless.Expr.Lit(
                 value = value,
                 metas = metas)
@@ -788,7 +788,7 @@ class ToyLangNameless private constructor() {
         fun not(
             expr: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Not =
             ToyLangNameless.Expr.Not(
                 expr = expr,
                 metas = metas)
@@ -797,7 +797,7 @@ class ToyLangNameless private constructor() {
         fun plus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Plus =
             ToyLangNameless.Expr.Plus(
                 operands = operands,
                 metas = metas)
@@ -807,7 +807,7 @@ class ToyLangNameless private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Plus =
             ToyLangNameless.Expr.Plus(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -816,7 +816,7 @@ class ToyLangNameless private constructor() {
         fun minus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Minus =
             ToyLangNameless.Expr.Minus(
                 operands = operands,
                 metas = metas)
@@ -826,7 +826,7 @@ class ToyLangNameless private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Minus =
             ToyLangNameless.Expr.Minus(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -835,7 +835,7 @@ class ToyLangNameless private constructor() {
         fun times(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Times =
             ToyLangNameless.Expr.Times(
                 operands = operands,
                 metas = metas)
@@ -845,7 +845,7 @@ class ToyLangNameless private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Times =
             ToyLangNameless.Expr.Times(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -854,7 +854,7 @@ class ToyLangNameless private constructor() {
         fun divide(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Divide =
             ToyLangNameless.Expr.Divide(
                 operands = operands,
                 metas = metas)
@@ -864,7 +864,7 @@ class ToyLangNameless private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Divide =
             ToyLangNameless.Expr.Divide(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -873,7 +873,7 @@ class ToyLangNameless private constructor() {
         fun modulo(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Modulo =
             ToyLangNameless.Expr.Modulo(
                 operands = operands,
                 metas = metas)
@@ -883,7 +883,7 @@ class ToyLangNameless private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Modulo =
             ToyLangNameless.Expr.Modulo(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -891,22 +891,22 @@ class ToyLangNameless private constructor() {
         
         fun call(
             name: String,
-            operands: Expr,
+            argument: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Call =
             ToyLangNameless.Expr.Call(
                 name = name.asPrimitive(),
-                operands = operands,
+                argument = argument,
                 metas = metas)
         
         fun call_(
             name: SymbolPrimitive,
-            operands: Expr,
+            argument: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Call =
             ToyLangNameless.Expr.Call(
                 name = name,
-                operands = operands,
+                argument = argument,
                 metas = metas)
         
         
@@ -914,7 +914,7 @@ class ToyLangNameless private constructor() {
             varName: String,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Function =
             ToyLangNameless.Expr.Function(
                 varName = varName.asPrimitive(),
                 body = body,
@@ -924,7 +924,7 @@ class ToyLangNameless private constructor() {
             varName: SymbolPrimitive,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Function =
             ToyLangNameless.Expr.Function(
                 varName = varName,
                 body = body,
@@ -934,7 +934,7 @@ class ToyLangNameless private constructor() {
         fun variable(
             index: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Variable =
             ToyLangNameless.Expr.Variable(
                 index = index.asPrimitive(),
                 metas = metas)
@@ -942,7 +942,7 @@ class ToyLangNameless private constructor() {
         fun variable_(
             index: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Variable =
             ToyLangNameless.Expr.Variable(
                 index = index,
                 metas = metas)
@@ -953,7 +953,7 @@ class ToyLangNameless private constructor() {
             value: Expr,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Let =
             ToyLangNameless.Expr.Let(
                 index = index.asPrimitive(),
                 value = value,
@@ -965,7 +965,7 @@ class ToyLangNameless private constructor() {
             value: Expr,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): ToyLangNameless.Expr.Let =
             ToyLangNameless.Expr.Let(
                 index = index,
                 value = value,
@@ -1242,21 +1242,21 @@ class ToyLangNameless private constructor() {
     
         class Call(
             val name: SymbolPrimitive,
-            val operands: Expr,
+            val argument: Expr,
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
             override fun withMeta(metaKey: String, metaValue: Any): Call =
                 Call(
                     name = name,
-                    operands = operands,
+                    argument = argument,
                     metas = metas + metaContainerOf(metaKey to metaValue))
         
             override fun toIonElement(): SexpElement {
                 val elements = ionSexpOf(
                     ionSymbol("call"),
                     name.toIonElement(),
-                    operands.toIonElement(),
+                    argument.toIonElement(),
                     metas = metas)
                 return elements
             }
@@ -1268,13 +1268,13 @@ class ToyLangNameless private constructor() {
         
                 other as Call
                 if (name != other.name) return false
-                if (operands != other.operands) return false
+                if (argument != other.argument) return false
                 return true
             }
         
             private val myHashCode by lazy(LazyThreadSafetyMode.NONE) {
                 var hc = name.hashCode()
-                hc = 31 * hc + operands.hashCode()
+                hc = 31 * hc + argument.hashCode()
                 hc
             }
         
@@ -1470,10 +1470,10 @@ class ToyLangNameless private constructor() {
                 "call" -> {
                     sexp.requireArityOrMalformed(IntRange(2, 2))
                     val name = sexp.getRequired(0).toSymbolPrimitive()
-                    val operands = sexp.getRequired(1).transformExpect<Expr>()
+                    val argument = sexp.getRequired(1).transformExpect<Expr>()
                     ToyLangNameless.Expr.Call(
                         name,
-                        operands,
+                        argument,
                         metas = sexp.metas)
                 }
                 "function" -> {
@@ -1530,7 +1530,7 @@ class TestDomain private constructor() {
             first: Long,
             second: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): IntPair =
+        ): TestDomain.IntPair =
             TestDomain.IntPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
@@ -1540,7 +1540,7 @@ class TestDomain private constructor() {
             first: LongPrimitive,
             second: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): IntPair =
+        ): TestDomain.IntPair =
             TestDomain.IntPair(
                 first = first,
                 second = second,
@@ -1551,7 +1551,7 @@ class TestDomain private constructor() {
             first: String,
             second: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): SymbolPair =
+        ): TestDomain.SymbolPair =
             TestDomain.SymbolPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
@@ -1561,7 +1561,7 @@ class TestDomain private constructor() {
             first: SymbolPrimitive,
             second: SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): SymbolPair =
+        ): TestDomain.SymbolPair =
             TestDomain.SymbolPair(
                 first = first,
                 second = second,
@@ -1572,7 +1572,7 @@ class TestDomain private constructor() {
             first: IonElement,
             second: IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): IonPair =
+        ): TestDomain.IonPair =
             TestDomain.IonPair(
                 first = first,
                 second = second,
@@ -1583,7 +1583,7 @@ class TestDomain private constructor() {
             first: Long,
             second: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): IntSymbolPair =
+        ): TestDomain.IntSymbolPair =
             TestDomain.IntSymbolPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
@@ -1593,7 +1593,7 @@ class TestDomain private constructor() {
             first: LongPrimitive,
             second: SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): IntSymbolPair =
+        ): TestDomain.IntSymbolPair =
             TestDomain.IntSymbolPair(
                 first = first,
                 second = second,
@@ -1604,7 +1604,7 @@ class TestDomain private constructor() {
             first: String,
             second: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): SymbolIntPair =
+        ): TestDomain.SymbolIntPair =
             TestDomain.SymbolIntPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
@@ -1614,7 +1614,7 @@ class TestDomain private constructor() {
             first: SymbolPrimitive,
             second: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): SymbolIntPair =
+        ): TestDomain.SymbolIntPair =
             TestDomain.SymbolIntPair(
                 first = first,
                 second = second,
@@ -1622,33 +1622,33 @@ class TestDomain private constructor() {
         
         
         fun ionIntPair(
-            firs: IonElement,
+            first: IonElement,
             second: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): IonIntPair =
+        ): TestDomain.IonIntPair =
             TestDomain.IonIntPair(
-                firs = firs,
+                first = first,
                 second = second.asPrimitive(),
                 metas = metas)
         
         fun ionIntPair_(
-            firs: IonElement,
+            first: IonElement,
             second: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): IonIntPair =
+        ): TestDomain.IonIntPair =
             TestDomain.IonIntPair(
-                firs = firs,
+                first = first,
                 second = second,
                 metas = metas)
         
         
         fun ionSymbolPair(
-            firs: IonElement,
+            first: IonElement,
             second: IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): IonSymbolPair =
+        ): TestDomain.IonSymbolPair =
             TestDomain.IonSymbolPair(
-                firs = firs,
+                first = first,
                 second = second,
                 metas = metas)
         
@@ -1657,7 +1657,7 @@ class TestDomain private constructor() {
             first: IntPair,
             second: IntPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): IntPairPair =
+        ): TestDomain.IntPairPair =
             TestDomain.IntPairPair(
                 first = first,
                 second = second,
@@ -1668,7 +1668,7 @@ class TestDomain private constructor() {
             first: SymbolPair,
             second: SymbolPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): SymbolPairPair =
+        ): TestDomain.SymbolPairPair =
             TestDomain.SymbolPairPair(
                 first = first,
                 second = second,
@@ -1679,7 +1679,7 @@ class TestDomain private constructor() {
             first: IonPair,
             second: IonPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): IonPairPair =
+        ): TestDomain.IonPairPair =
             TestDomain.IonPairPair(
                 first = first,
                 second = second,
@@ -1690,7 +1690,7 @@ class TestDomain private constructor() {
             first: Long,
             second: RecursivePair? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): RecursivePair =
+        ): TestDomain.RecursivePair =
             TestDomain.RecursivePair(
                 first = first.asPrimitive(),
                 second = second,
@@ -1700,7 +1700,7 @@ class TestDomain private constructor() {
             first: LongPrimitive,
             second: RecursivePair? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): RecursivePair =
+        ): TestDomain.RecursivePair =
             TestDomain.RecursivePair(
                 first = first,
                 second = second,
@@ -1711,7 +1711,7 @@ class TestDomain private constructor() {
             first: Answer,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): AnswerPair =
+        ): TestDomain.AnswerPair =
             TestDomain.AnswerPair(
                 first = first,
                 second = second,
@@ -1722,7 +1722,7 @@ class TestDomain private constructor() {
             first: Answer,
             second: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): AnswerIntPair =
+        ): TestDomain.AnswerIntPair =
             TestDomain.AnswerIntPair(
                 first = first,
                 second = second.asPrimitive(),
@@ -1732,7 +1732,7 @@ class TestDomain private constructor() {
             first: Answer,
             second: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): AnswerIntPair =
+        ): TestDomain.AnswerIntPair =
             TestDomain.AnswerIntPair(
                 first = first,
                 second = second,
@@ -1743,7 +1743,7 @@ class TestDomain private constructor() {
             first: Long,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): IntAnswerPair =
+        ): TestDomain.IntAnswerPair =
             TestDomain.IntAnswerPair(
                 first = first.asPrimitive(),
                 second = second,
@@ -1753,7 +1753,7 @@ class TestDomain private constructor() {
             first: LongPrimitive,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): IntAnswerPair =
+        ): TestDomain.IntAnswerPair =
             TestDomain.IntAnswerPair(
                 first = first,
                 second = second,
@@ -1764,7 +1764,7 @@ class TestDomain private constructor() {
             first: String,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): SymbolAnswerPair =
+        ): TestDomain.SymbolAnswerPair =
             TestDomain.SymbolAnswerPair(
                 first = first.asPrimitive(),
                 second = second,
@@ -1774,7 +1774,7 @@ class TestDomain private constructor() {
             first: SymbolPrimitive,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): SymbolAnswerPair =
+        ): TestDomain.SymbolAnswerPair =
             TestDomain.SymbolAnswerPair(
                 first = first,
                 second = second,
@@ -1785,7 +1785,7 @@ class TestDomain private constructor() {
             first: Answer,
             second: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): AnswerSymbolPair =
+        ): TestDomain.AnswerSymbolPair =
             TestDomain.AnswerSymbolPair(
                 first = first,
                 second = second.asPrimitive(),
@@ -1795,7 +1795,7 @@ class TestDomain private constructor() {
             first: Answer,
             second: SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): AnswerSymbolPair =
+        ): TestDomain.AnswerSymbolPair =
             TestDomain.AnswerSymbolPair(
                 first = first,
                 second = second,
@@ -1805,7 +1805,7 @@ class TestDomain private constructor() {
         fun variadicMin0(
             ints: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): VariadicMin0 =
+        ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints.map { it.asPrimitive() },
                 metas = metas)
@@ -1813,7 +1813,7 @@ class TestDomain private constructor() {
         fun variadicMin0_(
             ints: kotlin.collections.List<LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): VariadicMin0 =
+        ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints,
                 metas = metas)
@@ -1821,7 +1821,7 @@ class TestDomain private constructor() {
         fun variadicMin0(
             vararg ints: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): VariadicMin0 =
+        ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints.map { it.asPrimitive() },
                 metas = metas)
@@ -1829,7 +1829,7 @@ class TestDomain private constructor() {
         fun variadicMin0_(
             vararg ints: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): VariadicMin0 =
+        ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints.toList(),
                 metas = metas)
@@ -1838,7 +1838,7 @@ class TestDomain private constructor() {
         fun variadicMin1(
             ints: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): VariadicMin1 =
+        ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = ints.map { it.asPrimitive() },
                 metas = metas)
@@ -1846,7 +1846,7 @@ class TestDomain private constructor() {
         fun variadicMin1_(
             ints: kotlin.collections.List<LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): VariadicMin1 =
+        ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = ints,
                 metas = metas)
@@ -1855,7 +1855,7 @@ class TestDomain private constructor() {
             ints0: Long,
             vararg ints: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): VariadicMin1 =
+        ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = listOfPrimitives(ints0) + ints.map { it.asPrimitive() },
                 metas = metas)
@@ -1864,7 +1864,7 @@ class TestDomain private constructor() {
             ints0: LongPrimitive,
             vararg ints: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): VariadicMin1 =
+        ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = listOfPrimitives(ints0) + ints.toList(),
                 metas = metas)
@@ -1874,7 +1874,7 @@ class TestDomain private constructor() {
             name: String,
             ints: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): ElementVariadic =
+        ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
                 name = name.asPrimitive(),
                 ints = ints.map { it.asPrimitive() },
@@ -1884,7 +1884,7 @@ class TestDomain private constructor() {
             name: SymbolPrimitive,
             ints: kotlin.collections.List<LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): ElementVariadic =
+        ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
                 name = name,
                 ints = ints,
@@ -1894,7 +1894,7 @@ class TestDomain private constructor() {
             name: String,
             vararg ints: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): ElementVariadic =
+        ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
                 name = name.asPrimitive(),
                 ints = ints.map { it.asPrimitive() },
@@ -1904,7 +1904,7 @@ class TestDomain private constructor() {
             name: SymbolPrimitive,
             vararg ints: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): ElementVariadic =
+        ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
                 name = name,
                 ints = ints.toList(),
@@ -1914,7 +1914,7 @@ class TestDomain private constructor() {
         fun optional1(
             value: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): Optional1 =
+        ): TestDomain.Optional1 =
             TestDomain.Optional1(
                 value = value?.asPrimitive(),
                 metas = metas)
@@ -1922,7 +1922,7 @@ class TestDomain private constructor() {
         fun optional1_(
             value: LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): Optional1 =
+        ): TestDomain.Optional1 =
             TestDomain.Optional1(
                 value = value,
                 metas = metas)
@@ -1932,7 +1932,7 @@ class TestDomain private constructor() {
             first: Long? = null,
             second: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): Optional2 =
+        ): TestDomain.Optional2 =
             TestDomain.Optional2(
                 first = first?.asPrimitive(),
                 second = second?.asPrimitive(),
@@ -1942,7 +1942,7 @@ class TestDomain private constructor() {
             first: LongPrimitive? = null,
             second: LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): Optional2 =
+        ): TestDomain.Optional2 =
             TestDomain.Optional2(
                 first = first,
                 second = second,
@@ -1954,7 +1954,7 @@ class TestDomain private constructor() {
             anotherField: String,
             optionalField: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainLevelRecord =
+        ): TestDomain.DomainLevelRecord =
             TestDomain.DomainLevelRecord(
                 someField = someField.asPrimitive(),
                 anotherField = anotherField.asPrimitive(),
@@ -1966,7 +1966,7 @@ class TestDomain private constructor() {
             anotherField: SymbolPrimitive,
             optionalField: LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainLevelRecord =
+        ): TestDomain.DomainLevelRecord =
             TestDomain.DomainLevelRecord(
                 someField = someField,
                 anotherField = anotherField,
@@ -1978,7 +1978,7 @@ class TestDomain private constructor() {
             value: Long,
             dlr: DomainLevelRecord,
             metas: MetaContainer = emptyMetaContainer()
-        ): ProductWithRecord =
+        ): TestDomain.ProductWithRecord =
             TestDomain.ProductWithRecord(
                 value = value.asPrimitive(),
                 dlr = dlr,
@@ -1988,7 +1988,7 @@ class TestDomain private constructor() {
             value: LongPrimitive,
             dlr: DomainLevelRecord,
             metas: MetaContainer = emptyMetaContainer()
-        ): ProductWithRecord =
+        ): TestDomain.ProductWithRecord =
             TestDomain.ProductWithRecord(
                 value = value,
                 dlr = dlr,
@@ -1999,7 +1999,7 @@ class TestDomain private constructor() {
             first: Entity,
             second: Entity,
             metas: MetaContainer = emptyMetaContainer()
-        ): EntityPair =
+        ): TestDomain.EntityPair =
             TestDomain.EntityPair(
                 first = first,
                 second = second,
@@ -2009,14 +2009,14 @@ class TestDomain private constructor() {
         // Variants for Sum: Answer 
         fun no(
             metas: MetaContainer = emptyMetaContainer()
-        ): Answer =
+        ): TestDomain.Answer.No =
             TestDomain.Answer.No(
                 metas = metas)
         
         
         fun yes(
             metas: MetaContainer = emptyMetaContainer()
-        ): Answer =
+        ): TestDomain.Answer.Yes =
             TestDomain.Answer.Yes(
                 metas = metas)
         
@@ -2026,7 +2026,7 @@ class TestDomain private constructor() {
             value: Long,
             dlr: DomainLevelRecord,
             metas: MetaContainer = emptyMetaContainer()
-        ): SumWithRecord =
+        ): TestDomain.SumWithRecord.VariantWithRecord =
             TestDomain.SumWithRecord.VariantWithRecord(
                 value = value.asPrimitive(),
                 dlr = dlr,
@@ -2036,7 +2036,7 @@ class TestDomain private constructor() {
             value: LongPrimitive,
             dlr: DomainLevelRecord,
             metas: MetaContainer = emptyMetaContainer()
-        ): SumWithRecord =
+        ): TestDomain.SumWithRecord.VariantWithRecord =
             TestDomain.SumWithRecord.VariantWithRecord(
                 value = value,
                 dlr = dlr,
@@ -2046,7 +2046,7 @@ class TestDomain private constructor() {
         // Variants for Sum: Entity 
         fun slug(
             metas: MetaContainer = emptyMetaContainer()
-        ): Entity =
+        ): TestDomain.Entity.Slug =
             TestDomain.Entity.Slug(
                 metas = metas)
         
@@ -2054,7 +2054,7 @@ class TestDomain private constructor() {
         fun android(
             id: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): Entity =
+        ): TestDomain.Entity.Android =
             TestDomain.Entity.Android(
                 id = id.asPrimitive(),
                 metas = metas)
@@ -2062,7 +2062,7 @@ class TestDomain private constructor() {
         fun android_(
             id: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): Entity =
+        ): TestDomain.Entity.Android =
             TestDomain.Entity.Android(
                 id = id,
                 metas = metas)
@@ -2074,7 +2074,7 @@ class TestDomain private constructor() {
             title: String? = null,
             parent: Entity? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): Entity =
+        ): TestDomain.Entity.Human =
             TestDomain.Entity.Human(
                 firstName = firstName.asPrimitive(),
                 lastName = lastName.asPrimitive(),
@@ -2088,7 +2088,7 @@ class TestDomain private constructor() {
             title: SymbolPrimitive? = null,
             parent: Entity? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): Entity =
+        ): TestDomain.Entity.Human =
             TestDomain.Entity.Human(
                 firstName = firstName,
                 lastName = lastName,
@@ -2314,21 +2314,21 @@ class TestDomain private constructor() {
     }
     
     class IonIntPair(
-        val firs: IonElement,
+        val first: IonElement,
         val second: LongPrimitive,
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
         override fun withMeta(metaKey: String, metaValue: Any): IonIntPair =
             IonIntPair(
-                firs = firs,
+                first = first,
                 second = second,
                 metas = metas + metaContainerOf(metaKey to metaValue))
     
         override fun toIonElement(): SexpElement {
             val elements = ionSexpOf(
                 ionSymbol("ion_int_pair"),
-                firs.toIonElement(),
+                first.toIonElement(),
                 second.toIonElement(),
                 metas = metas)
             return elements
@@ -2340,13 +2340,13 @@ class TestDomain private constructor() {
             if (other.javaClass != IonIntPair::class.java) return false
     
             other as IonIntPair
-            if (firs != other.firs) return false
+            if (first != other.first) return false
             if (second != other.second) return false
             return true
         }
     
         private val myHashCode by lazy(LazyThreadSafetyMode.NONE) {
-            var hc = firs.hashCode()
+            var hc = first.hashCode()
             hc = 31 * hc + second.hashCode()
             hc
         }
@@ -2355,21 +2355,21 @@ class TestDomain private constructor() {
     }
     
     class IonSymbolPair(
-        val firs: IonElement,
+        val first: IonElement,
         val second: IonElement,
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
         override fun withMeta(metaKey: String, metaValue: Any): IonSymbolPair =
             IonSymbolPair(
-                firs = firs,
+                first = first,
                 second = second,
                 metas = metas + metaContainerOf(metaKey to metaValue))
     
         override fun toIonElement(): SexpElement {
             val elements = ionSexpOf(
                 ionSymbol("ion_symbol_pair"),
-                firs.toIonElement(),
+                first.toIonElement(),
                 second.toIonElement(),
                 metas = metas)
             return elements
@@ -2381,13 +2381,13 @@ class TestDomain private constructor() {
             if (other.javaClass != IonSymbolPair::class.java) return false
     
             other as IonSymbolPair
-            if (firs != other.firs) return false
+            if (first != other.first) return false
             if (second != other.second) return false
             return true
         }
     
         private val myHashCode by lazy(LazyThreadSafetyMode.NONE) {
-            var hc = firs.hashCode()
+            var hc = first.hashCode()
             hc = 31 * hc + second.hashCode()
             hc
         }
@@ -3366,19 +3366,19 @@ class TestDomain private constructor() {
                 }
                 "ion_int_pair" -> {
                     sexp.requireArityOrMalformed(IntRange(2, 2))
-                    val firs = sexp.getRequiredIon(0)
+                    val first = sexp.getRequiredIon(0)
                     val second = sexp.getRequired(1).toLongPrimitive()
                     TestDomain.IonIntPair(
-                        firs,
+                        first,
                         second,
                         metas = sexp.metas)
                 }
                 "ion_symbol_pair" -> {
                     sexp.requireArityOrMalformed(IntRange(2, 2))
-                    val firs = sexp.getRequiredIon(0)
+                    val first = sexp.getRequiredIon(0)
                     val second = sexp.getRequiredIon(1)
                     TestDomain.IonSymbolPair(
-                        firs,
+                        first,
                         second,
                         metas = sexp.metas)
                 }
@@ -3608,7 +3608,7 @@ class MultiWordDomain private constructor() {
                 // Tuples
         fun aaaAaa(
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAaa =
+        ): MultiWordDomain.AaaAaa =
             MultiWordDomain.AaaAaa(
                 metas = metas)
         
@@ -3616,7 +3616,7 @@ class MultiWordDomain private constructor() {
         fun aaaAab(
             dField: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAab =
+        ): MultiWordDomain.AaaAab =
             MultiWordDomain.AaaAab(
                 dField = dField?.asPrimitive(),
                 metas = metas)
@@ -3624,7 +3624,7 @@ class MultiWordDomain private constructor() {
         fun aaaAab_(
             dField: LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAab =
+        ): MultiWordDomain.AaaAab =
             MultiWordDomain.AaaAab(
                 dField = dField,
                 metas = metas)
@@ -3634,7 +3634,7 @@ class MultiWordDomain private constructor() {
             dField: Long? = null,
             eField: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAac =
+        ): MultiWordDomain.AaaAac =
             MultiWordDomain.AaaAac(
                 dField = dField?.asPrimitive(),
                 eField = eField?.asPrimitive(),
@@ -3644,7 +3644,7 @@ class MultiWordDomain private constructor() {
             dField: LongPrimitive? = null,
             eField: SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAac =
+        ): MultiWordDomain.AaaAac =
             MultiWordDomain.AaaAac(
                 dField = dField,
                 eField = eField,
@@ -3654,7 +3654,7 @@ class MultiWordDomain private constructor() {
         fun aaaAad(
             dField: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAad =
+        ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField.map { it.asPrimitive() },
                 metas = metas)
@@ -3662,7 +3662,7 @@ class MultiWordDomain private constructor() {
         fun aaaAad_(
             dField: kotlin.collections.List<LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAad =
+        ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField,
                 metas = metas)
@@ -3670,7 +3670,7 @@ class MultiWordDomain private constructor() {
         fun aaaAad(
             vararg dField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAad =
+        ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField.map { it.asPrimitive() },
                 metas = metas)
@@ -3678,7 +3678,7 @@ class MultiWordDomain private constructor() {
         fun aaaAad_(
             vararg dField: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAad =
+        ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField.toList(),
                 metas = metas)
@@ -3687,7 +3687,7 @@ class MultiWordDomain private constructor() {
         fun aaaAae(
             dField: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAae =
+        ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = dField.map { it.asPrimitive() },
                 metas = metas)
@@ -3695,7 +3695,7 @@ class MultiWordDomain private constructor() {
         fun aaaAae_(
             dField: kotlin.collections.List<LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAae =
+        ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = dField,
                 metas = metas)
@@ -3705,7 +3705,7 @@ class MultiWordDomain private constructor() {
             dField1: Long,
             vararg dField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAae =
+        ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
                 metas = metas)
@@ -3715,7 +3715,7 @@ class MultiWordDomain private constructor() {
             dField1: LongPrimitive,
             vararg dField: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): AaaAae =
+        ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = listOfPrimitives(dField0, dField1) + dField.toList(),
                 metas = metas)
@@ -3725,7 +3725,7 @@ class MultiWordDomain private constructor() {
             bField: Long,
             cField: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAaa =
+        ): MultiWordDomain.AabAaa =
             MultiWordDomain.AabAaa(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
@@ -3735,7 +3735,7 @@ class MultiWordDomain private constructor() {
             bField: LongPrimitive,
             cField: SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAaa =
+        ): MultiWordDomain.AabAaa =
             MultiWordDomain.AabAaa(
                 bField = bField,
                 cField = cField,
@@ -3747,7 +3747,7 @@ class MultiWordDomain private constructor() {
             cField: String,
             dField: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAab =
+        ): MultiWordDomain.AabAab =
             MultiWordDomain.AabAab(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
@@ -3759,7 +3759,7 @@ class MultiWordDomain private constructor() {
             cField: SymbolPrimitive,
             dField: LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAab =
+        ): MultiWordDomain.AabAab =
             MultiWordDomain.AabAab(
                 bField = bField,
                 cField = cField,
@@ -3773,7 +3773,7 @@ class MultiWordDomain private constructor() {
             dField: Long? = null,
             eField: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAac =
+        ): MultiWordDomain.AabAac =
             MultiWordDomain.AabAac(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
@@ -3787,7 +3787,7 @@ class MultiWordDomain private constructor() {
             dField: LongPrimitive? = null,
             eField: SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAac =
+        ): MultiWordDomain.AabAac =
             MultiWordDomain.AabAac(
                 bField = bField,
                 cField = cField,
@@ -3801,7 +3801,7 @@ class MultiWordDomain private constructor() {
             cField: String,
             dField: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAad =
+        ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
@@ -3813,7 +3813,7 @@ class MultiWordDomain private constructor() {
             cField: SymbolPrimitive,
             dField: kotlin.collections.List<LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAad =
+        ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
                 bField = bField,
                 cField = cField,
@@ -3825,7 +3825,7 @@ class MultiWordDomain private constructor() {
             cField: String,
             vararg dField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAad =
+        ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
@@ -3837,7 +3837,7 @@ class MultiWordDomain private constructor() {
             cField: SymbolPrimitive,
             vararg dField: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAad =
+        ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
                 bField = bField,
                 cField = cField,
@@ -3850,7 +3850,7 @@ class MultiWordDomain private constructor() {
             cField: String,
             dField: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAae =
+        ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
@@ -3862,7 +3862,7 @@ class MultiWordDomain private constructor() {
             cField: SymbolPrimitive,
             dField: kotlin.collections.List<LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAae =
+        ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
                 bField = bField,
                 cField = cField,
@@ -3876,7 +3876,7 @@ class MultiWordDomain private constructor() {
             dField1: Long,
             vararg dField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAae =
+        ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
@@ -3890,7 +3890,7 @@ class MultiWordDomain private constructor() {
             dField1: LongPrimitive,
             vararg dField: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): AabAae =
+        ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
                 bField = bField,
                 cField = cField,
@@ -3898,11 +3898,32 @@ class MultiWordDomain private constructor() {
                 metas = metas)
         
         
+        fun rrr(
+            aField: Long,
+            bbbField: Long,
+            metas: MetaContainer = emptyMetaContainer()
+        ): MultiWordDomain.Rrr =
+            MultiWordDomain.Rrr(
+                aField = aField.asPrimitive(),
+                bbbField = bbbField.asPrimitive(),
+                metas = metas)
+        
+        fun rrr_(
+            aField: LongPrimitive,
+            bbbField: LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
+        ): MultiWordDomain.Rrr =
+            MultiWordDomain.Rrr(
+                aField = aField,
+                bbbField = bbbField,
+                metas = metas)
+        
+        
         // Variants for Sum: SssTtt 
         fun lll(
             uField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): SssTtt =
+        ): MultiWordDomain.SssTtt.Lll =
             MultiWordDomain.SssTtt.Lll(
                 uField = uField.asPrimitive(),
                 metas = metas)
@@ -3910,7 +3931,7 @@ class MultiWordDomain private constructor() {
         fun lll_(
             uField: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): SssTtt =
+        ): MultiWordDomain.SssTtt.Lll =
             MultiWordDomain.SssTtt.Lll(
                 uField = uField,
                 metas = metas)
@@ -3919,7 +3940,7 @@ class MultiWordDomain private constructor() {
         fun mmm(
             vField: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): SssTtt =
+        ): MultiWordDomain.SssTtt.Mmm =
             MultiWordDomain.SssTtt.Mmm(
                 vField = vField.asPrimitive(),
                 metas = metas)
@@ -3927,27 +3948,8 @@ class MultiWordDomain private constructor() {
         fun mmm_(
             vField: SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): SssTtt =
+        ): MultiWordDomain.SssTtt.Mmm =
             MultiWordDomain.SssTtt.Mmm(
-                vField = vField,
-                metas = metas)
-        
-        
-        // Variants for Sum: SssTtu 
-        fun nnn(
-            uField: AaaAaa,
-            metas: MetaContainer = emptyMetaContainer()
-        ): SssTtu =
-            MultiWordDomain.SssTtu.Nnn(
-                uField = uField,
-                metas = metas)
-        
-        
-        fun ooo(
-            vField: AaaAab,
-            metas: MetaContainer = emptyMetaContainer()
-        ): SssTtu =
-            MultiWordDomain.SssTtu.Ooo(
                 vField = vField,
                 metas = metas)
     }
@@ -4368,6 +4370,48 @@ class MultiWordDomain private constructor() {
         override fun hashCode(): Int = myHashCode
     }
     
+    class Rrr(
+        val aField: LongPrimitive,
+        val bbbField: LongPrimitive,
+        override val metas: MetaContainer = emptyMetaContainer()
+    ): MultiWordDomainNode() {
+    
+        override fun withMeta(metaKey: String, metaValue: Any): Rrr =
+            Rrr(
+                aField = aField,
+                bbbField = bbbField,
+                metas = metas + metaContainerOf(metaKey to metaValue))
+    
+        override fun toIonElement(): SexpElement {
+            val elements = listOfNotNull(
+                ionSymbol("rrr"),
+                aField?.let { ionSexpOf(ionSymbol("a_field"), it.toIonElement()) },
+                bbbField?.let { ionSexpOf(ionSymbol("b_field"), it.toIonElement()) }
+            )
+    
+            return ionSexpOf(elements, metas = metas)
+        }
+    
+        override fun equals(other: Any?): Boolean {
+            if (other == null) return false
+            if (this === other) return true
+            if (other.javaClass != Rrr::class.java) return false
+    
+            other as Rrr
+            if (aField != other.aField) return false
+            if (bbbField != other.bbbField) return false
+            return true
+        }
+    
+        private val myHashCode by lazy(LazyThreadSafetyMode.NONE) {
+            var hc = aField.hashCode()
+            hc = 31 * hc + bbbField.hashCode()
+            hc
+        }
+    
+        override fun hashCode(): Int = myHashCode
+    }
+    
     
     /////////////////////////////////////////////////////////////////////////////
     // Sum Types
@@ -4435,82 +4479,6 @@ class MultiWordDomain private constructor() {
                 if (other.javaClass != Mmm::class.java) return false
         
                 other as Mmm
-                if (vField != other.vField) return false
-                return true
-            }
-        
-            private val myHashCode by lazy(LazyThreadSafetyMode.NONE) {
-                var hc = vField.hashCode()
-                hc
-            }
-        
-            override fun hashCode(): Int = myHashCode
-        }
-    
-    }
-    
-    sealed class SssTtu : MultiWordDomainNode() {
-    
-        class Nnn(
-            val uField: AaaAaa,
-            override val metas: MetaContainer = emptyMetaContainer()
-        ): SssTtu() {
-        
-            override fun withMeta(metaKey: String, metaValue: Any): Nnn =
-                Nnn(
-                    uField = uField,
-                    metas = metas + metaContainerOf(metaKey to metaValue))
-        
-            override fun toIonElement(): SexpElement {
-                val elements = ionSexpOf(
-                    ionSymbol("nnn"),
-                    uField.toIonElement(),
-                    metas = metas)
-                return elements
-            }
-        
-            override fun equals(other: Any?): Boolean {
-                if (other == null) return false
-                if (this === other) return true
-                if (other.javaClass != Nnn::class.java) return false
-        
-                other as Nnn
-                if (uField != other.uField) return false
-                return true
-            }
-        
-            private val myHashCode by lazy(LazyThreadSafetyMode.NONE) {
-                var hc = uField.hashCode()
-                hc
-            }
-        
-            override fun hashCode(): Int = myHashCode
-        }
-    
-        class Ooo(
-            val vField: AaaAab,
-            override val metas: MetaContainer = emptyMetaContainer()
-        ): SssTtu() {
-        
-            override fun withMeta(metaKey: String, metaValue: Any): Ooo =
-                Ooo(
-                    vField = vField,
-                    metas = metas + metaContainerOf(metaKey to metaValue))
-        
-            override fun toIonElement(): SexpElement {
-                val elements = ionSexpOf(
-                    ionSymbol("ooo"),
-                    vField.toIonElement(),
-                    metas = metas)
-                return elements
-            }
-        
-            override fun equals(other: Any?): Boolean {
-                if (other == null) return false
-                if (this === other) return true
-                if (other.javaClass != Ooo::class.java) return false
-        
-                other as Ooo
                 if (vField != other.vField) return false
                 return true
             }
@@ -4627,6 +4595,16 @@ class MultiWordDomain private constructor() {
                         dField,
                         metas = sexp.metas)
                 }
+                "rrr" -> {
+                    val ir = sexp.transformToIntermediateRecord()
+            
+                    val aField = ir.processRequiredField("a_field") { it.toLongPrimitive() }
+                    val bbbField = ir.processRequiredField("bbb_field") { it.toLongPrimitive() }
+            
+                    ir.malformedIfAnyUnprocessedFieldsRemain()
+            
+                    Rrr(aField, bbbField, metas = sexp.metas)
+                }
                 //////////////////////////////////////
                 // Variants for Sum Type 'SssTtt'
                 //////////////////////////////////////
@@ -4641,23 +4619,6 @@ class MultiWordDomain private constructor() {
                     sexp.requireArityOrMalformed(IntRange(1, 1))
                     val vField = sexp.getRequired(0).toSymbolPrimitive()
                     MultiWordDomain.SssTtt.Mmm(
-                        vField,
-                        metas = sexp.metas)
-                }
-                //////////////////////////////////////
-                // Variants for Sum Type 'SssTtu'
-                //////////////////////////////////////
-                "nnn" -> {
-                    sexp.requireArityOrMalformed(IntRange(1, 1))
-                    val uField = sexp.getRequired(0).transformExpect<AaaAaa>()
-                    MultiWordDomain.SssTtu.Nnn(
-                        uField,
-                        metas = sexp.metas)
-                }
-                "ooo" -> {
-                    sexp.requireArityOrMalformed(IntRange(1, 1))
-                    val vField = sexp.getRequired(0).transformExpect<AaaAab>()
-                    MultiWordDomain.SssTtu.Ooo(
                         vField,
                         metas = sexp.metas)
                 }
@@ -4688,7 +4649,7 @@ class PartiqlBasic private constructor() {
             first: Expr,
             second: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ExprPair =
+        ): PartiqlBasic.ExprPair =
             PartiqlBasic.ExprPair(
                 first = first,
                 second = second,
@@ -4699,7 +4660,7 @@ class PartiqlBasic private constructor() {
             value: Expr,
             asAlias: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): GroupByItem =
+        ): PartiqlBasic.GroupByItem =
             PartiqlBasic.GroupByItem(
                 value = value,
                 asAlias = asAlias?.asPrimitive(),
@@ -4709,7 +4670,7 @@ class PartiqlBasic private constructor() {
             value: Expr,
             asAlias: SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): GroupByItem =
+        ): PartiqlBasic.GroupByItem =
             PartiqlBasic.GroupByItem(
                 value = value,
                 asAlias = asAlias,
@@ -4719,7 +4680,7 @@ class PartiqlBasic private constructor() {
         fun groupByList(
             items: kotlin.collections.List<GroupByItem>,
             metas: MetaContainer = emptyMetaContainer()
-        ): GroupByList =
+        ): PartiqlBasic.GroupByList =
             PartiqlBasic.GroupByList(
                 items = items,
                 metas = metas)
@@ -4728,7 +4689,7 @@ class PartiqlBasic private constructor() {
             items0: GroupByItem,
             vararg items: GroupByItem,
             metas: MetaContainer = emptyMetaContainer()
-        ): GroupByList =
+        ): PartiqlBasic.GroupByList =
             PartiqlBasic.GroupByList(
                 items = listOf(items0) + items.toList(),
                 metas = metas)
@@ -4738,7 +4699,7 @@ class PartiqlBasic private constructor() {
             items: GroupByList,
             groupAsAlias: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): GroupBy =
+        ): PartiqlBasic.GroupBy =
             PartiqlBasic.GroupBy(
                 items = items,
                 groupAsAlias = groupAsAlias?.asPrimitive(),
@@ -4748,7 +4709,7 @@ class PartiqlBasic private constructor() {
             items: GroupByList,
             groupAsAlias: SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): GroupBy =
+        ): PartiqlBasic.GroupBy =
             PartiqlBasic.GroupBy(
                 items = items,
                 groupAsAlias = groupAsAlias,
@@ -4759,7 +4720,7 @@ class PartiqlBasic private constructor() {
         fun projectList(
             items: kotlin.collections.List<ProjectItem>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Projection =
+        ): PartiqlBasic.Projection.ProjectList =
             PartiqlBasic.Projection.ProjectList(
                 items = items,
                 metas = metas)
@@ -4768,7 +4729,7 @@ class PartiqlBasic private constructor() {
             items0: ProjectItem,
             vararg items: ProjectItem,
             metas: MetaContainer = emptyMetaContainer()
-        ): Projection =
+        ): PartiqlBasic.Projection.ProjectList =
             PartiqlBasic.Projection.ProjectList(
                 items = listOf(items0) + items.toList(),
                 metas = metas)
@@ -4777,7 +4738,7 @@ class PartiqlBasic private constructor() {
         fun projectValue(
             value: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Projection =
+        ): PartiqlBasic.Projection.ProjectValue =
             PartiqlBasic.Projection.ProjectValue(
                 value = value,
                 metas = metas)
@@ -4786,7 +4747,7 @@ class PartiqlBasic private constructor() {
         // Variants for Sum: ProjectItem 
         fun projectAll(
             metas: MetaContainer = emptyMetaContainer()
-        ): ProjectItem =
+        ): PartiqlBasic.ProjectItem.ProjectAll =
             PartiqlBasic.ProjectItem.ProjectAll(
                 metas = metas)
         
@@ -4795,7 +4756,7 @@ class PartiqlBasic private constructor() {
             value: Expr,
             asAlias: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): ProjectItem =
+        ): PartiqlBasic.ProjectItem.ProjectExpr =
             PartiqlBasic.ProjectItem.ProjectExpr(
                 value = value,
                 asAlias = asAlias?.asPrimitive(),
@@ -4805,7 +4766,7 @@ class PartiqlBasic private constructor() {
             value: Expr,
             asAlias: SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): ProjectItem =
+        ): PartiqlBasic.ProjectItem.ProjectExpr =
             PartiqlBasic.ProjectItem.ProjectExpr(
                 value = value,
                 asAlias = asAlias,
@@ -4815,28 +4776,28 @@ class PartiqlBasic private constructor() {
         // Variants for Sum: JoinType 
         fun inner(
             metas: MetaContainer = emptyMetaContainer()
-        ): JoinType =
+        ): PartiqlBasic.JoinType.Inner =
             PartiqlBasic.JoinType.Inner(
                 metas = metas)
         
         
         fun left(
             metas: MetaContainer = emptyMetaContainer()
-        ): JoinType =
+        ): PartiqlBasic.JoinType.Left =
             PartiqlBasic.JoinType.Left(
                 metas = metas)
         
         
         fun right(
             metas: MetaContainer = emptyMetaContainer()
-        ): JoinType =
+        ): PartiqlBasic.JoinType.Right =
             PartiqlBasic.JoinType.Right(
                 metas = metas)
         
         
         fun outer(
             metas: MetaContainer = emptyMetaContainer()
-        ): JoinType =
+        ): PartiqlBasic.JoinType.Outer =
             PartiqlBasic.JoinType.Outer(
                 metas = metas)
         
@@ -4848,7 +4809,7 @@ class PartiqlBasic private constructor() {
             atAlias: String? = null,
             byAlias: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): FromSource =
+        ): PartiqlBasic.FromSource.Scan =
             PartiqlBasic.FromSource.Scan(
                 expr = expr,
                 asAlias = asAlias?.asPrimitive(),
@@ -4862,7 +4823,7 @@ class PartiqlBasic private constructor() {
             atAlias: SymbolPrimitive? = null,
             byAlias: SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): FromSource =
+        ): PartiqlBasic.FromSource.Scan =
             PartiqlBasic.FromSource.Scan(
                 expr = expr,
                 asAlias = asAlias,
@@ -4877,7 +4838,7 @@ class PartiqlBasic private constructor() {
             right: FromSource,
             predicate: Expr? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): FromSource =
+        ): PartiqlBasic.FromSource.Join =
             PartiqlBasic.FromSource.Join(
                 type = type,
                 left = left,
@@ -4889,14 +4850,14 @@ class PartiqlBasic private constructor() {
         // Variants for Sum: CaseSensitivity 
         fun caseSensitive(
             metas: MetaContainer = emptyMetaContainer()
-        ): CaseSensitivity =
+        ): PartiqlBasic.CaseSensitivity.CaseSensitive =
             PartiqlBasic.CaseSensitivity.CaseSensitive(
                 metas = metas)
         
         
         fun caseInsensitive(
             metas: MetaContainer = emptyMetaContainer()
-        ): CaseSensitivity =
+        ): PartiqlBasic.CaseSensitivity.CaseInsensitive =
             PartiqlBasic.CaseSensitivity.CaseInsensitive(
                 metas = metas)
         
@@ -4904,14 +4865,14 @@ class PartiqlBasic private constructor() {
         // Variants for Sum: ScopeQualifier 
         fun unqualified(
             metas: MetaContainer = emptyMetaContainer()
-        ): ScopeQualifier =
+        ): PartiqlBasic.ScopeQualifier.Unqualified =
             PartiqlBasic.ScopeQualifier.Unqualified(
                 metas = metas)
         
         
         fun qualified(
             metas: MetaContainer = emptyMetaContainer()
-        ): ScopeQualifier =
+        ): PartiqlBasic.ScopeQualifier.Qualified =
             PartiqlBasic.ScopeQualifier.Qualified(
                 metas = metas)
         
@@ -4919,14 +4880,14 @@ class PartiqlBasic private constructor() {
         // Variants for Sum: SetQuantifier 
         fun all(
             metas: MetaContainer = emptyMetaContainer()
-        ): SetQuantifier =
+        ): PartiqlBasic.SetQuantifier.All =
             PartiqlBasic.SetQuantifier.All(
                 metas = metas)
         
         
         fun distinct(
             metas: MetaContainer = emptyMetaContainer()
-        ): SetQuantifier =
+        ): PartiqlBasic.SetQuantifier.Distinct =
             PartiqlBasic.SetQuantifier.Distinct(
                 metas = metas)
         
@@ -4935,7 +4896,7 @@ class PartiqlBasic private constructor() {
         fun pathExpr(
             expr: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PathElement =
+        ): PartiqlBasic.PathElement.PathExpr =
             PartiqlBasic.PathElement.PathExpr(
                 expr = expr,
                 metas = metas)
@@ -4943,14 +4904,14 @@ class PartiqlBasic private constructor() {
         
         fun pathWildcard(
             metas: MetaContainer = emptyMetaContainer()
-        ): PathElement =
+        ): PartiqlBasic.PathElement.PathWildcard =
             PartiqlBasic.PathElement.PathWildcard(
                 metas = metas)
         
         
         fun pathUnpivot(
             metas: MetaContainer = emptyMetaContainer()
-        ): PathElement =
+        ): PartiqlBasic.PathElement.PathUnpivot =
             PartiqlBasic.PathElement.PathUnpivot(
                 metas = metas)
         
@@ -4959,7 +4920,7 @@ class PartiqlBasic private constructor() {
         fun lit(
             value: IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Lit =
             PartiqlBasic.Expr.Lit(
                 value = value,
                 metas = metas)
@@ -4970,7 +4931,7 @@ class PartiqlBasic private constructor() {
             case: CaseSensitivity,
             scopeQualifier: ScopeQualifier,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Id =
             PartiqlBasic.Expr.Id(
                 name = name.asPrimitive(),
                 case = case,
@@ -4982,7 +4943,7 @@ class PartiqlBasic private constructor() {
             case: CaseSensitivity,
             scopeQualifier: ScopeQualifier,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Id =
             PartiqlBasic.Expr.Id(
                 name = name,
                 case = case,
@@ -4993,7 +4954,7 @@ class PartiqlBasic private constructor() {
         fun parameter(
             index: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Parameter =
             PartiqlBasic.Expr.Parameter(
                 index = index.asPrimitive(),
                 metas = metas)
@@ -5001,7 +4962,7 @@ class PartiqlBasic private constructor() {
         fun parameter_(
             index: LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Parameter =
             PartiqlBasic.Expr.Parameter(
                 index = index,
                 metas = metas)
@@ -5010,7 +4971,7 @@ class PartiqlBasic private constructor() {
         fun not(
             expr: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Not =
             PartiqlBasic.Expr.Not(
                 expr = expr,
                 metas = metas)
@@ -5019,7 +4980,7 @@ class PartiqlBasic private constructor() {
         fun plus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Plus =
             PartiqlBasic.Expr.Plus(
                 operands = operands,
                 metas = metas)
@@ -5029,7 +4990,7 @@ class PartiqlBasic private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Plus =
             PartiqlBasic.Expr.Plus(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -5038,7 +4999,7 @@ class PartiqlBasic private constructor() {
         fun minus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Minus =
             PartiqlBasic.Expr.Minus(
                 operands = operands,
                 metas = metas)
@@ -5048,7 +5009,7 @@ class PartiqlBasic private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Minus =
             PartiqlBasic.Expr.Minus(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -5057,7 +5018,7 @@ class PartiqlBasic private constructor() {
         fun times(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Times =
             PartiqlBasic.Expr.Times(
                 operands = operands,
                 metas = metas)
@@ -5067,7 +5028,7 @@ class PartiqlBasic private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Times =
             PartiqlBasic.Expr.Times(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -5076,7 +5037,7 @@ class PartiqlBasic private constructor() {
         fun divide(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Divide =
             PartiqlBasic.Expr.Divide(
                 operands = operands,
                 metas = metas)
@@ -5086,7 +5047,7 @@ class PartiqlBasic private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Divide =
             PartiqlBasic.Expr.Divide(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -5095,7 +5056,7 @@ class PartiqlBasic private constructor() {
         fun modulo(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Modulo =
             PartiqlBasic.Expr.Modulo(
                 operands = operands,
                 metas = metas)
@@ -5105,7 +5066,7 @@ class PartiqlBasic private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Modulo =
             PartiqlBasic.Expr.Modulo(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -5114,7 +5075,7 @@ class PartiqlBasic private constructor() {
         fun concat(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Concat =
             PartiqlBasic.Expr.Concat(
                 operands = operands,
                 metas = metas)
@@ -5124,7 +5085,7 @@ class PartiqlBasic private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Concat =
             PartiqlBasic.Expr.Concat(
                 operands = listOf(operands0, operands1) + operands.toList(),
                 metas = metas)
@@ -5135,7 +5096,7 @@ class PartiqlBasic private constructor() {
             right: Expr,
             escape: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Like =
             PartiqlBasic.Expr.Like(
                 left = left,
                 right = right,
@@ -5148,7 +5109,7 @@ class PartiqlBasic private constructor() {
             from: Expr,
             to: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Between =
             PartiqlBasic.Expr.Between(
                 value = value,
                 from = from,
@@ -5160,7 +5121,7 @@ class PartiqlBasic private constructor() {
             root: Expr,
             elements: kotlin.collections.List<PathElement>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Path =
             PartiqlBasic.Expr.Path(
                 root = root,
                 elements = elements,
@@ -5171,7 +5132,7 @@ class PartiqlBasic private constructor() {
             elements0: PathElement,
             vararg elements: PathElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Path =
             PartiqlBasic.Expr.Path(
                 root = root,
                 elements = listOf(elements0) + elements.toList(),
@@ -5182,7 +5143,7 @@ class PartiqlBasic private constructor() {
             name: String,
             args: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
                 name = name.asPrimitive(),
                 args = args,
@@ -5192,7 +5153,7 @@ class PartiqlBasic private constructor() {
             name: SymbolPrimitive,
             args: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
                 name = name,
                 args = args,
@@ -5203,7 +5164,7 @@ class PartiqlBasic private constructor() {
             args0: Expr,
             vararg args: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
                 name = name.asPrimitive(),
                 args = listOf(args0) + args.toList(),
@@ -5214,7 +5175,7 @@ class PartiqlBasic private constructor() {
             args0: Expr,
             vararg args: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
                 name = name,
                 args = listOf(args0) + args.toList(),
@@ -5223,22 +5184,26 @@ class PartiqlBasic private constructor() {
         
         fun callAgg(
             name: String,
-            setQuantifier: Expr,
+            setQuantifier: SetQuantifier,
+            arg: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.CallAgg =
             PartiqlBasic.Expr.CallAgg(
                 name = name.asPrimitive(),
                 setQuantifier = setQuantifier,
+                arg = arg,
                 metas = metas)
         
         fun callAgg_(
             name: SymbolPrimitive,
-            setQuantifier: Expr,
+            setQuantifier: SetQuantifier,
+            arg: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.CallAgg =
             PartiqlBasic.Expr.CallAgg(
                 name = name,
                 setQuantifier = setQuantifier,
+                arg = arg,
                 metas = metas)
         
         
@@ -5246,7 +5211,7 @@ class PartiqlBasic private constructor() {
             value: Expr,
             branches: kotlin.collections.List<ExprPair>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.SimpleCase =
             PartiqlBasic.Expr.SimpleCase(
                 value = value,
                 branches = branches,
@@ -5257,7 +5222,7 @@ class PartiqlBasic private constructor() {
             branches0: ExprPair,
             vararg branches: ExprPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.SimpleCase =
             PartiqlBasic.Expr.SimpleCase(
                 value = value,
                 branches = listOf(branches0) + branches.toList(),
@@ -5267,7 +5232,7 @@ class PartiqlBasic private constructor() {
         fun searchedCase(
             branches: kotlin.collections.List<ExprPair>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.SearchedCase =
             PartiqlBasic.Expr.SearchedCase(
                 branches = branches,
                 metas = metas)
@@ -5276,7 +5241,7 @@ class PartiqlBasic private constructor() {
             branches0: ExprPair,
             vararg branches: ExprPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.SearchedCase =
             PartiqlBasic.Expr.SearchedCase(
                 branches = listOf(branches0) + branches.toList(),
                 metas = metas)
@@ -5285,7 +5250,7 @@ class PartiqlBasic private constructor() {
         fun struct(
             fields: kotlin.collections.List<ExprPair>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Struct =
             PartiqlBasic.Expr.Struct(
                 fields = fields,
                 metas = metas)
@@ -5293,7 +5258,7 @@ class PartiqlBasic private constructor() {
         fun struct(
             vararg fields: ExprPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Struct =
             PartiqlBasic.Expr.Struct(
                 fields = fields.toList(),
                 metas = metas)
@@ -5302,7 +5267,7 @@ class PartiqlBasic private constructor() {
         fun bag(
             values: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Bag =
             PartiqlBasic.Expr.Bag(
                 values = values,
                 metas = metas)
@@ -5310,7 +5275,7 @@ class PartiqlBasic private constructor() {
         fun bag(
             vararg values: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Bag =
             PartiqlBasic.Expr.Bag(
                 values = values.toList(),
                 metas = metas)
@@ -5319,7 +5284,7 @@ class PartiqlBasic private constructor() {
         fun list(
             values: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.List =
             PartiqlBasic.Expr.List(
                 values = values,
                 metas = metas)
@@ -5327,7 +5292,7 @@ class PartiqlBasic private constructor() {
         fun list(
             vararg values: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.List =
             PartiqlBasic.Expr.List(
                 values = values.toList(),
                 metas = metas)
@@ -5342,7 +5307,7 @@ class PartiqlBasic private constructor() {
             having: Expr? = null,
             limit: Expr? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): Expr =
+        ): PartiqlBasic.Expr.Select =
             PartiqlBasic.Expr.Select(
                 setq = setq,
                 project = project,
@@ -6698,7 +6663,8 @@ class PartiqlBasic private constructor() {
     
         class CallAgg(
             val name: SymbolPrimitive,
-            val setQuantifier: Expr,
+            val setQuantifier: SetQuantifier,
+            val arg: Expr,
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
@@ -6706,6 +6672,7 @@ class PartiqlBasic private constructor() {
                 CallAgg(
                     name = name,
                     setQuantifier = setQuantifier,
+                    arg = arg,
                     metas = metas + metaContainerOf(metaKey to metaValue))
         
             override fun toIonElement(): SexpElement {
@@ -6713,6 +6680,7 @@ class PartiqlBasic private constructor() {
                     ionSymbol("call_agg"),
                     name.toIonElement(),
                     setQuantifier.toIonElement(),
+                    arg.toIonElement(),
                     metas = metas)
                 return elements
             }
@@ -6725,12 +6693,14 @@ class PartiqlBasic private constructor() {
                 other as CallAgg
                 if (name != other.name) return false
                 if (setQuantifier != other.setQuantifier) return false
+                if (arg != other.arg) return false
                 return true
             }
         
             private val myHashCode by lazy(LazyThreadSafetyMode.NONE) {
                 var hc = name.hashCode()
                 hc = 31 * hc + setQuantifier.hashCode()
+                hc = 31 * hc + arg.hashCode()
                 hc
             }
         
@@ -7300,12 +7270,14 @@ class PartiqlBasic private constructor() {
                         metas = sexp.metas)
                 }
                 "call_agg" -> {
-                    sexp.requireArityOrMalformed(IntRange(2, 2))
+                    sexp.requireArityOrMalformed(IntRange(3, 3))
                     val name = sexp.getRequired(0).toSymbolPrimitive()
-                    val setQuantifier = sexp.getRequired(1).transformExpect<Expr>()
+                    val setQuantifier = sexp.getRequired(1).transformExpect<SetQuantifier>()
+                    val arg = sexp.getRequired(2).transformExpect<Expr>()
                     PartiqlBasic.Expr.CallAgg(
                         name,
                         setQuantifier,
+                        arg,
                         metas = sexp.metas)
                 }
                 "simple_case" -> {

--- a/pig-tests/test/org/partiql/pig/tests/MultiWordDomainNamingTest.kt
+++ b/pig-tests/test/org/partiql/pig/tests/MultiWordDomainNamingTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.partiql.pig.tests
+
+import org.junit.jupiter.api.Test
+import org.partiql.pig.tests.generated.MultiWordDomain
+import kotlin.test.assertEquals
+
+
+class MultiWordDomainNamingTest {
+
+    // The main check here is if the conversion from snake_case to PascalCase is happening correctly
+    // for all of generated identifiers.  The way its tested is by the compilation fo this file,
+    // but we include some assertions anyway just to validate our assumptions further.
+    @Test
+    @Suppress("ComplexRedundantLet")
+    fun compilesCorrectly() {
+
+        // MultiWordDomain products
+
+        MultiWordDomain.build { aaaAaa() }
+
+        MultiWordDomain.build {
+            aaaAab(dField = 123)
+        }.let { a: MultiWordDomain.AaaAab ->
+            assertEquals(123, a.dField?.value)
+        }
+
+        MultiWordDomain.build { aaaAac(dField = 123, eField = "foo") }.let { a: MultiWordDomain.AaaAac ->
+            assertEquals(123, a.dField?.value)
+            assertEquals("foo", a.eField?.text)
+        }
+
+        MultiWordDomain.build {
+            aaaAad(dField = listOf(1L, 2L, 3L))
+        }.let { a: MultiWordDomain.AaaAad ->
+            assertEquals(listOf(1L, 2L, 3L), a.dField.map { i -> i.value })
+        }
+
+        MultiWordDomain.build {
+            aaaAae(dField0 = 1, dField1 = 2)
+        }.let { a: MultiWordDomain.AaaAae ->
+            assertEquals(listOf(1L, 2L), a.dField.map { i -> i.value })
+        }
+
+        // SssTtt variants
+        MultiWordDomain.build {
+            lll(uField = 1)
+        }.let { a: MultiWordDomain.SssTtt.Lll ->
+            assertEquals(1L, a.uField.value)
+        }
+
+        MultiWordDomain.build {
+            mmm(vField = "bleeg")
+        }.let { a: MultiWordDomain.SssTtt.Mmm ->
+            assertEquals("bleeg", a.vField.text)
+        }
+
+        // Record
+        MultiWordDomain.build {
+            rrr(aField = 123, bbbField = 456)
+        }.let { a: MultiWordDomain.Rrr ->
+            // aField uses the default name which is the same as its tag.
+            assertEquals(123L, a.aField.value)
+            // bbbField is the non-default name which is different than the element's tag.
+            assertEquals(456L, a.bbbField.value)
+        }
+    }
+}

--- a/pig-tests/type-domains/sample-universe.ion
+++ b/pig-tests/type-domains/sample-universe.ion
@@ -4,27 +4,27 @@
 (define toy_lang
  (domain
    (sum expr
-    (product lit (value ion))
-    (product variable (name symbol))
-    (product not (expr expr))
-    (product plus (operands (* expr 2)))
-    (product minus (operands (* expr 2)))
-    (product times (operands (* expr 2)))
-    (product divide (operands (* expr 2)))
-    (product modulo (operands (* expr 2)))
-    (product call (name symbol) (operands expr))
-    (product let (name symbol) (value expr) (body expr))
-    (product function (var_name symbol) (body expr)))))
+    (lit value::ion)
+    (variable name::symbol)
+    (not expr::expr)
+    (plus operands::(* expr 2))
+    (minus operands::(* expr 2))
+    (times operands::(* expr 2))
+    (divide operands::(* expr 2))
+    (modulo operands::(* expr 2))
+    (call name::symbol argument::expr)
+    (let name::symbol value::expr body::expr)
+    (function var_name::symbol body::expr))))
 
 // Define another type domain which extends "toy_lang" by removing named variables and adding DeBruijn indices:
-
 (define toy_lang_nameless
   (permute_domain toy_lang
     (with expr
       (exclude variable let)
       (include
-        (product variable (index int))
-        (product let (index int) (value expr) (body expr))))))
+        (variable index::int)
+        (let index::int value::expr body::expr)))))
+
 
 /*
     `test_domain` covers all of the following equivalence classes and is included to test the serializers and
@@ -52,60 +52,60 @@
 
  (define test_domain
     (domain
-        (product int_pair (first int) (second int))
-        (product symbol_pair (first symbol) (second symbol))
-        (product ion_pair (first ion) (second ion))
+        (product int_pair first::int second::int)
+        (product symbol_pair first::symbol second::symbol)
+        (product ion_pair first::ion second::ion)
 
-        (product int_symbol_pair (first int) (second symbol))
-        (product symbol_int_pair (first symbol) (second int))
-        (product ion_int_pair (first  ion) (second int))
-        (product ion_symbol_pair (first  ion) (second ion))
+        (product int_symbol_pair first::int second::symbol)
+        (product symbol_int_pair first::symbol second::int)
+        (product ion_int_pair first::ion second::int)
+        (product ion_symbol_pair first::ion second::ion)
 
-        (product int_pair_pair (first int_pair) (second int_pair))
-        (product symbol_pair_pair (first symbol_pair) (second symbol_pair))
-        (product ion_pair_pair (first ion_pair) (second ion_pair))
+        (product int_pair_pair first::int_pair second::int_pair)
+        (product symbol_pair_pair first::symbol_pair second::symbol_pair)
+        (product ion_pair_pair first::ion_pair second::ion_pair)
 
-        (product recursive_pair (first int) (second (? recursive_pair)))
+        (product recursive_pair first::int second::(? recursive_pair))
 
-        (sum answer (product no) (product yes))
+        (sum answer (no) (yes))
 
-        (product answer_pair (first answer) (second answer))
-        (product answer_int_pair (first answer) (second int))
-        (product int_answer_pair (first int) (second answer))
-        (product symbol_answer_pair (first symbol) (second answer))
-        (product answer_symbol_pair (first answer) (second symbol))
+        (product answer_pair first::answer second::answer)
+        (product answer_int_pair first::answer second::int)
+        (product int_answer_pair first::int second::answer)
+        (product symbol_answer_pair first::symbol second::answer)
+        (product answer_symbol_pair first::answer second::symbol)
 
-        (product variadic_min_0 (ints (* int 0 )))
-        (product variadic_min_1 (ints (* int 1 )))
-        (product element_variadic (name symbol) (ints (* int 0 )))
+        (product variadic_min_0 ints::(* int 0 ))
+        (product variadic_min_1 ints::(* int 1 ))
+        (product element_variadic name::symbol ints::(* int 0 ))
 
-        (product optional_1 (value (? int)))
-        (product optional_2 (first (? int)) (second (? int)))
+        (product optional_1 value::(? int))
+        (product optional_2 first::(? int) second::(? int))
 
         (record domain_level_record
             (some_field int)
             (another_field symbol)
             (optional_field (? int)))
 
-        (product product_with_record (value int) (dlr domain_level_record))
+        (product product_with_record value::int dlr::domain_level_record)
         (sum sum_with_record
-            (product variant_with_record (value int) (dlr domain_level_record)))
+            (variant_with_record value::int dlr::domain_level_record))
 
         (sum entity
             // Slugs are not uniquely identified.
-            (product slug)
+            (slug)
             // Androids are identified by serial number.
-            (product android (id int))
+            (android id::int)
 
             // Uniquely identifying humans a bit more is complex and requires a record.
-            (record human (first_name symbol)          // required
+            (human (first_name symbol)          // required
                    //TODO: variadic record fields are not currently supported in records.
                    // (middle_names (* symbol 0))  // variadic
                    (last_name symbol)           // required
                    (title (? symbol))           // optional
                    (parent (? entity))))        // recursive
 
-        (product entity_pair (first entity) (second entity))
+        (product entity_pair first::entity second::entity)
     ))
 
 
@@ -117,25 +117,26 @@
 (define multi_word_domain
     (domain
         (product aaa_aaa)
-        (product aaa_aab (d_field (? int)))
-        (product aaa_aac (d_field (? int)) (e_field (? symbol)))
-        (product aaa_aad (d_field (* int 0)))
-        (product aaa_aae (d_field (* int 2)))
+        (product aaa_aab d_field::(? int))
+        (product aaa_aac d_field::(? int) e_field::(? symbol))
+        (product aaa_aad d_field::(* int 0))
+        (product aaa_aae d_field::(* int 2))
 
-        (product aab_aaa (b_field int) (c_field symbol))
-        (product aab_aab (b_field int) (c_field symbol) (d_field (? int)))
-        (product aab_aac (b_field int) (c_field symbol) (d_field (? int)) (e_field (? symbol)))
-        (product aab_aad (b_field int) (c_field symbol) (d_field (* int 0)))
-        (product aab_aae (b_field int) (c_field symbol) (d_field (* int 2)))
+        (product aab_aaa b_field::int c_field::symbol)
+        (product aab_aab b_field::int c_field::symbol d_field::(? int))
+        (product aab_aac b_field::int c_field::symbol d_field::(? int) e_field::(? symbol))
+        (product aab_aad b_field::int c_field::symbol d_field::(* int 0))
+        (product aab_aae b_field::int c_field::symbol d_field::(* int 2))
 
         (sum sss_ttt
-            (product lll (u_field int))
-            (product mmm (v_field symbol)))
+            (lll u_field::int)
+            (mmm v_field::symbol))
 
-        (sum sss_ttu
-            (product nnn (u_field aaa_aaa))
-            (product ooo (v_field aaa_aab)))
-        ))
+        (record rrr
+            (a_field int)
+            bbb_field::(b_field int))
+
+))
 
 
 // This is an incomplete AST definition for PartiQL to show what a more complex domain definition will look like.
@@ -145,80 +146,79 @@
 (define partiql_basic
   (domain
     (sum projection
-      (product project_list (items (* project_item 1)))
-      (product project_value (value expr)))
+      (project_list items::(* project_item 1))
+      (project_value value::expr))
 
     (sum project_item
-      (product project_all)
-      (product project_expr (value expr) (as_alias (? symbol))))
+      (project_all)
+      (project_expr value::expr as_alias::(? symbol)))
 
     (sum join_type
-      (product inner)
-      (product left)
-      (product right)
-      (product outer))
+      (inner)
+      (left)
+      (right)
+      (outer))
 
     (sum from_source
-      (product scan (expr expr) (as_alias (? symbol)) (at_alias (? symbol)) (by_alias (? symbol)))
-      (product join (type join_type) (left from_source) (right from_source) (predicate (? expr))))
+      (scan expr::expr as_alias::(? symbol) at_alias::(? symbol) by_alias::(? symbol))
+      (join type::join_type left::from_source right::from_source predicate::(? expr)))
 
-    (product expr_pair (first expr) (second expr))
+    (product expr_pair first::expr second::expr)
 
-    (product group_by_item (value expr) (as_alias (? symbol)))
+    (product group_by_item value::expr as_alias::(? symbol))
 
     (product group_by_list
-      (items (* group_by_item 1)))
+      items::(* group_by_item 1))
 
     (product group_by
-      (items group_by_list)
-      (group_as_alias (? symbol)))  // group as alias
-
+      items::group_by_list
+      group_as_alias::(? symbol))  // group as alias
     (sum case_sensitivity
-      (product case_sensitive)
-      (product case_insensitive))
+      (case_sensitive)
+      (case_insensitive))
 
     (sum scope_qualifier
-      (product unqualified)
-      (product qualified))
+      (unqualified)
+      (qualified))
 
     (sum set_quantifier
-      (product all)
-      (product distinct))
+      (all)
+      (distinct))
 
     (sum path_element
-      (product path_expr (expr expr))
-      (product path_wildcard)
-      (product path_unpivot))
+      (path_expr expr::expr)
+      (path_wildcard)
+      (path_unpivot))
 
     (sum expr
       // Basic Expressions
-      (product lit (value ion))
-      (product id (name symbol) (case case_sensitivity) (scope_qualifier scope_qualifier))
-      (product parameter (index int))
-      (product not (expr expr))
-      (product plus (operands (* expr 2)))
-      (product minus (operands (* expr 2)))
-      (product times (operands (* expr 2)))
-      (product divide (operands (* expr 2)))
-      (product modulo (operands (* expr 2)))
-      (product concat (operands (* expr 2)))
+      (lit value::ion)
+      (id name::symbol case::case_sensitivity scope_qualifier::scope_qualifier)
+      (parameter index::int)
+      (not expr::expr)
+      (plus operands::(* expr 2))
+      (minus operands::(* expr 2))
+      (times operands::(* expr 2))
+      (divide operands::(* expr 2))
+      (modulo operands::(* expr 2))
+      (concat operands::(* expr 2))
 
-      (product like (value expr) (pattern expr) (escape expr))
-      (product between (value expr) (from expr) (to expr))
-      (product path (root expr) (elements (* path_element 1)))
-      (product call (name symbol) (args (* expr 1)))
-      (product call_agg (name symbol) (set_quantifier arg::expr))
+      (like left::expr right::expr escape::expr)
+      (between value::expr from::expr to::expr)
+      (path root::expr elements::(* path_element 1))
+      (call name::symbol args::(* expr 1))
+      (call_agg name::symbol set_quantifier::set_quantifier arg::expr)
 
      // Case Statements
-      (product simple_case (value expr) (branches (* expr_pair 1)))
-      (product searched_case (branches (* expr_pair 1)))
+      (simple_case value::expr branches::(* expr_pair 1))
+      (searched_case branches::(* expr_pair 1))
 
      // Value Constructors
-      (product struct (fields (* expr_pair 0)))
-      (product bag (values (* expr 0)))
-      (product list (values (* expr 0)))
+      (struct fields::(* expr_pair 0))
+      (bag values::(* expr 0))
+      (list values::(* expr 0))
 
-     (record select
+     (select
       (setq (? set_quantifier))
       (project projection)
       (from from_source)
@@ -228,3 +228,5 @@
       (limit (? expr))))       // limit
     ) // end domain
  ) // end define
+
+

--- a/pig/resources/org/partiql/pig/templates/html.ftl
+++ b/pig/resources/org/partiql/pig/templates/html.ftl
@@ -27,7 +27,10 @@
     <thead>
     <tr>
         <th>
-            Name
+            Identifier
+        </th>
+        <th>
+            Tag
         </th>
         <th>
             Type
@@ -44,7 +47,10 @@
     [#list tuple.elements as element]
         <tr>
             <td>
-                ${element.name}
+                ${element.identifier}
+            </td>
+            <td>
+                ${element.tag}
             </td>
             <td>
                 ${element.type}
@@ -66,7 +72,7 @@
         <thead>
             <tr>
                 <th>
-                    Tag Name
+                    Tag
                 </th>
                 <th>
                     Tuple Type
@@ -79,8 +85,9 @@
         <tbody>
             [#list tuples as tuple]
                 <tr>
+
                     <td>
-                        ${tuple.name}
+                        ${tuple.tag}
                     </td>
                     <td>
                         ${tuple.tupleType}

--- a/pig/resources/org/partiql/pig/templates/kotlin.ftl
+++ b/pig/resources/org/partiql/pig/templates/kotlin.ftl
@@ -98,14 +98,14 @@ class ${t.kotlinName}(
 [/#macro]
 
 [#--Emits builder functions that wraps the constructors of domain type. --]
-[#macro builder_constructor_fun t ret_type ret_value_cons]
+[#macro builder_constructor_fun t return_type]
 [#list t.builderFunctions as bf]
 fun ${bf.kotlinName}(
     [@indent count=4]
         [@parameter_list bf.parameters/]
     [/@indent]
-): ${ret_type} =
-    ${ret_value_cons}(
+): ${return_type} =
+    ${return_type}(
     [#list bf.constructorArguments as p]
         ${p.kotlinName} = ${p.value},
     [/#list]
@@ -150,7 +150,7 @@ object builder {
         [#if domain.tuples?size > 0]
         // Tuples
         [#list domain.tuples as tuple]
-        [@builder_constructor_fun tuple tuple.kotlinName "${domain.kotlinName}.${tuple.kotlinName}"/]
+        [@builder_constructor_fun tuple "${domain.kotlinName}.${tuple.kotlinName}"/]
 
         [/#list]
         [/#if]
@@ -158,7 +158,7 @@ object builder {
         [#-- Not sure why the [#lt] below is needed to emit the correct indentation. --]
         // Variants for Sum: ${s.kotlinName} [#lt]
         [#list s.variants as tuple]
-        [@builder_constructor_fun tuple s.kotlinName "${domain.kotlinName}.${s.kotlinName}.${tuple.kotlinName}"/]
+        [@builder_constructor_fun tuple "${domain.kotlinName}.${s.kotlinName}.${tuple.kotlinName}"/]
 
         [/#list]
         [/#list]

--- a/pig/src/org/partiql/pig/domain/model/NamedElement.kt
+++ b/pig/src/org/partiql/pig/domain/model/NamedElement.kt
@@ -16,25 +16,14 @@
 package org.partiql.pig.domain.model
 
 import com.amazon.ionelement.api.MetaContainer
-import com.amazon.ionelement.api.ionSexpOf
-import com.amazon.ionelement.api.ionSymbol
 
-/**
- * An element of a product or record.
- *
- * For products whose elements do not have names, the [tag] field should be synthesized by the
- * instantiator.
- */
-class NamedElement(val tag: String, val typeReference: TypeRef, val metas: MetaContainer) {
-
-    /**
-     * Generates an s-expression representation of this [NamedElement].
-     *
-     * This primarily aids in unit testing and is not intended to have an identical structure to PIG's type universe
-     * syntax.
-     */
-    fun toIonElement() =
-        ionSexpOf(
-            ionSymbol(tag),
-            typeReference.toIonElement())
-}
+/** An element of a product or record. */
+class NamedElement(
+    /** The name of the element that should be used in generated code. */
+    val identifier: String,
+    /** The tag used in the s-expression representation, if this is a record element. */
+    val tag: String,
+    /** A reference to the type of this element.*/
+    val typeReference: TypeRef,
+    val metas: MetaContainer
+)

--- a/pig/src/org/partiql/pig/domain/model/SemanticErrorContext.kt
+++ b/pig/src/org/partiql/pig/domain/model/SemanticErrorContext.kt
@@ -66,10 +66,13 @@ sealed class SemanticErrorContext(val msgFormatter: () -> String): ErrorContext 
         : SemanticErrorContext({ "Cannot remove built-in type '$typeName'" })
 
     data class DuplicateTypeDomainName(val domainName: String)
-        : SemanticErrorContext({ "Duplicate type domain name: '${domainName} "})
+        : SemanticErrorContext({ "Duplicate type domain tag: '${domainName} "})
 
-    data class DuplicateRecordElementName(val elementName: String)
-        : SemanticErrorContext({ "Duplicate record element name: '${elementName} "})
+    data class DuplicateRecordElementTag(val elementName: String)
+        : SemanticErrorContext({ "Duplicate record element tag: '${elementName} "})
+
+    data class DuplicateElementIdentifier(val elementName: String)
+        : SemanticErrorContext({ "Duplicate element identifier: '${elementName} "})
 
     data class NameAlreadyUsed(val name: String, val domainName: String)
         : SemanticErrorContext({ "Name '$name' was previously used in the `$domainName` type domain" })

--- a/pig/src/org/partiql/pig/domain/parser/ParserErrorContext.kt
+++ b/pig/src/org/partiql/pig/domain/parser/ParserErrorContext.kt
@@ -71,6 +71,12 @@ sealed class ParserErrorContext(val msgFormatter: () -> String): ErrorContext {
 
     data class InvalidArityForTag(val expectedCount: IntRange, val tag: String, val actualCount: Int)
         : ParserErrorContext({ "$expectedCount argument(s) were required to '$tag', but $actualCount was/were supplied."})
+
+    object MissingElementIdentifierAnnotation
+        : ParserErrorContext({ "Element is missing required name annotation"})
+
+    object MultipleElementIdentifierAnnotations
+        : ParserErrorContext({ "Element has multiple name annotations"})
 }
 
 

--- a/pig/src/org/partiql/pig/generator/custom/CTypeDomain.kt
+++ b/pig/src/org/partiql/pig/generator/custom/CTypeDomain.kt
@@ -28,14 +28,15 @@ data class CTypeDomain(
 )
 
 data class CElement(
-    val name: String,
+    val identifier: String,
+    val tag: String,
     val type: String,
     val isVariadic: Boolean,
     val isOptional: Boolean
 )
 
 data class CTuple(
-    val name: String,
+    val tag: String,
     val memberOfType: String?,
     val elements: List<CElement>,
     val arity: IntRange,
@@ -80,7 +81,7 @@ fun TypeDomain.toCTypeDomain(): CTypeDomain {
 
 private fun DataType.Tuple.toCTuple(memberOfType: String?) =
     CTuple(
-        name = this.tag,
+        tag = this.tag,
         memberOfType = memberOfType,
         elements = this.namedElements.map { it.toCElement() },
         arity = this.computeArity(),
@@ -95,7 +96,8 @@ private fun NamedElement.toCElement(): CElement {
     }
 
     return CElement(
-        name = this.tag,
+        identifier = this.identifier,
+        tag = this.tag,
         type = this.typeReference.typeName,
         isOptional = isOptional,
         isVariadic = isVariadic)

--- a/pig/src/org/partiql/pig/generator/kotlin/KTypeDomainConverter.kt
+++ b/pig/src/org/partiql/pig/generator/kotlin/KTypeDomainConverter.kt
@@ -121,7 +121,7 @@ internal class KTypeDomainConverter(private val typeDomain: TypeDomain) {
             parameters = tuple.namedElements
                 .map {
                     KParameter(
-                        kotlinName =  it.tag.snakeToCamelCase(),
+                        kotlinName =  it.identifier.snakeToCamelCase(),
                         type = it.typeReference.toKotlinTypeName(useKotlinPrimitives),
                         defaultValue = if (it.typeReference.arity is Arity.Optional) "null" else null,
                         isVariadic = false)
@@ -136,7 +136,7 @@ internal class KTypeDomainConverter(private val typeDomain: TypeDomain) {
         element: NamedElement,
         useKotlinPrimitives: Boolean
     ): KConstructorArgument {
-        val elementKotlinName = element.tag.snakeToCamelCase()
+        val elementKotlinName = element.identifier.snakeToCamelCase()
         val argumentExpr = when {
             isKotlinPrimitive(element) && useKotlinPrimitives ->
                 when (element.typeReference.arity) {
@@ -162,11 +162,10 @@ internal class KTypeDomainConverter(private val typeDomain: TypeDomain) {
             parameters = computeExpandedVariadicBuilderFunctionParameters(tuple, useKotlinPrimitives),
             constructorArguments = tuple.namedElements.map { element ->
                 val elementIsKotlinPrimitive = isKotlinPrimitive(element)
-                val elementKotlinName = element.tag.snakeToCamelCase()
+                val elementKotlinName = element.identifier.snakeToCamelCase()
                 when (element.typeReference.arity) {
                     is Arity.Required, Arity.Optional -> {
                         KConstructorArgument(
-                            // TODO: missing test case
                             kotlinName = elementKotlinName,
                             value = elementKotlinName + when {
                                 elementIsKotlinPrimitive && useKotlinPrimitives -> ".asPrimitive()"
@@ -234,9 +233,8 @@ internal class KTypeDomainConverter(private val typeDomain: TypeDomain) {
             when (val arity = element.typeReference.arity) {
                 is Arity.Required, is Arity.Optional -> {
                     listOf(
-                        // TODO: missing test case
                         KParameter(
-                            kotlinName = element.tag.snakeToCamelCase(),
+                            kotlinName = element.identifier.snakeToCamelCase(),
                             type = element.typeReference.toKotlinTypeName(primitive),
                             defaultValue = if(arity is Arity.Optional) "null" else null,
                             isVariadic = false))
@@ -245,7 +243,7 @@ internal class KTypeDomainConverter(private val typeDomain: TypeDomain) {
                     val requiredParameters =
                         IntRange(0, arity.minimumArity - 1).map { paramIndex ->
                             KParameter(
-                                kotlinName = "${element.tag.snakeToCamelCase()}$paramIndex",
+                                kotlinName = "${element.identifier.snakeToCamelCase()}$paramIndex",
                                 type = element.typeReference.toBaseKotlinTypeName(primitive),
                                 defaultValue = null,
                                 isVariadic = false)
@@ -253,7 +251,7 @@ internal class KTypeDomainConverter(private val typeDomain: TypeDomain) {
 
                     val variadicParameter =
                         KParameter(
-                            kotlinName = element.tag.snakeToCamelCase(),
+                            kotlinName = element.identifier.snakeToCamelCase(),
                             type = element.typeReference.toBaseKotlinTypeName(primitive),
                             defaultValue = null,
                             isVariadic = true)
@@ -272,7 +270,7 @@ internal class KTypeDomainConverter(private val typeDomain: TypeDomain) {
                     is Arity.Optional -> "processOptionalField"
                     is Arity.Variadic -> TODO("Variadic elements in records not yet supported")
                 }
-                "ir.${processFuncName}(\"${element.tag}\") { it$expectCast }"
+                "ir.${processFuncName}(\"${element.identifier}\") { it$expectCast }"
             }
             TupleType.PRODUCT -> {
                 val expectCast = createExpectCast(element.typeReference)
@@ -298,8 +296,8 @@ internal class KTypeDomainConverter(private val typeDomain: TypeDomain) {
                 is Arity.Variadic -> true to false
             }
             KProperty(
-                kotlinName = element.tag.snakeToCamelCase(),
-                tag = element.tag,
+                kotlinName = element.identifier.snakeToCamelCase(),
+                tag = element.tag, // TODO: use tag
                 type = element.typeReference.toKotlinTypeName(useKotlinPrimitives = false),
                 isVariadic = isVariadic,
                 isNullable = isNullable,

--- a/pig/test/org/partiql/pig/domain/PermuteDomainTests.kt
+++ b/pig/test/org/partiql/pig/domain/PermuteDomainTests.kt
@@ -40,24 +40,24 @@ class PermuteDomainTests {
         val typeUniverseWithExtensions = """        
         (define test_domain
             (domain 
-                (product pair (first ion) (second ion))
-                (product other_pair (a symbol) (b symbol))
+                (product pair first::ion second::ion)
+                (product other_pair first::symbol second::symbol)
                 (sum thing
-                    (product a (x pair))
-                    (product b (y symbol))
-                    (product c (z int)))))
+                    (a x::pair)
+                    (b y::symbol)
+                    (c z::int))))
 
         (define permuted_domain 
             (permute_domain test_domain
                 (exclude pair)
                 (include
-                    (product pair (x int) (y int))
-                    (product new_pair (z symbol) (n int)))
+                    (product pair n::int t::int)
+                    (product new_pair m::symbol n::int))
                 (with thing
                     (exclude a)
                     (include
-                        (product d (foo pair))
-                        (product e (bar symbol))))))
+                        (d a::pair)
+                        (e b::symbol)))))
         """
 
         val td: TypeUniverse = IonReaderBuilder.standard().build(typeUniverseWithExtensions).use { parseTypeUniverse(it) }

--- a/pig/test/org/partiql/pig/domain/TypeDomainParserErrorsTest.kt
+++ b/pig/test/org/partiql/pig/domain/TypeDomainParserErrorsTest.kt
@@ -71,6 +71,10 @@ class TypeDomainParserErrorsTest {
                 makeErr(1, 22, ParserErrorContext.InvalidDomainLevelTag("bad_tag"))),
 
             TestCase(
+                "(define huh (domain (product one::huh two::int three::(bad_tag))))",
+                makeErr(1, 56, ParserErrorContext.ExpectedTypeReferenceArityTag("bad_tag"))),
+
+            TestCase(
                 "(define huh (permute_domain huh (bad_tag)))",
                 makeErr(1, 33, ParserErrorContext.InvalidPermutedDomainTag("bad_tag"))),
 
@@ -79,12 +83,12 @@ class TypeDomainParserErrorsTest {
                 makeErr(1, 43, ParserErrorContext.InvalidWithSumTag("bad_tag"))),
 
             TestCase(
-                "(define huh (domain (product huh (a (? )))))",
+                "(define huh (domain (product x::huh y::(? ))))",
                 makeErr(1, 37, ParserErrorContext.InvalidArityForTag(IntRange(1, 1), "?", 0))),
 
             TestCase(
-                "(define huh (domain (product huh (a (? one two)))))",
-                makeErr(1, 37, ParserErrorContext.InvalidArityForTag(IntRange(1, 1), "?", 2))),
+                "(define huh (domain (product huh x::(? o::one t::two))))",
+                makeErr(1, 34, ParserErrorContext.InvalidArityForTag(IntRange(1, 1), "?", 2))),
 
             TestCase(
                 "(define huh (domain (record foo (name_field_with_too_few_elements))))",
@@ -95,8 +99,12 @@ class TypeDomainParserErrorsTest {
                 makeErr(1, 33, ParserErrorContext.InvalidArity(2, 3))),
 
             TestCase( // Covers first place in parser this can be thrown
-                "(define huh (domain (product huh (blargh 42))))",
-                makeErr(1, 42, ParserErrorContext.ExpectedSymbolOrSexp(ElementType.INT)))
+                "(define huh (domain (product huh x::42)))",
+                makeErr(1, 34, ParserErrorContext.ExpectedSymbolOrSexp(ElementType.INT))),
+
+            TestCase( // Covers second place in parser this can be thrown
+                "(define huh (domain (product huh x::int y::42)))",
+                makeErr(1, 41, ParserErrorContext.ExpectedSymbolOrSexp(ElementType.INT)))
         )
     }
 }

--- a/pig/test/org/partiql/pig/domain/TypeDomainParserTests.kt
+++ b/pig/test/org/partiql/pig/domain/TypeDomainParserTests.kt
@@ -33,8 +33,8 @@ class TypeDomainParserTests {
             """
                 (define test_domain 
                     (domain 
-                        (product foo (a string) (b (* int 2)))
-                        (product bar (a bat) (b (? baz)) (c (* blargh 10)))))
+                        (product foo a::string b::(* int 2))
+                        (product bar a::bat b::(? baz) c::(* blargh 10))))
             """)
 
     @Test
@@ -43,7 +43,8 @@ class TypeDomainParserTests {
                 (define test_domain 
                     (domain 
                         (record foo (bat int) (blorg (? int)))
-                        (record bar (bloo int) (blat (* int 1)))))
+                        (record bar (bloo int) (blat (* int 1)))
+                        (record bat xx::(x int) yy::(y int))))
             """)
 
     @Test
@@ -53,18 +54,18 @@ class TypeDomainParserTests {
                 (define some_domain
                     (domain 
                         (sum test_sum
-                        // Product with no elements
-                        (product vacuum)
-                        
-                        // Product with one element
-                        (product lonely (single int))
-                        
-                        // Product with two elements
-                        (product company (id int) (name symbol))
-                        
-                        // Record with three elements
-                        (record crowd (first int) (second symbol) (third ion))
-                        )))
+                            // Product with no elements
+                            (vacuum)
+                            
+                            // Product with one element
+                            (lonely single::int)
+                            
+                            // Product with two elements
+                            (company id::int name::symbol)
+                            
+                            // Record with three elements
+                            (crowd first::int second::symbol third::ion)
+                            )))
             """)
 
 
@@ -75,11 +76,11 @@ class TypeDomainParserTests {
                     (permute_domain some_domain
                         (exclude excluded_type)
                         (include 
-                            (product included_product (a int)))
+                            (product included_product a::int))
                         (with altered_sum
                             (exclude removed_variant)
                             (include
-                                (product added_variant (a int) (b int))))))
+                                (added_variant a::int b::int)))))
             """)
 
     private fun runTestCase(tc: String) {

--- a/pig/test/org/partiql/pig/domain/TypeDomainSemanticCheckerTests.kt
+++ b/pig/test/org/partiql/pig/domain/TypeDomainSemanticCheckerTests.kt
@@ -34,8 +34,12 @@ class TypeDomainSemanticCheckerTests {
     fun perumteErrorsTest(tc: TestCase) = runTest(tc)
 
     @ParameterizedTest
-    @MethodSource("parametersForNameErrorsTest")
-    fun nameErrorsTest(tc: TestCase) = runTest(tc)
+    @MethodSource("parametersForNameErrorsTest1")
+    fun nameErrorsTest1(tc: TestCase) = runTest(tc)
+
+    @ParameterizedTest
+    @MethodSource("parametersForNameErrorsTest2")
+    fun nameErrorsTest2(tc: TestCase) = runTest(tc)
 
     private fun runTest(tc: TestCase) {
         val u = parseTypeUniverse(tc.typeUniverseText)
@@ -59,22 +63,22 @@ class TypeDomainSemanticCheckerTests {
                      makeErr(1, 29, SemanticErrorContext.EmptySumType("empty_sum"))),
 
             // Product element arity ordering
-            TestCase("(define some_domain (domain (product some_product (a (? int)) (b int))))",
-                     makeErr(1, 63, SemanticErrorContext.RequiredElementAfterOptional)),
+            TestCase("(define some_domain (domain (product some_product x::(? int) y::int)))",
+                     makeErr(1, 62, SemanticErrorContext.RequiredElementAfterOptional)),
 
-            TestCase("(define some_domain (domain (product some_product (a (* int 1)) (b int))))",
-                makeErr(1, 65, SemanticErrorContext.RequiredElementAfterVariadic)),
+            TestCase("(define some_domain (domain (product some_product x::(? int) y::(* int 1))))",
+                     makeErr(1, 62, SemanticErrorContext.ProductCannotHaveBothOptionalAndVariadicElements)),
 
-            TestCase("(define some_domain (domain (product some_product (a (? int)) (b (* int 1)))))",
-                     makeErr(1, 63, SemanticErrorContext.ProductCannotHaveBothOptionalAndVariadicElements)),
+            TestCase("(define some_domain (domain (product some_product x::(* int 1) y::int)))",
+                     makeErr(1, 64, SemanticErrorContext.RequiredElementAfterVariadic)),
 
-            TestCase("(define some_domain (domain (product some_product (a (* int 1)) (b (? int)))))",
-                     makeErr(1, 65, SemanticErrorContext.OptionalElementAfterVariadic)),
+            TestCase("(define some_domain (domain (product some_product x::(* int 1) y::(? int))))",
+                     makeErr(1, 64, SemanticErrorContext.OptionalElementAfterVariadic)),
 
-            TestCase("(define some_domain (domain (product some_product (a (* int 1)) (b (* int 1)))))",
-                     makeErr(1, 65, SemanticErrorContext.MoreThanOneVariadicElement)),
+            TestCase("(define some_domain (domain (product some_product x::(* int 1) y::(* int 1))))",
+                     makeErr(1, 64, SemanticErrorContext.MoreThanOneVariadicElement)),
 
-            TestCase("(define some_domain (domain (product some_product (a (? ion)))))",
+            TestCase("(define some_domain (domain (product some_product x::(? ion))))",
                      makeErr(1, 51, SemanticErrorContext.OptionalIonTypeElement)))
 
         @JvmStatic
@@ -89,87 +93,110 @@ class TypeDomainSemanticCheckerTests {
             TestCase("(define some_domain (domain)) (define some_permuted_domain (permute_domain some_domain (with nonexistent)))",
                      makeErr(1, 88, SemanticErrorContext.CannotPermuteNonExistentSum("nonexistent", "some_permuted_domain", "some_domain"))),
 
-            TestCase("(define some_domain (domain (sum some_sum (product a (x int))))) (define some_permuted_domain (permute_domain some_domain (with some_sum (exclude nonexistent))))",
-                     makeErr(1, 123, SemanticErrorContext.CannotRemoveNonExistentSumVariant(sumTypeName = "some_sum", variantName = "nonexistent"))),
+            TestCase("(define some_domain (domain (sum some_sum (a x::int)))) (define some_permuted_domain (permute_domain some_domain (with some_sum (exclude nonexistent))))",
+                     makeErr(1, 114, SemanticErrorContext.CannotRemoveNonExistentSumVariant(sumTypeName = "some_sum", variantName = "nonexistent"))),
 
             TestCase("(define some_domain (domain)) (define some_domain (permute_domain some_domain (with int)))",
                      makeErr(1, 79, SemanticErrorContext.CannotPermuteNonSumType("int"))),
 
-            TestCase("(define some_domain (domain (product foo (x int)))) (define some_domain (permute_domain some_domain (with foo)))",
-                     makeErr(1, 101, SemanticErrorContext.CannotPermuteNonSumType("foo"))),
+            TestCase("(define some_domain (domain (product x::foo y::int))) (define some_domain (permute_domain some_domain (with foo)))",
+                     makeErr(1, 103, SemanticErrorContext.CannotPermuteNonSumType("foo"))),
 
             TestCase("(define some_domain (domain)) (define permuted_domain (permute_domain some_domain (exclude int)))",
                      makeErr(1, 55, SemanticErrorContext.CannotRemoveBuiltinType("int"))),
 
-            TestCase("(define some_domain (domain (product some_product (x undefined))))",
-                     makeErr(1, 54, SemanticErrorContext.UndefinedType("undefined"))),
+            TestCase("(define some_domain (domain (product some_product x::undefined)))",
+                     makeErr(1, 51, SemanticErrorContext.UndefinedType("undefined"))),
 
             // Excluding the only variant from a sum should result in the EmptySumType error
-            TestCase("(define some_domain (domain (sum non_empty_sum (product a (x int))))) (define another_domain (permute_domain some_domain (with non_empty_sum (exclude a))))",
-                     makeErr(1, 94, SemanticErrorContext.EmptySumType("non_empty_sum"))))
+            TestCase("(define some_domain (domain (sum non_empty_sum (a x::int)))) (define another_domain (permute_domain some_domain (with non_empty_sum (exclude a))))",
+                     makeErr(1, 85, SemanticErrorContext.EmptySumType("non_empty_sum"))))
 
         @JvmStatic
         @Suppress("unused")
-        fun parametersForNameErrorsTest() = listOf(
-            // Variant name used in place of type name (in same sum)
-            TestCase("(define some_domain (domain (sum some_sum (product a_variant)) (product b_variant (a a_variant))))",
-                     makeErr(1, 86, SemanticErrorContext.NotATypeName("a_variant"))),
+        fun parametersForNameErrorsTest1() = listOf(
+            // Variant tag used in place of type tag (in same sum)
+            TestCase("(define some_domain (domain (sum some_sum (a_variant) (b_variant x::a_variant))))",
+                     makeErr(1, 66, SemanticErrorContext.NotATypeName("a_variant"))),
 
-            // Variant name used in place of type name (in a different sum)
-            TestCase("(define some_domain (domain (sum some_sum (product a_variant)) (sum another_sum (product b_variant (x a_variant)))))",
-                     makeErr(1, 103, SemanticErrorContext.NotATypeName("a_variant"))),
+            // Variant tag used in place of type name (in a different sum)
+            TestCase("(define some_domain (domain (sum some_sum (a_variant)) (sum another_sum (b_variant x::a_variant))))",
+                     makeErr(1, 84, SemanticErrorContext.NotATypeName("a_variant"))),
 
-            // Field name used in place of type name (in same sum)
-            TestCase("(define some_domain (domain (sum some_sum (product a_variant (a_field int)) (product b_variant (x a_field)))))",
-                     makeErr(1, 99, SemanticErrorContext.UndefinedType("a_field"))),
-            
+            // Field tag used in place of type name (in same sum)
+            TestCase("(define some_domain (domain (sum some_sum (a_variant (a_field int)) (b_variant x::a_field))))",
+                     makeErr(1, 80, SemanticErrorContext.UndefinedType("a_field"))),
+
+            // Variant identifier used in place of type name (in a different sum)
+            TestCase("(define some_domain (domain (sum some_sum av::(a_variant)) (sum another_sum (b_variant x::av))))",
+                     makeErr(1, 88, SemanticErrorContext.UndefinedType("av"))),
+
+            // Field identifier used in place of type name (in same sum)
+            TestCase("(define some_domain (domain (sum some_sum (a_variant af::(a_field int)) (b_variant x::af))))",
+                     makeErr(1, 84, SemanticErrorContext.UndefinedType("af"))),
+
             // Duplicate domain name
             TestCase("(define foo (domain)) (define foo (permute_domain foo))",
                      makeErr(1, 35, SemanticErrorContext.DuplicateTypeDomainName("foo"))),
 
-            // Duplicate product name
-            TestCase("(define some_domain (domain (product some_product (x int)) (product some_product)))",
-                     makeErr(1, 60, SemanticErrorContext.NameAlreadyUsed("some_product", "some_domain"))),
+            // Duplicate product tag
+            TestCase("(define some_domain (domain (product some_product x::int) (product some_product)))",
+                     makeErr(1, 59, SemanticErrorContext.NameAlreadyUsed("some_product", "some_domain"))),
 
-            // Duplicate sum name
-            TestCase("(define some_domain (domain (sum dup_sum (product variant)) (sum dup_sum (product variant))))",
-                     makeErr(1, 61, SemanticErrorContext.NameAlreadyUsed("dup_sum", "some_domain"))),
+            // Duplicate sum tag
+            TestCase("(define some_domain (domain (sum dup_sum (variant)) (sum dup_sum (variant))))",
+                     makeErr(1, 53, SemanticErrorContext.NameAlreadyUsed("dup_sum", "some_domain"))),
 
             // Duplicate sum has same name as product
-            TestCase("(define some_domain (domain (sum dup_tag (product variant)) (product dup_tag (n int))))",
-                     makeErr(1, 61, SemanticErrorContext.NameAlreadyUsed("dup_tag", "some_domain"))),
-
-            // Duplicate product has same name as sum
+            TestCase("(define some_domain (domain (sum dup_tag (variant)) (product dup_tag x::int)))",
+                     makeErr(1, 53, SemanticErrorContext.NameAlreadyUsed("dup_tag", "some_domain")))
+        )
+        @JvmStatic
+        @Suppress("unused")
+        fun parametersForNameErrorsTest2() = listOf(
+            // Duplicate product has same tag as sum
             TestCase("(define some_domain (domain (product dup_tag) (sum dup_tag)))",
                      makeErr(1, 47, SemanticErrorContext.NameAlreadyUsed("dup_tag", "some_domain"))),
 
             // Duplicate sum variant (same sum)
-            TestCase("(define some_domain (domain (sum some_sum (product a (x int)) (product a (y int)))))",
-                     makeErr(1, 63, SemanticErrorContext.NameAlreadyUsed("a", "some_domain"))),
+            TestCase("(define some_domain (domain (sum some_sum (a x::int) (a y::int))))",
+                     makeErr(1, 54, SemanticErrorContext.NameAlreadyUsed("a", "some_domain"))),
 
             // Duplicate sum variant (different sums)
-            TestCase("(define some_domain (domain (sum some_sum (product dup_variant (x int))) (sum another_sum (product dup_variant (y int)))))",
-                     makeErr(1, 91, SemanticErrorContext.NameAlreadyUsed("dup_variant", "some_domain"))),
+            TestCase("(define some_domain (domain (sum some_sum (dup_variant x::int)) (sum another_sum (dup_variant y::int))))",
+                     makeErr(1, 82, SemanticErrorContext.NameAlreadyUsed("dup_variant", "some_domain"))),
 
-            // Sum variant uses same name as sum
-            TestCase("(define some_domain (domain (sum dup_tag (product dup_tag))))",
+            // Sum variant uses same tag as sum
+            TestCase("(define some_domain (domain (sum dup_tag (dup_tag))))",
                      makeErr(1, 42, SemanticErrorContext.NameAlreadyUsed("dup_tag", "some_domain"))),
 
-            // Sum variant uses same name as other type in same domain
-            TestCase("(define some_domain (domain (product some_product) (sum some_sum (product some_product))))",
+            // Sum variant uses same tag as other type in same domain
+            TestCase("(define some_domain (domain (product some_product) (sum some_sum (some_product))))",
                      makeErr(1, 66, SemanticErrorContext.NameAlreadyUsed("some_product", "some_domain"))),
 
-            // Duplicate record element name within same sum variant record
-            TestCase("(define some_domain (domain (sum some_sum (record a_variant (some_field int) (some_field int)))))",
-                     makeErr(1, 78, SemanticErrorContext.DuplicateRecordElementName("some_field"))),
+            // Duplicate record element tag within same sum variant record
+            TestCase("(define some_domain (domain (sum some_sum (a_variant (some_field int) (some_field int)))))",
+                     makeErr(1, 71, SemanticErrorContext.DuplicateRecordElementTag("some_field"))),
 
-            // Duplicate record element name
+            // Duplicate record element tag within same record type
             TestCase("(define some_domain (domain (record some_record (some_field int) (some_field int))))",
-                     makeErr(1, 66, SemanticErrorContext.DuplicateRecordElementName("some_field"))),
+                     makeErr(1, 66, SemanticErrorContext.DuplicateRecordElementTag("some_field"))),
 
-            // Duplicate product element name
-            TestCase("(define some_domain (domain (product some_product (some_field int) (some_field int))))",
-                     makeErr(1, 68, SemanticErrorContext.DuplicateRecordElementName("some_field"))),
+            // Duplicate product element tag
+            TestCase("(define some_domain (domain (product some_product some_field::int some_field::int)))",
+                     makeErr(1, 67, SemanticErrorContext.DuplicateElementIdentifier("some_field"))),
+
+            // Duplicate product element identifier
+            TestCase("(define some_domain (domain (product some_product some_field::int some_field::int)))",
+                     makeErr(1, 67, SemanticErrorContext.DuplicateElementIdentifier("some_field"))),
+
+            // Duplicate record element identifier (duplicates other identifier)
+            TestCase("(define some_domain (domain (record some_record x::(x int) x::(y int))))",
+                     makeErr(1, 60, SemanticErrorContext.DuplicateElementIdentifier("x"))),
+
+            // Duplicate record element identifier (duplicates other tag)
+            TestCase("(define some_domain (domain (record some_record (a int) a::(c int))))",
+                     makeErr(1, 57, SemanticErrorContext.DuplicateElementIdentifier("a"))),
 
             // Record with no fields
             TestCase("(define some_domain (domain (record some_record)))",

--- a/pig/test/org/partiql/pig/generator/custom/CreateCustomFreeMarkerGlobalsTest.kt
+++ b/pig/test/org/partiql/pig/generator/custom/CreateCustomFreeMarkerGlobalsTest.kt
@@ -40,7 +40,7 @@ class CreateCustomFreeMarkerGlobalsTest {
                                 tag = "foo",
                                 tupleType = TupleType.PRODUCT,
                                 namedElements = listOf(
-                                    NamedElement("bat", TypeRef("int", Arity.Required, em), em)),
+                                    NamedElement("bat", "baz", TypeRef("int", Arity.Required, em), em)),
                                 metas = em),
                             DataType.Sum(
                                 "some_sum",
@@ -49,7 +49,7 @@ class CreateCustomFreeMarkerGlobalsTest {
                                         tag = "bar",
                                         tupleType = TupleType.PRODUCT,
                                         namedElements = listOf(
-                                            NamedElement("bloo", TypeRef("int", Arity.Required, em), em)),
+                                            NamedElement("bloo", "blar", TypeRef("int", Arity.Required, em), em)),
                                         metas = em)),
                                 metas = em)))))
 
@@ -65,11 +65,12 @@ class CreateCustomFreeMarkerGlobalsTest {
                         name = "test_domain",
                         tuples = listOf(
                             CTuple(
-                                name = "foo",
+                                tag = "foo",
                                 tupleType = TupleType.PRODUCT,
                                 elements = listOf(
                                     CElement(
-                                        name = "bat",
+                                        identifier = "bat",
+                                        tag = "baz",
                                         type = "int",
                                         isVariadic = false,
                                         isOptional = false
@@ -81,11 +82,12 @@ class CreateCustomFreeMarkerGlobalsTest {
                                 name = "some_sum",
                                 variants= listOf(
                                     CTuple(
-                                        name="bar",
+                                        tag ="bar",
                                         memberOfType="some_sum",
                                         elements=listOf(
                                                 CElement(
-                                                    name="bloo",
+                                                    identifier="bloo",
+                                                    tag="blar",
                                                     type="int",
                                                     isVariadic=false,
                                                     isOptional=false)),


### PR DESCRIPTION
- Restores previous syntax for product elements.
- Uses annotations on both product and record elements to provide an
identifier to be used in generated code.
- Require identifiers on product elements.
- Add semantic checks to prevent duplicate element identifiers;
- Updates README.md


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
