### PR TITLE
Add copy method to LongPrimitive and SymbolPrimitive and add tests

### DIFF
--- a/pig-runtime/src/org/partiql/pig/runtime/LongPrimitive.kt
+++ b/pig-runtime/src/org/partiql/pig/runtime/LongPrimitive.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.partiql.pig.runtime
+
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.metaContainerOf
+
+/**
+ * Represents a long value that is part of a generated type domain.
+ *
+ * This is needed to allow such values to have metas.
+ */
+class LongPrimitive(val value: Long, override val metas: MetaContainer) : DomainNode {
+
+    /** Creates a copy of the current node with the specified values. */
+    fun copy(value: Long = this.value, metas: MetaContainer = this.metas): LongPrimitive =
+        LongPrimitive(value, metas)
+
+    /** Creates a copy of the current [LongPrimitive] with the specified additional meta. */
+    override fun withMeta(metaKey: String, metaValue: Any): LongPrimitive =
+        LongPrimitive(this.value, metas + metaContainerOf(metaKey to metaValue))
+
+    /** Creates an `IonElement` representation of the current [LongPrimitive]. */
+    override fun toIonElement(): IonElement = ionInt(value, metas = metas)
+
+    /** Converts [value] to a string. */
+    override fun toString(): String = value.toString()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as LongPrimitive
+
+        if (value != other.value) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+}
+

--- a/pig-runtime/src/org/partiql/pig/runtime/PrimitiveUtils.kt
+++ b/pig-runtime/src/org/partiql/pig/runtime/PrimitiveUtils.kt
@@ -16,59 +16,9 @@
 package org.partiql.pig.runtime
 
 import com.amazon.ionelement.api.AnyElement
-import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.MetaContainer
 import com.amazon.ionelement.api.emptyMetaContainer
-import com.amazon.ionelement.api.ionInt
-import com.amazon.ionelement.api.ionSymbol
-import com.amazon.ionelement.api.metaContainerOf
-import com.amazon.ionelement.api.withMetas
 
-class LongPrimitive(val value: Long, override val metas: MetaContainer) : DomainNode {
-    override fun withMeta(metaKey: String, metaValue: Any): LongPrimitive =
-        LongPrimitive(this.value, metas + metaContainerOf(metaKey to metaValue))
-
-    override fun toIonElement(): IonElement = ionInt(value).withMetas(metas)
-    override fun toString(): String = value.toString()
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as LongPrimitive
-
-        if (value != other.value) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return value.hashCode()
-    }
-}
-
-class SymbolPrimitive(val text: String, override val metas: MetaContainer) : DomainNode {
-    override fun withMeta(metaKey: String, metaValue: Any): SymbolPrimitive =
-        SymbolPrimitive(text, metas + metaContainerOf(metaKey to metaValue))
-
-    override fun toIonElement(): IonElement = ionSymbol(text).withMetas(metas)
-    override fun toString(): String = text
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as SymbolPrimitive
-
-        if (text != other.text) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return text.hashCode()
-    }
-}
 
 fun AnyElement.toLongPrimitive() =
     LongPrimitive(this.longValue, this.metas)

--- a/pig-runtime/src/org/partiql/pig/runtime/SymbolPrimitive.kt
+++ b/pig-runtime/src/org/partiql/pig/runtime/SymbolPrimitive.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.partiql.pig.runtime
+
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.ionSymbol
+import com.amazon.ionelement.api.metaContainerOf
+
+/**
+ * Represents a symbol value that is part of a generated type domain.
+ *
+ * This is needed to allow such values to have metas.
+ */
+class SymbolPrimitive(val text: String, override val metas: MetaContainer) : DomainNode {
+
+    /** Creates a copy of the current node with the specified values. */
+    fun copy(text: String = this.text, metas: MetaContainer = this.metas): SymbolPrimitive =
+        SymbolPrimitive(text, metas)
+
+    /** Creates a copy of the current [SymbolPrimitive] with the specified additional meta. */
+    override fun withMeta(metaKey: String, metaValue: Any): SymbolPrimitive =
+        SymbolPrimitive(text, metas + metaContainerOf(metaKey to metaValue))
+
+    /** Creates an `IonElement` representation of the current [SymbolPrimitive]. */
+    override fun toIonElement(): IonElement = ionSymbol(text, metas = metas)
+
+    override fun toString(): String = text
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SymbolPrimitive
+
+        if (text != other.text) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return text.hashCode()
+    }
+}
+

--- a/pig-runtime/test/org/partiql/pig/runtime/LongPrimitiveTests.kt
+++ b/pig-runtime/test/org/partiql/pig/runtime/LongPrimitiveTests.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.partiql.pig.runtime
+
+import com.amazon.ionelement.api.emptyMetaContainer
+import com.amazon.ionelement.api.ionInt
+import com.amazon.ionelement.api.metaContainerOf
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class LongPrimitiveTests {
+    @Test
+    fun copy() {
+        val l = 42.asPrimitive(metaContainerOf("foo" to 43))
+        assertEquals(42, l.value)
+        assertEquals(metaContainerOf("foo" to 43), l.metas)
+
+        val l2 = l.copy(value = 43)
+        assertEquals(43, l2.value)
+        assertEquals(metaContainerOf("foo" to 43), l2.metas)
+
+        val l3 = l.copy(metas = metaContainerOf("foo" to 88))
+        assertEquals(42, l3.value)
+        assertEquals(metaContainerOf("foo" to 88), l3.metas)
+    }
+
+    @Test
+    fun withMeta() {
+        val l = 42.asPrimitive()
+        assertEquals(42, l.value)
+        assertEquals(emptyMetaContainer(), l.metas)
+
+        val l2 = l.withMeta("foo", 42)
+        assertEquals(42, l2.value)
+        assertEquals(metaContainerOf("foo" to 42), l2.metas)
+    }
+
+    @Test
+    fun toIonElement() {
+        val elem = 42.asPrimitive(metaContainerOf("foo" to 43)).toIonElement()
+        assertEquals(ionInt(42), elem)
+        assertEquals(metaContainerOf("foo" to 43), elem.metas)
+    }
+
+    @Test
+    fun toStringTest() {
+        assertEquals("12345", 12345.asPrimitive().toString())
+        assertEquals("12345", 12345.asPrimitive(metaContainerOf("foo" to 43)).toString())
+    }
+
+    @Test
+    fun equalsAndHashCode() {
+        val l1 = 42.asPrimitive()
+        val l2 = 42.asPrimitive(metaContainerOf("foo" to 43))
+        val l3 = 24.asPrimitive()
+
+        // metas should not effect equivalence
+        assertEquals(l1, l2)
+        assertEquals(l1.hashCode(), l2.hashCode())
+
+        assertNotEquals(l1, l3)
+        assertNotEquals(l2, l3)
+        // Note: hashCode is *likely* to be different, but it is not guaranteed, so therefore no assertion for that.
+    }
+}
+

--- a/pig-runtime/test/org/partiql/pig/runtime/SymbolPrimitiveTests.kt
+++ b/pig-runtime/test/org/partiql/pig/runtime/SymbolPrimitiveTests.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package org.partiql.pig.runtime
+
+import com.amazon.ionelement.api.emptyMetaContainer
+import com.amazon.ionelement.api.ionSymbol
+import com.amazon.ionelement.api.metaContainerOf
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SymbolPrimitiveTests {
+    @Test
+    fun copy() {
+        val s = "bat".asPrimitive(metaContainerOf("foo" to 43))
+        assertEquals("bat", s.text)
+        assertEquals(metaContainerOf("foo" to 43), s.metas)
+
+        val s2 = s.copy(text = "baz")
+        assertEquals("baz", s2.text)
+        assertEquals(metaContainerOf("foo" to 43), s2.metas)
+
+        val s3 = s.copy(metas = metaContainerOf("foo" to 88))
+        assertEquals("bat", s3.text)
+        assertEquals(metaContainerOf("foo" to 88), s3.metas)
+    }
+
+    @Test
+    fun withMeta() {
+        val s = "bat".asPrimitive()
+        assertEquals("bat", s.text)
+        assertEquals(emptyMetaContainer(), s.metas)
+
+        val s2 = s.withMeta("foo", 42)
+        assertEquals("bat", s2.text)
+        assertEquals(metaContainerOf("foo" to 42), s2.metas)
+    }
+
+    @Test
+    fun toIonElement() {
+        val elem = "bat".asPrimitive(metaContainerOf("foo" to 43)).toIonElement()
+        assertEquals(ionSymbol("bat"), elem)
+        assertEquals(metaContainerOf("foo" to 43), elem.metas)
+    }
+
+    @Test
+    fun toStringTest() {
+        assertEquals("foobar", "foobar".asPrimitive().toString())
+        assertEquals("foobar", "foobar".asPrimitive(metaContainerOf("foo" to 43)).toString())
+    }
+
+    @Test
+    fun equalsAndHashCode() {
+        val s1 = "bat".asPrimitive()
+        val s2 = "bat".asPrimitive(metaContainerOf("foo" to 43))
+        val s3 = "baz".asPrimitive()
+
+        // metas should not effect equivalence
+        assertEquals(s1, s2)
+        assertEquals(s1.hashCode(), s2.hashCode())
+
+        assertNotEquals(s1, s3)
+        assertNotEquals(s2, s3)
+        // Note: hashCode is *likely* to be different, but it is not guaranteed, so therefore no assertion for that.
+    }
+}


### PR DESCRIPTION
While working on https://github.com/partiql/partiql-lang-kotlin/pull/261 I found that it would be very nice to have a `copy` function on `SymbolPrimitive` and `LongPrimitive`.  The primary purpose of this PR is to add those functions.  However, I also noticed that these classes lacked tests and `kdoc` so I also added some.  I also moved each class into its own file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
