### PR TITLE
Version bump in preparation for release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ allprojects {
 
 subprojects {
     group = 'org.partiql'
-    version = '0.2.1-SNAPSHOT'
+    version = '0.3.0'
 }
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 


### PR DESCRIPTION
Since there are breaking changes, bump to `v0.3.0` instead of `v0.2.1` as originally planned.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
