### PR TITLE
Enhance public API for generating code (#5)

### DIFF
--- a/pig/src/org/partiql/pig/domain/model/SemanticErrorContext.kt
+++ b/pig/src/org/partiql/pig/domain/model/SemanticErrorContext.kt
@@ -18,7 +18,7 @@ package org.partiql.pig.domain.model
 import com.amazon.ionelement.api.IonLocation
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.location
-import org.partiql.pig.domain.PigException
+import org.partiql.pig.errors.PigException
 import org.partiql.pig.errors.ErrorContext
 import org.partiql.pig.errors.PigError
 

--- a/pig/src/org/partiql/pig/domain/model/TypeUniverse.kt
+++ b/pig/src/org/partiql/pig/domain/model/TypeUniverse.kt
@@ -15,7 +15,7 @@
 
 package org.partiql.pig.domain.model
 
-import org.partiql.pig.domain.PigException
+import org.partiql.pig.errors.PigException
 
 data class TypeUniverse(val statements: List<Statement>) {
 

--- a/pig/src/org/partiql/pig/domain/parser/ParserErrorContext.kt
+++ b/pig/src/org/partiql/pig/domain/parser/ParserErrorContext.kt
@@ -20,7 +20,7 @@ import com.amazon.ionelement.api.IonLocation
 import com.amazon.ionelement.api.location
 import com.amazon.ionelement.api.ElementType
 import com.amazon.ionelement.api.IonElementException
-import org.partiql.pig.domain.PigException
+import org.partiql.pig.errors.PigException
 import org.partiql.pig.errors.ErrorContext
 import org.partiql.pig.errors.PigError
 

--- a/pig/src/org/partiql/pig/errors/Exceptions.kt
+++ b/pig/src/org/partiql/pig/errors/Exceptions.kt
@@ -13,7 +13,7 @@
  *  permissions and limitations under the License.
  */
 
-package org.partiql.pig.domain
+package org.partiql.pig.errors
 
 import org.partiql.pig.errors.PigError
 

--- a/pig/src/org/partiql/pig/errors/PigError.kt
+++ b/pig/src/org/partiql/pig/errors/PigError.kt
@@ -30,6 +30,6 @@ interface ErrorContext {
 }
 
 data class PigError(val location: IonLocation?, val context: ErrorContext) {
-    val message: String get() = "${locationToString(location)}: $${context}"
+    override fun toString(): String = "${locationToString(location)}: ${context.message}"
 }
 

--- a/pig/test/org/partiql/pig/domain/TypeDomainParserErrorsTest.kt
+++ b/pig/test/org/partiql/pig/domain/TypeDomainParserErrorsTest.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.partiql.pig.domain.parser.ParserErrorContext
 import org.partiql.pig.domain.parser.parseTypeUniverse
 import org.partiql.pig.errors.PigError
+import org.partiql.pig.errors.PigException
 
 class TypeDomainParserErrorsTest {
 
@@ -41,7 +42,7 @@ class TypeDomainParserErrorsTest {
 
         // This is mainly to improve code coverage but also ensures the
         // message formatting function doesn't throw
-        assertNotNull(tc.expectedError.message)
+        assertNotNull(tc.expectedError.toString())
     }
 
     companion object {

--- a/pig/test/org/partiql/pig/domain/TypeDomainSemanticCheckerTests.kt
+++ b/pig/test/org/partiql/pig/domain/TypeDomainSemanticCheckerTests.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.partiql.pig.domain.model.SemanticErrorContext
 import org.partiql.pig.domain.parser.parseTypeUniverse
 import org.partiql.pig.errors.PigError
+import org.partiql.pig.errors.PigException
 
 class TypeDomainSemanticCheckerTests {
 


### PR DESCRIPTION
While preparing https://github.com/partiql/partiql-lang-kotlin/pull/261 I ran into several pig errors related to the type domain that were not properly being displayed by PartiQL's gradle build.  I found that the reasons for this were that `exitProcess` was being called prematurely as described in #5 and that some `.toString()` overrides weren't present, and so I decided it was time to fix.

Invoking `pig` from a `build.gradle` of a consuming project now looks like:

```Groovy
task generatePigDomains {
    group = "code generation"

    def typeUniverse = new File(projectDir, "resources/org/partiql/type-domains/partiql.ion")
    def outputFile = new File(projectDir, "src/org/partiql/lang/domains/partiql-domains.kt")
    def targetLanguage = new TargetLanguage.Kotlin("org.partiql.lang.domains")
    def cmd = new Command.Generate(typeUniverse, outputFile, targetLanguage)

    doLast {
        try {
            org.partiql.pig.MainKt.generateCode(cmd)
        } catch(PigException e) {
            System.err.println("Failed to generate PIG domains: ${e.error}")
            // This exception tells gradle that the task failed and so the build should fail
            throw new TaskExecutionException(generatePigDomains, e)
        }
    }
}
```

Note that `PigException` is being thrown instead of `exitProcess` being called. That allows us to in turn throw a `TaskExecutionException` which, stops the build and displays `e.toString()` correctly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
