### PR TITLE
Fix publishing to maven local

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,9 @@ allprojects {
 
 subprojects {
     group = 'org.partiql'
-    version = '0.2.0'
+    version = '0.2.1-SNAPSHOT'
 }
+ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 buildDir = new File(rootProject.projectDir, "gradle-build/" + project.name)
 

--- a/pig-runtime/build.gradle
+++ b/pig-runtime/build.gradle
@@ -113,11 +113,11 @@ publishing {
 }
 
 signing {
-    // Allow publishing to maven local even if we don't have the signing keys
-    // This works because when not required, the signing task will be skipped
-    // if signing.keyId, signing.password, signing.secretKeyRingFile, etc are
-    // not present in gradle.properties.
-    required { !gradle.taskGraph.hasTask(":lang:publishToMavenLocal") }
-
+    required { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
     sign publishing.publications.maven
 }
+
+tasks.withType(Sign) {
+    onlyIf { isReleaseVersion }
+}
+

--- a/pig/build.gradle
+++ b/pig/build.gradle
@@ -130,11 +130,10 @@ publishing {
 }
 
 signing {
-    // Allow publishing to maven local even if we don't have the signing keys
-    // This works because when not required, the signing task will be skipped
-    // if signing.keyId, signing.password, signing.secretKeyRingFile, etc are
-    // not present in gradle.properties.
-    required { !gradle.taskGraph.hasTask(":lang:publishToMavenLocal") }
-
+    required { isReleaseVersion && gradle.taskGraph.hasTask("publish") }
     sign publishing.publications.maven
+}
+
+tasks.withType(Sign) {
+    onlyIf { isReleaseVersion }
 }


### PR DESCRIPTION
After this change, `./gradlew publishToMavenLocal` will work properly even if you don't have the signing keys on your local machine.

I needed this fix to properly test https://github.com/partiql/partiql-lang-kotlin/pull/261 without releasing PIG `v0.2.1` and thought I should make the fix permanent so we can do this again in the future.

I had attempted to allow this previously but failed.  This time I actually fixed it for real using a solution straight out of the Gradle documentation, which I was having trouble finding before.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
