### PR TITLE
Fix builder importing

### DIFF
--- a/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
@@ -16,8 +16,11 @@ class ToyLang private constructor() {
     // Builder
     /////////////////////////////////////////////////////////////////////////////
     companion object {
+        @JvmStatic
+        fun BUILDER() : Builder = ToyLangBuilder
+    
         fun <T: ToyLangNode> build(block: Builder.() -> T) =
-            Builder.block()
+            ToyLangBuilder.block()
     
         fun transform(element: AnyElement): ToyLangNode =
             transform(element.asSexp())
@@ -26,7 +29,7 @@ class ToyLang private constructor() {
             Transformer().transform(element)
     }
     
-    object Builder {
+    interface Builder {
         // Variants for Sum: Expr 
         /**
          * Creates an instance of [ToyLang.Expr.Lit].
@@ -34,10 +37,7 @@ class ToyLang private constructor() {
         fun lit(
             value: com.amazon.ionelement.api.IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Lit =
-            ToyLang.Expr.Lit(
-                value = value.asAnyElement(),
-                metas = metas)
+        ): ToyLang.Expr.Lit
         
         
         /**
@@ -46,10 +46,7 @@ class ToyLang private constructor() {
         fun variable(
             name: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Variable =
-            ToyLang.Expr.Variable(
-                name = name.asPrimitive(),
-                metas = metas)
+        ): ToyLang.Expr.Variable
         
         /**
          * Creates an instance of [ToyLang.Expr.Variable].
@@ -61,10 +58,7 @@ class ToyLang private constructor() {
         fun variable_(
             name: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Variable =
-            ToyLang.Expr.Variable(
-                name = name,
-                metas = metas)
+        ): ToyLang.Expr.Variable
         
         
         /**
@@ -73,10 +67,7 @@ class ToyLang private constructor() {
         fun not(
             expr: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Not =
-            ToyLang.Expr.Not(
-                expr = expr,
-                metas = metas)
+        ): ToyLang.Expr.Not
         
         
         /**
@@ -85,10 +76,7 @@ class ToyLang private constructor() {
         fun plus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Plus =
-            ToyLang.Expr.Plus(
-                operands = operands,
-                metas = metas)
+        ): ToyLang.Expr.Plus
         
         /**
          * Creates an instance of [ToyLang.Expr.Plus].
@@ -98,10 +86,7 @@ class ToyLang private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Plus =
-            ToyLang.Expr.Plus(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): ToyLang.Expr.Plus
         
         
         /**
@@ -110,10 +95,7 @@ class ToyLang private constructor() {
         fun minus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Minus =
-            ToyLang.Expr.Minus(
-                operands = operands,
-                metas = metas)
+        ): ToyLang.Expr.Minus
         
         /**
          * Creates an instance of [ToyLang.Expr.Minus].
@@ -123,10 +105,7 @@ class ToyLang private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Minus =
-            ToyLang.Expr.Minus(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): ToyLang.Expr.Minus
         
         
         /**
@@ -135,10 +114,7 @@ class ToyLang private constructor() {
         fun times(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Times =
-            ToyLang.Expr.Times(
-                operands = operands,
-                metas = metas)
+        ): ToyLang.Expr.Times
         
         /**
          * Creates an instance of [ToyLang.Expr.Times].
@@ -148,10 +124,7 @@ class ToyLang private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Times =
-            ToyLang.Expr.Times(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): ToyLang.Expr.Times
         
         
         /**
@@ -160,10 +133,7 @@ class ToyLang private constructor() {
         fun divide(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Divide =
-            ToyLang.Expr.Divide(
-                operands = operands,
-                metas = metas)
+        ): ToyLang.Expr.Divide
         
         /**
          * Creates an instance of [ToyLang.Expr.Divide].
@@ -173,10 +143,7 @@ class ToyLang private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Divide =
-            ToyLang.Expr.Divide(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): ToyLang.Expr.Divide
         
         
         /**
@@ -185,10 +152,7 @@ class ToyLang private constructor() {
         fun modulo(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Modulo =
-            ToyLang.Expr.Modulo(
-                operands = operands,
-                metas = metas)
+        ): ToyLang.Expr.Modulo
         
         /**
          * Creates an instance of [ToyLang.Expr.Modulo].
@@ -198,10 +162,7 @@ class ToyLang private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Modulo =
-            ToyLang.Expr.Modulo(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): ToyLang.Expr.Modulo
         
         
         /**
@@ -211,11 +172,7 @@ class ToyLang private constructor() {
             name: String,
             argument: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Call =
-            ToyLang.Expr.Call(
-                name = name.asPrimitive(),
-                argument = argument,
-                metas = metas)
+        ): ToyLang.Expr.Call
         
         /**
          * Creates an instance of [ToyLang.Expr.Call].
@@ -228,11 +185,7 @@ class ToyLang private constructor() {
             name: org.partiql.pig.runtime.SymbolPrimitive,
             argument: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Call =
-            ToyLang.Expr.Call(
-                name = name,
-                argument = argument,
-                metas = metas)
+        ): ToyLang.Expr.Call
         
         
         /**
@@ -243,12 +196,7 @@ class ToyLang private constructor() {
             value: Expr,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Let =
-            ToyLang.Expr.Let(
-                name = name.asPrimitive(),
-                value = value,
-                body = body,
-                metas = metas)
+        ): ToyLang.Expr.Let
         
         /**
          * Creates an instance of [ToyLang.Expr.Let].
@@ -262,12 +210,7 @@ class ToyLang private constructor() {
             value: Expr,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Let =
-            ToyLang.Expr.Let(
-                name = name,
-                value = value,
-                body = body,
-                metas = metas)
+        ): ToyLang.Expr.Let
         
         
         /**
@@ -277,11 +220,7 @@ class ToyLang private constructor() {
             varName: String,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Function =
-            ToyLang.Expr.Function(
-                varName = varName.asPrimitive(),
-                body = body,
-                metas = metas)
+        ): ToyLang.Expr.Function
         
         /**
          * Creates an instance of [ToyLang.Expr.Function].
@@ -294,6 +233,201 @@ class ToyLang private constructor() {
             varName: org.partiql.pig.runtime.SymbolPrimitive,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
+        ): ToyLang.Expr.Function
+    }
+    
+    private object ToyLangBuilder : Builder {
+        // Variants for Sum: Expr 
+        override fun lit(
+            value: com.amazon.ionelement.api.IonElement,
+            metas: MetaContainer
+        ): ToyLang.Expr.Lit =
+            ToyLang.Expr.Lit(
+                value = value.asAnyElement(),
+                metas = metas)
+        
+        
+        override fun variable(
+            name: String,
+            metas: MetaContainer
+        ): ToyLang.Expr.Variable =
+            ToyLang.Expr.Variable(
+                name = name.asPrimitive(),
+                metas = metas)
+        
+        override fun variable_(
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer
+        ): ToyLang.Expr.Variable =
+            ToyLang.Expr.Variable(
+                name = name,
+                metas = metas)
+        
+        
+        override fun not(
+            expr: Expr,
+            metas: MetaContainer
+        ): ToyLang.Expr.Not =
+            ToyLang.Expr.Not(
+                expr = expr,
+                metas = metas)
+        
+        
+        override fun plus(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): ToyLang.Expr.Plus =
+            ToyLang.Expr.Plus(
+                operands = operands,
+                metas = metas)
+        
+        override fun plus(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): ToyLang.Expr.Plus =
+            ToyLang.Expr.Plus(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun minus(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): ToyLang.Expr.Minus =
+            ToyLang.Expr.Minus(
+                operands = operands,
+                metas = metas)
+        
+        override fun minus(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): ToyLang.Expr.Minus =
+            ToyLang.Expr.Minus(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun times(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): ToyLang.Expr.Times =
+            ToyLang.Expr.Times(
+                operands = operands,
+                metas = metas)
+        
+        override fun times(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): ToyLang.Expr.Times =
+            ToyLang.Expr.Times(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun divide(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): ToyLang.Expr.Divide =
+            ToyLang.Expr.Divide(
+                operands = operands,
+                metas = metas)
+        
+        override fun divide(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): ToyLang.Expr.Divide =
+            ToyLang.Expr.Divide(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun modulo(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): ToyLang.Expr.Modulo =
+            ToyLang.Expr.Modulo(
+                operands = operands,
+                metas = metas)
+        
+        override fun modulo(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): ToyLang.Expr.Modulo =
+            ToyLang.Expr.Modulo(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun call(
+            name: String,
+            argument: Expr,
+            metas: MetaContainer
+        ): ToyLang.Expr.Call =
+            ToyLang.Expr.Call(
+                name = name.asPrimitive(),
+                argument = argument,
+                metas = metas)
+        
+        override fun call_(
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            argument: Expr,
+            metas: MetaContainer
+        ): ToyLang.Expr.Call =
+            ToyLang.Expr.Call(
+                name = name,
+                argument = argument,
+                metas = metas)
+        
+        
+        override fun let(
+            name: String,
+            value: Expr,
+            body: Expr,
+            metas: MetaContainer
+        ): ToyLang.Expr.Let =
+            ToyLang.Expr.Let(
+                name = name.asPrimitive(),
+                value = value,
+                body = body,
+                metas = metas)
+        
+        override fun let_(
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            value: Expr,
+            body: Expr,
+            metas: MetaContainer
+        ): ToyLang.Expr.Let =
+            ToyLang.Expr.Let(
+                name = name,
+                value = value,
+                body = body,
+                metas = metas)
+        
+        
+        override fun function(
+            varName: String,
+            body: Expr,
+            metas: MetaContainer
+        ): ToyLang.Expr.Function =
+            ToyLang.Expr.Function(
+                varName = varName.asPrimitive(),
+                body = body,
+                metas = metas)
+        
+        override fun function_(
+            varName: org.partiql.pig.runtime.SymbolPrimitive,
+            body: Expr,
+            metas: MetaContainer
         ): ToyLang.Expr.Function =
             ToyLang.Expr.Function(
                 varName = varName,
@@ -1335,8 +1469,11 @@ class ToyLangNameless private constructor() {
     // Builder
     /////////////////////////////////////////////////////////////////////////////
     companion object {
+        @JvmStatic
+        fun BUILDER() : Builder = ToyLangNamelessBuilder
+    
         fun <T: ToyLangNamelessNode> build(block: Builder.() -> T) =
-            Builder.block()
+            ToyLangNamelessBuilder.block()
     
         fun transform(element: AnyElement): ToyLangNamelessNode =
             transform(element.asSexp())
@@ -1345,7 +1482,7 @@ class ToyLangNameless private constructor() {
             Transformer().transform(element)
     }
     
-    object Builder {
+    interface Builder {
         // Variants for Sum: Expr 
         /**
          * Creates an instance of [ToyLangNameless.Expr.Lit].
@@ -1353,10 +1490,7 @@ class ToyLangNameless private constructor() {
         fun lit(
             value: com.amazon.ionelement.api.IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Lit =
-            ToyLangNameless.Expr.Lit(
-                value = value.asAnyElement(),
-                metas = metas)
+        ): ToyLangNameless.Expr.Lit
         
         
         /**
@@ -1365,10 +1499,7 @@ class ToyLangNameless private constructor() {
         fun not(
             expr: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Not =
-            ToyLangNameless.Expr.Not(
-                expr = expr,
-                metas = metas)
+        ): ToyLangNameless.Expr.Not
         
         
         /**
@@ -1377,10 +1508,7 @@ class ToyLangNameless private constructor() {
         fun plus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Plus =
-            ToyLangNameless.Expr.Plus(
-                operands = operands,
-                metas = metas)
+        ): ToyLangNameless.Expr.Plus
         
         /**
          * Creates an instance of [ToyLangNameless.Expr.Plus].
@@ -1390,10 +1518,7 @@ class ToyLangNameless private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Plus =
-            ToyLangNameless.Expr.Plus(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): ToyLangNameless.Expr.Plus
         
         
         /**
@@ -1402,10 +1527,7 @@ class ToyLangNameless private constructor() {
         fun minus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Minus =
-            ToyLangNameless.Expr.Minus(
-                operands = operands,
-                metas = metas)
+        ): ToyLangNameless.Expr.Minus
         
         /**
          * Creates an instance of [ToyLangNameless.Expr.Minus].
@@ -1415,10 +1537,7 @@ class ToyLangNameless private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Minus =
-            ToyLangNameless.Expr.Minus(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): ToyLangNameless.Expr.Minus
         
         
         /**
@@ -1427,10 +1546,7 @@ class ToyLangNameless private constructor() {
         fun times(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Times =
-            ToyLangNameless.Expr.Times(
-                operands = operands,
-                metas = metas)
+        ): ToyLangNameless.Expr.Times
         
         /**
          * Creates an instance of [ToyLangNameless.Expr.Times].
@@ -1440,10 +1556,7 @@ class ToyLangNameless private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Times =
-            ToyLangNameless.Expr.Times(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): ToyLangNameless.Expr.Times
         
         
         /**
@@ -1452,10 +1565,7 @@ class ToyLangNameless private constructor() {
         fun divide(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Divide =
-            ToyLangNameless.Expr.Divide(
-                operands = operands,
-                metas = metas)
+        ): ToyLangNameless.Expr.Divide
         
         /**
          * Creates an instance of [ToyLangNameless.Expr.Divide].
@@ -1465,10 +1575,7 @@ class ToyLangNameless private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Divide =
-            ToyLangNameless.Expr.Divide(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): ToyLangNameless.Expr.Divide
         
         
         /**
@@ -1477,10 +1584,7 @@ class ToyLangNameless private constructor() {
         fun modulo(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Modulo =
-            ToyLangNameless.Expr.Modulo(
-                operands = operands,
-                metas = metas)
+        ): ToyLangNameless.Expr.Modulo
         
         /**
          * Creates an instance of [ToyLangNameless.Expr.Modulo].
@@ -1490,10 +1594,7 @@ class ToyLangNameless private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Modulo =
-            ToyLangNameless.Expr.Modulo(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): ToyLangNameless.Expr.Modulo
         
         
         /**
@@ -1503,11 +1604,7 @@ class ToyLangNameless private constructor() {
             name: String,
             argument: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Call =
-            ToyLangNameless.Expr.Call(
-                name = name.asPrimitive(),
-                argument = argument,
-                metas = metas)
+        ): ToyLangNameless.Expr.Call
         
         /**
          * Creates an instance of [ToyLangNameless.Expr.Call].
@@ -1520,11 +1617,7 @@ class ToyLangNameless private constructor() {
             name: org.partiql.pig.runtime.SymbolPrimitive,
             argument: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Call =
-            ToyLangNameless.Expr.Call(
-                name = name,
-                argument = argument,
-                metas = metas)
+        ): ToyLangNameless.Expr.Call
         
         
         /**
@@ -1534,11 +1627,7 @@ class ToyLangNameless private constructor() {
             varName: String,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Function =
-            ToyLangNameless.Expr.Function(
-                varName = varName.asPrimitive(),
-                body = body,
-                metas = metas)
+        ): ToyLangNameless.Expr.Function
         
         /**
          * Creates an instance of [ToyLangNameless.Expr.Function].
@@ -1551,11 +1640,7 @@ class ToyLangNameless private constructor() {
             varName: org.partiql.pig.runtime.SymbolPrimitive,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Function =
-            ToyLangNameless.Expr.Function(
-                varName = varName,
-                body = body,
-                metas = metas)
+        ): ToyLangNameless.Expr.Function
         
         
         /**
@@ -1564,10 +1649,7 @@ class ToyLangNameless private constructor() {
         fun variable(
             index: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Variable =
-            ToyLangNameless.Expr.Variable(
-                index = index.asPrimitive(),
-                metas = metas)
+        ): ToyLangNameless.Expr.Variable
         
         /**
          * Creates an instance of [ToyLangNameless.Expr.Variable].
@@ -1579,10 +1661,7 @@ class ToyLangNameless private constructor() {
         fun variable_(
             index: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Variable =
-            ToyLangNameless.Expr.Variable(
-                index = index,
-                metas = metas)
+        ): ToyLangNameless.Expr.Variable
         
         
         /**
@@ -1593,12 +1672,7 @@ class ToyLangNameless private constructor() {
             value: Expr,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangNameless.Expr.Let =
-            ToyLangNameless.Expr.Let(
-                index = index.asPrimitive(),
-                value = value,
-                body = body,
-                metas = metas)
+        ): ToyLangNameless.Expr.Let
         
         /**
          * Creates an instance of [ToyLangNameless.Expr.Let].
@@ -1612,6 +1686,200 @@ class ToyLangNameless private constructor() {
             value: Expr,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
+        ): ToyLangNameless.Expr.Let
+    }
+    
+    private object ToyLangNamelessBuilder : Builder {
+        // Variants for Sum: Expr 
+        override fun lit(
+            value: com.amazon.ionelement.api.IonElement,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Lit =
+            ToyLangNameless.Expr.Lit(
+                value = value.asAnyElement(),
+                metas = metas)
+        
+        
+        override fun not(
+            expr: Expr,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Not =
+            ToyLangNameless.Expr.Not(
+                expr = expr,
+                metas = metas)
+        
+        
+        override fun plus(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Plus =
+            ToyLangNameless.Expr.Plus(
+                operands = operands,
+                metas = metas)
+        
+        override fun plus(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Plus =
+            ToyLangNameless.Expr.Plus(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun minus(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Minus =
+            ToyLangNameless.Expr.Minus(
+                operands = operands,
+                metas = metas)
+        
+        override fun minus(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Minus =
+            ToyLangNameless.Expr.Minus(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun times(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Times =
+            ToyLangNameless.Expr.Times(
+                operands = operands,
+                metas = metas)
+        
+        override fun times(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Times =
+            ToyLangNameless.Expr.Times(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun divide(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Divide =
+            ToyLangNameless.Expr.Divide(
+                operands = operands,
+                metas = metas)
+        
+        override fun divide(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Divide =
+            ToyLangNameless.Expr.Divide(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun modulo(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Modulo =
+            ToyLangNameless.Expr.Modulo(
+                operands = operands,
+                metas = metas)
+        
+        override fun modulo(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Modulo =
+            ToyLangNameless.Expr.Modulo(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun call(
+            name: String,
+            argument: Expr,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Call =
+            ToyLangNameless.Expr.Call(
+                name = name.asPrimitive(),
+                argument = argument,
+                metas = metas)
+        
+        override fun call_(
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            argument: Expr,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Call =
+            ToyLangNameless.Expr.Call(
+                name = name,
+                argument = argument,
+                metas = metas)
+        
+        
+        override fun function(
+            varName: String,
+            body: Expr,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Function =
+            ToyLangNameless.Expr.Function(
+                varName = varName.asPrimitive(),
+                body = body,
+                metas = metas)
+        
+        override fun function_(
+            varName: org.partiql.pig.runtime.SymbolPrimitive,
+            body: Expr,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Function =
+            ToyLangNameless.Expr.Function(
+                varName = varName,
+                body = body,
+                metas = metas)
+        
+        
+        override fun variable(
+            index: Long,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Variable =
+            ToyLangNameless.Expr.Variable(
+                index = index.asPrimitive(),
+                metas = metas)
+        
+        override fun variable_(
+            index: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Variable =
+            ToyLangNameless.Expr.Variable(
+                index = index,
+                metas = metas)
+        
+        
+        override fun let(
+            index: Long,
+            value: Expr,
+            body: Expr,
+            metas: MetaContainer
+        ): ToyLangNameless.Expr.Let =
+            ToyLangNameless.Expr.Let(
+                index = index.asPrimitive(),
+                value = value,
+                body = body,
+                metas = metas)
+        
+        override fun let_(
+            index: org.partiql.pig.runtime.LongPrimitive,
+            value: Expr,
+            body: Expr,
+            metas: MetaContainer
         ): ToyLangNameless.Expr.Let =
             ToyLangNameless.Expr.Let(
                 index = index,
@@ -2654,8 +2922,11 @@ class TestDomain private constructor() {
     // Builder
     /////////////////////////////////////////////////////////////////////////////
     companion object {
+        @JvmStatic
+        fun BUILDER() : Builder = TestDomainBuilder
+    
         fun <T: TestDomainNode> build(block: Builder.() -> T) =
-            Builder.block()
+            TestDomainBuilder.block()
     
         fun transform(element: AnyElement): TestDomainNode =
             transform(element.asSexp())
@@ -2664,7 +2935,7 @@ class TestDomain private constructor() {
             Transformer().transform(element)
     }
     
-    object Builder {
+    interface Builder {
                 // Tuples
         /**
          * Creates an instance of [TestDomain.IntPair].
@@ -2673,11 +2944,7 @@ class TestDomain private constructor() {
             first: Long,
             second: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntPair =
-            TestDomain.IntPair(
-                first = first.asPrimitive(),
-                second = second.asPrimitive(),
-                metas = metas)
+        ): TestDomain.IntPair
         
         /**
          * Creates an instance of [TestDomain.IntPair].
@@ -2690,11 +2957,7 @@ class TestDomain private constructor() {
             first: org.partiql.pig.runtime.LongPrimitive,
             second: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntPair =
-            TestDomain.IntPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.IntPair
         
         
         /**
@@ -2704,11 +2967,7 @@ class TestDomain private constructor() {
             first: String,
             second: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolPair =
-            TestDomain.SymbolPair(
-                first = first.asPrimitive(),
-                second = second.asPrimitive(),
-                metas = metas)
+        ): TestDomain.SymbolPair
         
         /**
          * Creates an instance of [TestDomain.SymbolPair].
@@ -2721,11 +2980,7 @@ class TestDomain private constructor() {
             first: org.partiql.pig.runtime.SymbolPrimitive,
             second: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolPair =
-            TestDomain.SymbolPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.SymbolPair
         
         
         /**
@@ -2735,11 +2990,7 @@ class TestDomain private constructor() {
             first: com.amazon.ionelement.api.IonElement,
             second: com.amazon.ionelement.api.IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IonPair =
-            TestDomain.IonPair(
-                first = first.asAnyElement(),
-                second = second.asAnyElement(),
-                metas = metas)
+        ): TestDomain.IonPair
         
         
         /**
@@ -2749,11 +3000,7 @@ class TestDomain private constructor() {
             first: Long,
             second: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntSymbolPair =
-            TestDomain.IntSymbolPair(
-                first = first.asPrimitive(),
-                second = second.asPrimitive(),
-                metas = metas)
+        ): TestDomain.IntSymbolPair
         
         /**
          * Creates an instance of [TestDomain.IntSymbolPair].
@@ -2766,11 +3013,7 @@ class TestDomain private constructor() {
             first: org.partiql.pig.runtime.LongPrimitive,
             second: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntSymbolPair =
-            TestDomain.IntSymbolPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.IntSymbolPair
         
         
         /**
@@ -2780,11 +3023,7 @@ class TestDomain private constructor() {
             first: String,
             second: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolIntPair =
-            TestDomain.SymbolIntPair(
-                first = first.asPrimitive(),
-                second = second.asPrimitive(),
-                metas = metas)
+        ): TestDomain.SymbolIntPair
         
         /**
          * Creates an instance of [TestDomain.SymbolIntPair].
@@ -2797,11 +3036,7 @@ class TestDomain private constructor() {
             first: org.partiql.pig.runtime.SymbolPrimitive,
             second: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolIntPair =
-            TestDomain.SymbolIntPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.SymbolIntPair
         
         
         /**
@@ -2811,11 +3046,7 @@ class TestDomain private constructor() {
             first: com.amazon.ionelement.api.IonElement,
             second: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IonIntPair =
-            TestDomain.IonIntPair(
-                first = first.asAnyElement(),
-                second = second.asPrimitive(),
-                metas = metas)
+        ): TestDomain.IonIntPair
         
         /**
          * Creates an instance of [TestDomain.IonIntPair].
@@ -2828,11 +3059,7 @@ class TestDomain private constructor() {
             first: com.amazon.ionelement.api.IonElement,
             second: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IonIntPair =
-            TestDomain.IonIntPair(
-                first = first.asAnyElement(),
-                second = second,
-                metas = metas)
+        ): TestDomain.IonIntPair
         
         
         /**
@@ -2842,11 +3069,7 @@ class TestDomain private constructor() {
             first: com.amazon.ionelement.api.IonElement,
             second: com.amazon.ionelement.api.IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IonSymbolPair =
-            TestDomain.IonSymbolPair(
-                first = first.asAnyElement(),
-                second = second.asAnyElement(),
-                metas = metas)
+        ): TestDomain.IonSymbolPair
         
         
         /**
@@ -2856,11 +3079,7 @@ class TestDomain private constructor() {
             first: IntPair,
             second: IntPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntPairPair =
-            TestDomain.IntPairPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.IntPairPair
         
         
         /**
@@ -2870,11 +3089,7 @@ class TestDomain private constructor() {
             first: SymbolPair,
             second: SymbolPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolPairPair =
-            TestDomain.SymbolPairPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.SymbolPairPair
         
         
         /**
@@ -2884,11 +3099,7 @@ class TestDomain private constructor() {
             first: IonPair,
             second: IonPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IonPairPair =
-            TestDomain.IonPairPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.IonPairPair
         
         
         /**
@@ -2898,11 +3109,7 @@ class TestDomain private constructor() {
             first: Long,
             second: RecursivePair? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.RecursivePair =
-            TestDomain.RecursivePair(
-                first = first.asPrimitive(),
-                second = second,
-                metas = metas)
+        ): TestDomain.RecursivePair
         
         /**
          * Creates an instance of [TestDomain.RecursivePair].
@@ -2915,11 +3122,7 @@ class TestDomain private constructor() {
             first: org.partiql.pig.runtime.LongPrimitive,
             second: RecursivePair? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.RecursivePair =
-            TestDomain.RecursivePair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.RecursivePair
         
         
         /**
@@ -2929,11 +3132,7 @@ class TestDomain private constructor() {
             first: Answer,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.AnswerPair =
-            TestDomain.AnswerPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.AnswerPair
         
         
         /**
@@ -2943,11 +3142,7 @@ class TestDomain private constructor() {
             first: Answer,
             second: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.AnswerIntPair =
-            TestDomain.AnswerIntPair(
-                first = first,
-                second = second.asPrimitive(),
-                metas = metas)
+        ): TestDomain.AnswerIntPair
         
         /**
          * Creates an instance of [TestDomain.AnswerIntPair].
@@ -2960,11 +3155,7 @@ class TestDomain private constructor() {
             first: Answer,
             second: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.AnswerIntPair =
-            TestDomain.AnswerIntPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.AnswerIntPair
         
         
         /**
@@ -2974,11 +3165,7 @@ class TestDomain private constructor() {
             first: Long,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntAnswerPair =
-            TestDomain.IntAnswerPair(
-                first = first.asPrimitive(),
-                second = second,
-                metas = metas)
+        ): TestDomain.IntAnswerPair
         
         /**
          * Creates an instance of [TestDomain.IntAnswerPair].
@@ -2991,11 +3178,7 @@ class TestDomain private constructor() {
             first: org.partiql.pig.runtime.LongPrimitive,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntAnswerPair =
-            TestDomain.IntAnswerPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.IntAnswerPair
         
         
         /**
@@ -3005,11 +3188,7 @@ class TestDomain private constructor() {
             first: String,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolAnswerPair =
-            TestDomain.SymbolAnswerPair(
-                first = first.asPrimitive(),
-                second = second,
-                metas = metas)
+        ): TestDomain.SymbolAnswerPair
         
         /**
          * Creates an instance of [TestDomain.SymbolAnswerPair].
@@ -3022,11 +3201,7 @@ class TestDomain private constructor() {
             first: org.partiql.pig.runtime.SymbolPrimitive,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolAnswerPair =
-            TestDomain.SymbolAnswerPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.SymbolAnswerPair
         
         
         /**
@@ -3036,11 +3211,7 @@ class TestDomain private constructor() {
             first: Answer,
             second: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.AnswerSymbolPair =
-            TestDomain.AnswerSymbolPair(
-                first = first,
-                second = second.asPrimitive(),
-                metas = metas)
+        ): TestDomain.AnswerSymbolPair
         
         /**
          * Creates an instance of [TestDomain.AnswerSymbolPair].
@@ -3053,11 +3224,7 @@ class TestDomain private constructor() {
             first: Answer,
             second: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.AnswerSymbolPair =
-            TestDomain.AnswerSymbolPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.AnswerSymbolPair
         
         
         /**
@@ -3066,10 +3233,7 @@ class TestDomain private constructor() {
         fun variadicMin0(
             ints: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin0 =
-            TestDomain.VariadicMin0(
-                ints = ints.map { it.asPrimitive() },
-                metas = metas)
+        ): TestDomain.VariadicMin0
         
         /**
          * Creates an instance of [TestDomain.VariadicMin0].
@@ -3081,10 +3245,7 @@ class TestDomain private constructor() {
         fun variadicMin0_(
             ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin0 =
-            TestDomain.VariadicMin0(
-                ints = ints,
-                metas = metas)
+        ): TestDomain.VariadicMin0
         
         /**
          * Creates an instance of [TestDomain.VariadicMin0].
@@ -3092,10 +3253,7 @@ class TestDomain private constructor() {
         fun variadicMin0(
             vararg ints: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin0 =
-            TestDomain.VariadicMin0(
-                ints = ints.map { it.asPrimitive() },
-                metas = metas)
+        ): TestDomain.VariadicMin0
         
         /**
          * Creates an instance of [TestDomain.VariadicMin0].
@@ -3107,10 +3265,7 @@ class TestDomain private constructor() {
         fun variadicMin0_(
             vararg ints: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin0 =
-            TestDomain.VariadicMin0(
-                ints = ints.toList(),
-                metas = metas)
+        ): TestDomain.VariadicMin0
         
         
         /**
@@ -3119,10 +3274,7 @@ class TestDomain private constructor() {
         fun variadicMin1(
             ints: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin1 =
-            TestDomain.VariadicMin1(
-                ints = ints.map { it.asPrimitive() },
-                metas = metas)
+        ): TestDomain.VariadicMin1
         
         /**
          * Creates an instance of [TestDomain.VariadicMin1].
@@ -3134,10 +3286,7 @@ class TestDomain private constructor() {
         fun variadicMin1_(
             ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin1 =
-            TestDomain.VariadicMin1(
-                ints = ints,
-                metas = metas)
+        ): TestDomain.VariadicMin1
         
         /**
          * Creates an instance of [TestDomain.VariadicMin1].
@@ -3146,10 +3295,7 @@ class TestDomain private constructor() {
             ints0: Long,
             vararg ints: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin1 =
-            TestDomain.VariadicMin1(
-                ints = listOfPrimitives(ints0) + ints.map { it.asPrimitive() },
-                metas = metas)
+        ): TestDomain.VariadicMin1
         
         /**
          * Creates an instance of [TestDomain.VariadicMin1].
@@ -3162,10 +3308,7 @@ class TestDomain private constructor() {
             ints0: org.partiql.pig.runtime.LongPrimitive,
             vararg ints: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin1 =
-            TestDomain.VariadicMin1(
-                ints = listOfPrimitives(ints0) + ints.toList(),
-                metas = metas)
+        ): TestDomain.VariadicMin1
         
         
         /**
@@ -3175,11 +3318,7 @@ class TestDomain private constructor() {
             name: String,
             ints: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.ElementVariadic =
-            TestDomain.ElementVariadic(
-                name = name.asPrimitive(),
-                ints = ints.map { it.asPrimitive() },
-                metas = metas)
+        ): TestDomain.ElementVariadic
         
         /**
          * Creates an instance of [TestDomain.ElementVariadic].
@@ -3192,11 +3331,7 @@ class TestDomain private constructor() {
             name: org.partiql.pig.runtime.SymbolPrimitive,
             ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.ElementVariadic =
-            TestDomain.ElementVariadic(
-                name = name,
-                ints = ints,
-                metas = metas)
+        ): TestDomain.ElementVariadic
         
         /**
          * Creates an instance of [TestDomain.ElementVariadic].
@@ -3205,11 +3340,7 @@ class TestDomain private constructor() {
             name: String,
             vararg ints: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.ElementVariadic =
-            TestDomain.ElementVariadic(
-                name = name.asPrimitive(),
-                ints = ints.map { it.asPrimitive() },
-                metas = metas)
+        ): TestDomain.ElementVariadic
         
         /**
          * Creates an instance of [TestDomain.ElementVariadic].
@@ -3222,11 +3353,7 @@ class TestDomain private constructor() {
             name: org.partiql.pig.runtime.SymbolPrimitive,
             vararg ints: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.ElementVariadic =
-            TestDomain.ElementVariadic(
-                name = name,
-                ints = ints.toList(),
-                metas = metas)
+        ): TestDomain.ElementVariadic
         
         
         /**
@@ -3235,10 +3362,7 @@ class TestDomain private constructor() {
         fun optional1(
             value: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Optional1 =
-            TestDomain.Optional1(
-                value = value?.asPrimitive(),
-                metas = metas)
+        ): TestDomain.Optional1
         
         /**
          * Creates an instance of [TestDomain.Optional1].
@@ -3250,10 +3374,7 @@ class TestDomain private constructor() {
         fun optional1_(
             value: org.partiql.pig.runtime.LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Optional1 =
-            TestDomain.Optional1(
-                value = value,
-                metas = metas)
+        ): TestDomain.Optional1
         
         
         /**
@@ -3263,11 +3384,7 @@ class TestDomain private constructor() {
             first: Long? = null,
             second: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Optional2 =
-            TestDomain.Optional2(
-                first = first?.asPrimitive(),
-                second = second?.asPrimitive(),
-                metas = metas)
+        ): TestDomain.Optional2
         
         /**
          * Creates an instance of [TestDomain.Optional2].
@@ -3280,11 +3397,7 @@ class TestDomain private constructor() {
             first: org.partiql.pig.runtime.LongPrimitive? = null,
             second: org.partiql.pig.runtime.LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Optional2 =
-            TestDomain.Optional2(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.Optional2
         
         
         /**
@@ -3295,12 +3408,7 @@ class TestDomain private constructor() {
             anotherField: String,
             optionalField: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.DomainLevelRecord =
-            TestDomain.DomainLevelRecord(
-                someField = someField.asPrimitive(),
-                anotherField = anotherField.asPrimitive(),
-                optionalField = optionalField?.asPrimitive(),
-                metas = metas)
+        ): TestDomain.DomainLevelRecord
         
         /**
          * Creates an instance of [TestDomain.DomainLevelRecord].
@@ -3314,12 +3422,7 @@ class TestDomain private constructor() {
             anotherField: org.partiql.pig.runtime.SymbolPrimitive,
             optionalField: org.partiql.pig.runtime.LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.DomainLevelRecord =
-            TestDomain.DomainLevelRecord(
-                someField = someField,
-                anotherField = anotherField,
-                optionalField = optionalField,
-                metas = metas)
+        ): TestDomain.DomainLevelRecord
         
         
         /**
@@ -3329,11 +3432,7 @@ class TestDomain private constructor() {
             value: Long,
             dlr: DomainLevelRecord,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.ProductWithRecord =
-            TestDomain.ProductWithRecord(
-                value = value.asPrimitive(),
-                dlr = dlr,
-                metas = metas)
+        ): TestDomain.ProductWithRecord
         
         /**
          * Creates an instance of [TestDomain.ProductWithRecord].
@@ -3346,11 +3445,7 @@ class TestDomain private constructor() {
             value: org.partiql.pig.runtime.LongPrimitive,
             dlr: DomainLevelRecord,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.ProductWithRecord =
-            TestDomain.ProductWithRecord(
-                value = value,
-                dlr = dlr,
-                metas = metas)
+        ): TestDomain.ProductWithRecord
         
         
         /**
@@ -3361,12 +3456,7 @@ class TestDomain private constructor() {
             b: TestSum,
             c: TestSum,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSumTriplet =
-            TestDomain.TestSumTriplet(
-                a = a,
-                b = b,
-                c = c,
-                metas = metas)
+        ): TestDomain.TestSumTriplet
         
         
         /**
@@ -3376,11 +3466,7 @@ class TestDomain private constructor() {
             first: Entity,
             second: Entity,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.EntityPair =
-            TestDomain.EntityPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): TestDomain.EntityPair
         
         
         // Variants for Sum: Answer 
@@ -3389,9 +3475,7 @@ class TestDomain private constructor() {
          */
         fun no(
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Answer.No =
-            TestDomain.Answer.No(
-                metas = metas)
+        ): TestDomain.Answer.No
         
         
         /**
@@ -3399,9 +3483,7 @@ class TestDomain private constructor() {
          */
         fun yes(
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Answer.Yes =
-            TestDomain.Answer.Yes(
-                metas = metas)
+        ): TestDomain.Answer.Yes
         
         
         // Variants for Sum: SumWithRecord 
@@ -3412,11 +3494,7 @@ class TestDomain private constructor() {
             value: Long,
             dlr: DomainLevelRecord,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SumWithRecord.VariantWithRecord =
-            TestDomain.SumWithRecord.VariantWithRecord(
-                value = value.asPrimitive(),
-                dlr = dlr,
-                metas = metas)
+        ): TestDomain.SumWithRecord.VariantWithRecord
         
         /**
          * Creates an instance of [TestDomain.SumWithRecord.VariantWithRecord].
@@ -3429,11 +3507,7 @@ class TestDomain private constructor() {
             value: org.partiql.pig.runtime.LongPrimitive,
             dlr: DomainLevelRecord,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SumWithRecord.VariantWithRecord =
-            TestDomain.SumWithRecord.VariantWithRecord(
-                value = value,
-                dlr = dlr,
-                metas = metas)
+        ): TestDomain.SumWithRecord.VariantWithRecord
         
         
         // Variants for Sum: TestSum 
@@ -3443,10 +3517,7 @@ class TestDomain private constructor() {
         fun one(
             a: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSum.One =
-            TestDomain.TestSum.One(
-                a = a.asPrimitive(),
-                metas = metas)
+        ): TestDomain.TestSum.One
         
         /**
          * Creates an instance of [TestDomain.TestSum.One].
@@ -3458,10 +3529,7 @@ class TestDomain private constructor() {
         fun one_(
             a: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSum.One =
-            TestDomain.TestSum.One(
-                a = a,
-                metas = metas)
+        ): TestDomain.TestSum.One
         
         
         /**
@@ -3471,11 +3539,7 @@ class TestDomain private constructor() {
             a: Long,
             b: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSum.Two =
-            TestDomain.TestSum.Two(
-                a = a.asPrimitive(),
-                b = b.asPrimitive(),
-                metas = metas)
+        ): TestDomain.TestSum.Two
         
         /**
          * Creates an instance of [TestDomain.TestSum.Two].
@@ -3488,11 +3552,7 @@ class TestDomain private constructor() {
             a: org.partiql.pig.runtime.LongPrimitive,
             b: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSum.Two =
-            TestDomain.TestSum.Two(
-                a = a,
-                b = b,
-                metas = metas)
+        ): TestDomain.TestSum.Two
         
         
         /**
@@ -3503,12 +3563,7 @@ class TestDomain private constructor() {
             b: Long,
             c: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSum.Three =
-            TestDomain.TestSum.Three(
-                a = a.asPrimitive(),
-                b = b.asPrimitive(),
-                c = c.asPrimitive(),
-                metas = metas)
+        ): TestDomain.TestSum.Three
         
         /**
          * Creates an instance of [TestDomain.TestSum.Three].
@@ -3522,12 +3577,7 @@ class TestDomain private constructor() {
             b: org.partiql.pig.runtime.LongPrimitive,
             c: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSum.Three =
-            TestDomain.TestSum.Three(
-                a = a,
-                b = b,
-                c = c,
-                metas = metas)
+        ): TestDomain.TestSum.Three
         
         
         // Variants for Sum: Entity 
@@ -3536,9 +3586,7 @@ class TestDomain private constructor() {
          */
         fun slug(
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Entity.Slug =
-            TestDomain.Entity.Slug(
-                metas = metas)
+        ): TestDomain.Entity.Slug
         
         
         /**
@@ -3547,10 +3595,7 @@ class TestDomain private constructor() {
         fun android(
             id: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Entity.Android =
-            TestDomain.Entity.Android(
-                id = id.asPrimitive(),
-                metas = metas)
+        ): TestDomain.Entity.Android
         
         /**
          * Creates an instance of [TestDomain.Entity.Android].
@@ -3562,10 +3607,7 @@ class TestDomain private constructor() {
         fun android_(
             id: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Entity.Android =
-            TestDomain.Entity.Android(
-                id = id,
-                metas = metas)
+        ): TestDomain.Entity.Android
         
         
         /**
@@ -3577,13 +3619,7 @@ class TestDomain private constructor() {
             title: String? = null,
             parent: Entity? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Entity.Human =
-            TestDomain.Entity.Human(
-                firstName = firstName.asPrimitive(),
-                lastName = lastName.asPrimitive(),
-                title = title?.asPrimitive(),
-                parent = parent,
-                metas = metas)
+        ): TestDomain.Entity.Human
         
         /**
          * Creates an instance of [TestDomain.Entity.Human].
@@ -3598,6 +3634,650 @@ class TestDomain private constructor() {
             title: org.partiql.pig.runtime.SymbolPrimitive? = null,
             parent: Entity? = null,
             metas: MetaContainer = emptyMetaContainer()
+        ): TestDomain.Entity.Human
+    }
+    
+    private object TestDomainBuilder : Builder {
+                // Tuples
+        override fun intPair(
+            first: Long,
+            second: Long,
+            metas: MetaContainer
+        ): TestDomain.IntPair =
+            TestDomain.IntPair(
+                first = first.asPrimitive(),
+                second = second.asPrimitive(),
+                metas = metas)
+        
+        override fun intPair_(
+            first: org.partiql.pig.runtime.LongPrimitive,
+            second: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): TestDomain.IntPair =
+            TestDomain.IntPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun symbolPair(
+            first: String,
+            second: String,
+            metas: MetaContainer
+        ): TestDomain.SymbolPair =
+            TestDomain.SymbolPair(
+                first = first.asPrimitive(),
+                second = second.asPrimitive(),
+                metas = metas)
+        
+        override fun symbolPair_(
+            first: org.partiql.pig.runtime.SymbolPrimitive,
+            second: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer
+        ): TestDomain.SymbolPair =
+            TestDomain.SymbolPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun ionPair(
+            first: com.amazon.ionelement.api.IonElement,
+            second: com.amazon.ionelement.api.IonElement,
+            metas: MetaContainer
+        ): TestDomain.IonPair =
+            TestDomain.IonPair(
+                first = first.asAnyElement(),
+                second = second.asAnyElement(),
+                metas = metas)
+        
+        
+        override fun intSymbolPair(
+            first: Long,
+            second: String,
+            metas: MetaContainer
+        ): TestDomain.IntSymbolPair =
+            TestDomain.IntSymbolPair(
+                first = first.asPrimitive(),
+                second = second.asPrimitive(),
+                metas = metas)
+        
+        override fun intSymbolPair_(
+            first: org.partiql.pig.runtime.LongPrimitive,
+            second: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer
+        ): TestDomain.IntSymbolPair =
+            TestDomain.IntSymbolPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun symbolIntPair(
+            first: String,
+            second: Long,
+            metas: MetaContainer
+        ): TestDomain.SymbolIntPair =
+            TestDomain.SymbolIntPair(
+                first = first.asPrimitive(),
+                second = second.asPrimitive(),
+                metas = metas)
+        
+        override fun symbolIntPair_(
+            first: org.partiql.pig.runtime.SymbolPrimitive,
+            second: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): TestDomain.SymbolIntPair =
+            TestDomain.SymbolIntPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun ionIntPair(
+            first: com.amazon.ionelement.api.IonElement,
+            second: Long,
+            metas: MetaContainer
+        ): TestDomain.IonIntPair =
+            TestDomain.IonIntPair(
+                first = first.asAnyElement(),
+                second = second.asPrimitive(),
+                metas = metas)
+        
+        override fun ionIntPair_(
+            first: com.amazon.ionelement.api.IonElement,
+            second: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): TestDomain.IonIntPair =
+            TestDomain.IonIntPair(
+                first = first.asAnyElement(),
+                second = second,
+                metas = metas)
+        
+        
+        override fun ionSymbolPair(
+            first: com.amazon.ionelement.api.IonElement,
+            second: com.amazon.ionelement.api.IonElement,
+            metas: MetaContainer
+        ): TestDomain.IonSymbolPair =
+            TestDomain.IonSymbolPair(
+                first = first.asAnyElement(),
+                second = second.asAnyElement(),
+                metas = metas)
+        
+        
+        override fun intPairPair(
+            first: IntPair,
+            second: IntPair,
+            metas: MetaContainer
+        ): TestDomain.IntPairPair =
+            TestDomain.IntPairPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun symbolPairPair(
+            first: SymbolPair,
+            second: SymbolPair,
+            metas: MetaContainer
+        ): TestDomain.SymbolPairPair =
+            TestDomain.SymbolPairPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun ionPairPair(
+            first: IonPair,
+            second: IonPair,
+            metas: MetaContainer
+        ): TestDomain.IonPairPair =
+            TestDomain.IonPairPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun recursivePair(
+            first: Long,
+            second: RecursivePair?,
+            metas: MetaContainer
+        ): TestDomain.RecursivePair =
+            TestDomain.RecursivePair(
+                first = first.asPrimitive(),
+                second = second,
+                metas = metas)
+        
+        override fun recursivePair_(
+            first: org.partiql.pig.runtime.LongPrimitive,
+            second: RecursivePair?,
+            metas: MetaContainer
+        ): TestDomain.RecursivePair =
+            TestDomain.RecursivePair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun answerPair(
+            first: Answer,
+            second: Answer,
+            metas: MetaContainer
+        ): TestDomain.AnswerPair =
+            TestDomain.AnswerPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun answerIntPair(
+            first: Answer,
+            second: Long,
+            metas: MetaContainer
+        ): TestDomain.AnswerIntPair =
+            TestDomain.AnswerIntPair(
+                first = first,
+                second = second.asPrimitive(),
+                metas = metas)
+        
+        override fun answerIntPair_(
+            first: Answer,
+            second: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): TestDomain.AnswerIntPair =
+            TestDomain.AnswerIntPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun intAnswerPair(
+            first: Long,
+            second: Answer,
+            metas: MetaContainer
+        ): TestDomain.IntAnswerPair =
+            TestDomain.IntAnswerPair(
+                first = first.asPrimitive(),
+                second = second,
+                metas = metas)
+        
+        override fun intAnswerPair_(
+            first: org.partiql.pig.runtime.LongPrimitive,
+            second: Answer,
+            metas: MetaContainer
+        ): TestDomain.IntAnswerPair =
+            TestDomain.IntAnswerPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun symbolAnswerPair(
+            first: String,
+            second: Answer,
+            metas: MetaContainer
+        ): TestDomain.SymbolAnswerPair =
+            TestDomain.SymbolAnswerPair(
+                first = first.asPrimitive(),
+                second = second,
+                metas = metas)
+        
+        override fun symbolAnswerPair_(
+            first: org.partiql.pig.runtime.SymbolPrimitive,
+            second: Answer,
+            metas: MetaContainer
+        ): TestDomain.SymbolAnswerPair =
+            TestDomain.SymbolAnswerPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun answerSymbolPair(
+            first: Answer,
+            second: String,
+            metas: MetaContainer
+        ): TestDomain.AnswerSymbolPair =
+            TestDomain.AnswerSymbolPair(
+                first = first,
+                second = second.asPrimitive(),
+                metas = metas)
+        
+        override fun answerSymbolPair_(
+            first: Answer,
+            second: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer
+        ): TestDomain.AnswerSymbolPair =
+            TestDomain.AnswerSymbolPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun variadicMin0(
+            ints: kotlin.collections.List<Long>,
+            metas: MetaContainer
+        ): TestDomain.VariadicMin0 =
+            TestDomain.VariadicMin0(
+                ints = ints.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun variadicMin0_(
+            ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+            metas: MetaContainer
+        ): TestDomain.VariadicMin0 =
+            TestDomain.VariadicMin0(
+                ints = ints,
+                metas = metas)
+        
+        override fun variadicMin0(
+            vararg ints: Long,
+            metas: MetaContainer
+        ): TestDomain.VariadicMin0 =
+            TestDomain.VariadicMin0(
+                ints = ints.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun variadicMin0_(
+            vararg ints: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): TestDomain.VariadicMin0 =
+            TestDomain.VariadicMin0(
+                ints = ints.toList(),
+                metas = metas)
+        
+        
+        override fun variadicMin1(
+            ints: kotlin.collections.List<Long>,
+            metas: MetaContainer
+        ): TestDomain.VariadicMin1 =
+            TestDomain.VariadicMin1(
+                ints = ints.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun variadicMin1_(
+            ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+            metas: MetaContainer
+        ): TestDomain.VariadicMin1 =
+            TestDomain.VariadicMin1(
+                ints = ints,
+                metas = metas)
+        
+        override fun variadicMin1(
+            ints0: Long,
+            vararg ints: Long,
+            metas: MetaContainer
+        ): TestDomain.VariadicMin1 =
+            TestDomain.VariadicMin1(
+                ints = listOfPrimitives(ints0) + ints.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun variadicMin1_(
+            ints0: org.partiql.pig.runtime.LongPrimitive,
+            vararg ints: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): TestDomain.VariadicMin1 =
+            TestDomain.VariadicMin1(
+                ints = listOfPrimitives(ints0) + ints.toList(),
+                metas = metas)
+        
+        
+        override fun elementVariadic(
+            name: String,
+            ints: kotlin.collections.List<Long>,
+            metas: MetaContainer
+        ): TestDomain.ElementVariadic =
+            TestDomain.ElementVariadic(
+                name = name.asPrimitive(),
+                ints = ints.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun elementVariadic_(
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+            metas: MetaContainer
+        ): TestDomain.ElementVariadic =
+            TestDomain.ElementVariadic(
+                name = name,
+                ints = ints,
+                metas = metas)
+        
+        override fun elementVariadic(
+            name: String,
+            vararg ints: Long,
+            metas: MetaContainer
+        ): TestDomain.ElementVariadic =
+            TestDomain.ElementVariadic(
+                name = name.asPrimitive(),
+                ints = ints.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun elementVariadic_(
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            vararg ints: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): TestDomain.ElementVariadic =
+            TestDomain.ElementVariadic(
+                name = name,
+                ints = ints.toList(),
+                metas = metas)
+        
+        
+        override fun optional1(
+            value: Long?,
+            metas: MetaContainer
+        ): TestDomain.Optional1 =
+            TestDomain.Optional1(
+                value = value?.asPrimitive(),
+                metas = metas)
+        
+        override fun optional1_(
+            value: org.partiql.pig.runtime.LongPrimitive?,
+            metas: MetaContainer
+        ): TestDomain.Optional1 =
+            TestDomain.Optional1(
+                value = value,
+                metas = metas)
+        
+        
+        override fun optional2(
+            first: Long?,
+            second: Long?,
+            metas: MetaContainer
+        ): TestDomain.Optional2 =
+            TestDomain.Optional2(
+                first = first?.asPrimitive(),
+                second = second?.asPrimitive(),
+                metas = metas)
+        
+        override fun optional2_(
+            first: org.partiql.pig.runtime.LongPrimitive?,
+            second: org.partiql.pig.runtime.LongPrimitive?,
+            metas: MetaContainer
+        ): TestDomain.Optional2 =
+            TestDomain.Optional2(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun domainLevelRecord(
+            someField: Long,
+            anotherField: String,
+            optionalField: Long?,
+            metas: MetaContainer
+        ): TestDomain.DomainLevelRecord =
+            TestDomain.DomainLevelRecord(
+                someField = someField.asPrimitive(),
+                anotherField = anotherField.asPrimitive(),
+                optionalField = optionalField?.asPrimitive(),
+                metas = metas)
+        
+        override fun domainLevelRecord_(
+            someField: org.partiql.pig.runtime.LongPrimitive,
+            anotherField: org.partiql.pig.runtime.SymbolPrimitive,
+            optionalField: org.partiql.pig.runtime.LongPrimitive?,
+            metas: MetaContainer
+        ): TestDomain.DomainLevelRecord =
+            TestDomain.DomainLevelRecord(
+                someField = someField,
+                anotherField = anotherField,
+                optionalField = optionalField,
+                metas = metas)
+        
+        
+        override fun productWithRecord(
+            value: Long,
+            dlr: DomainLevelRecord,
+            metas: MetaContainer
+        ): TestDomain.ProductWithRecord =
+            TestDomain.ProductWithRecord(
+                value = value.asPrimitive(),
+                dlr = dlr,
+                metas = metas)
+        
+        override fun productWithRecord_(
+            value: org.partiql.pig.runtime.LongPrimitive,
+            dlr: DomainLevelRecord,
+            metas: MetaContainer
+        ): TestDomain.ProductWithRecord =
+            TestDomain.ProductWithRecord(
+                value = value,
+                dlr = dlr,
+                metas = metas)
+        
+        
+        override fun testSumTriplet(
+            a: TestSum,
+            b: TestSum,
+            c: TestSum,
+            metas: MetaContainer
+        ): TestDomain.TestSumTriplet =
+            TestDomain.TestSumTriplet(
+                a = a,
+                b = b,
+                c = c,
+                metas = metas)
+        
+        
+        override fun entityPair(
+            first: Entity,
+            second: Entity,
+            metas: MetaContainer
+        ): TestDomain.EntityPair =
+            TestDomain.EntityPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        // Variants for Sum: Answer 
+        override fun no(
+            metas: MetaContainer
+        ): TestDomain.Answer.No =
+            TestDomain.Answer.No(
+                metas = metas)
+        
+        
+        override fun yes(
+            metas: MetaContainer
+        ): TestDomain.Answer.Yes =
+            TestDomain.Answer.Yes(
+                metas = metas)
+        
+        
+        // Variants for Sum: SumWithRecord 
+        override fun variantWithRecord(
+            value: Long,
+            dlr: DomainLevelRecord,
+            metas: MetaContainer
+        ): TestDomain.SumWithRecord.VariantWithRecord =
+            TestDomain.SumWithRecord.VariantWithRecord(
+                value = value.asPrimitive(),
+                dlr = dlr,
+                metas = metas)
+        
+        override fun variantWithRecord_(
+            value: org.partiql.pig.runtime.LongPrimitive,
+            dlr: DomainLevelRecord,
+            metas: MetaContainer
+        ): TestDomain.SumWithRecord.VariantWithRecord =
+            TestDomain.SumWithRecord.VariantWithRecord(
+                value = value,
+                dlr = dlr,
+                metas = metas)
+        
+        
+        // Variants for Sum: TestSum 
+        override fun one(
+            a: Long,
+            metas: MetaContainer
+        ): TestDomain.TestSum.One =
+            TestDomain.TestSum.One(
+                a = a.asPrimitive(),
+                metas = metas)
+        
+        override fun one_(
+            a: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): TestDomain.TestSum.One =
+            TestDomain.TestSum.One(
+                a = a,
+                metas = metas)
+        
+        
+        override fun two(
+            a: Long,
+            b: Long,
+            metas: MetaContainer
+        ): TestDomain.TestSum.Two =
+            TestDomain.TestSum.Two(
+                a = a.asPrimitive(),
+                b = b.asPrimitive(),
+                metas = metas)
+        
+        override fun two_(
+            a: org.partiql.pig.runtime.LongPrimitive,
+            b: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): TestDomain.TestSum.Two =
+            TestDomain.TestSum.Two(
+                a = a,
+                b = b,
+                metas = metas)
+        
+        
+        override fun three(
+            a: Long,
+            b: Long,
+            c: Long,
+            metas: MetaContainer
+        ): TestDomain.TestSum.Three =
+            TestDomain.TestSum.Three(
+                a = a.asPrimitive(),
+                b = b.asPrimitive(),
+                c = c.asPrimitive(),
+                metas = metas)
+        
+        override fun three_(
+            a: org.partiql.pig.runtime.LongPrimitive,
+            b: org.partiql.pig.runtime.LongPrimitive,
+            c: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): TestDomain.TestSum.Three =
+            TestDomain.TestSum.Three(
+                a = a,
+                b = b,
+                c = c,
+                metas = metas)
+        
+        
+        // Variants for Sum: Entity 
+        override fun slug(
+            metas: MetaContainer
+        ): TestDomain.Entity.Slug =
+            TestDomain.Entity.Slug(
+                metas = metas)
+        
+        
+        override fun android(
+            id: Long,
+            metas: MetaContainer
+        ): TestDomain.Entity.Android =
+            TestDomain.Entity.Android(
+                id = id.asPrimitive(),
+                metas = metas)
+        
+        override fun android_(
+            id: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): TestDomain.Entity.Android =
+            TestDomain.Entity.Android(
+                id = id,
+                metas = metas)
+        
+        
+        override fun human(
+            firstName: String,
+            lastName: String,
+            title: String?,
+            parent: Entity?,
+            metas: MetaContainer
+        ): TestDomain.Entity.Human =
+            TestDomain.Entity.Human(
+                firstName = firstName.asPrimitive(),
+                lastName = lastName.asPrimitive(),
+                title = title?.asPrimitive(),
+                parent = parent,
+                metas = metas)
+        
+        override fun human_(
+            firstName: org.partiql.pig.runtime.SymbolPrimitive,
+            lastName: org.partiql.pig.runtime.SymbolPrimitive,
+            title: org.partiql.pig.runtime.SymbolPrimitive?,
+            parent: Entity?,
+            metas: MetaContainer
         ): TestDomain.Entity.Human =
             TestDomain.Entity.Human(
                 firstName = firstName,
@@ -6792,8 +7472,11 @@ class MultiWordDomain private constructor() {
     // Builder
     /////////////////////////////////////////////////////////////////////////////
     companion object {
+        @JvmStatic
+        fun BUILDER() : Builder = MultiWordDomainBuilder
+    
         fun <T: MultiWordDomainNode> build(block: Builder.() -> T) =
-            Builder.block()
+            MultiWordDomainBuilder.block()
     
         fun transform(element: AnyElement): MultiWordDomainNode =
             transform(element.asSexp())
@@ -6802,16 +7485,14 @@ class MultiWordDomain private constructor() {
             Transformer().transform(element)
     }
     
-    object Builder {
+    interface Builder {
                 // Tuples
         /**
          * Creates an instance of [MultiWordDomain.AaaAaa].
          */
         fun aaaAaa(
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAaa =
-            MultiWordDomain.AaaAaa(
-                metas = metas)
+        ): MultiWordDomain.AaaAaa
         
         
         /**
@@ -6820,10 +7501,7 @@ class MultiWordDomain private constructor() {
         fun aaaAab(
             dField: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAab =
-            MultiWordDomain.AaaAab(
-                dField = dField?.asPrimitive(),
-                metas = metas)
+        ): MultiWordDomain.AaaAab
         
         /**
          * Creates an instance of [MultiWordDomain.AaaAab].
@@ -6835,10 +7513,7 @@ class MultiWordDomain private constructor() {
         fun aaaAab_(
             dField: org.partiql.pig.runtime.LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAab =
-            MultiWordDomain.AaaAab(
-                dField = dField,
-                metas = metas)
+        ): MultiWordDomain.AaaAab
         
         
         /**
@@ -6848,11 +7523,7 @@ class MultiWordDomain private constructor() {
             dField: Long? = null,
             eField: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAac =
-            MultiWordDomain.AaaAac(
-                dField = dField?.asPrimitive(),
-                eField = eField?.asPrimitive(),
-                metas = metas)
+        ): MultiWordDomain.AaaAac
         
         /**
          * Creates an instance of [MultiWordDomain.AaaAac].
@@ -6865,11 +7536,7 @@ class MultiWordDomain private constructor() {
             dField: org.partiql.pig.runtime.LongPrimitive? = null,
             eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAac =
-            MultiWordDomain.AaaAac(
-                dField = dField,
-                eField = eField,
-                metas = metas)
+        ): MultiWordDomain.AaaAac
         
         
         /**
@@ -6878,10 +7545,7 @@ class MultiWordDomain private constructor() {
         fun aaaAad(
             dField: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAad =
-            MultiWordDomain.AaaAad(
-                dField = dField.map { it.asPrimitive() },
-                metas = metas)
+        ): MultiWordDomain.AaaAad
         
         /**
          * Creates an instance of [MultiWordDomain.AaaAad].
@@ -6893,10 +7557,7 @@ class MultiWordDomain private constructor() {
         fun aaaAad_(
             dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAad =
-            MultiWordDomain.AaaAad(
-                dField = dField,
-                metas = metas)
+        ): MultiWordDomain.AaaAad
         
         /**
          * Creates an instance of [MultiWordDomain.AaaAad].
@@ -6904,10 +7565,7 @@ class MultiWordDomain private constructor() {
         fun aaaAad(
             vararg dField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAad =
-            MultiWordDomain.AaaAad(
-                dField = dField.map { it.asPrimitive() },
-                metas = metas)
+        ): MultiWordDomain.AaaAad
         
         /**
          * Creates an instance of [MultiWordDomain.AaaAad].
@@ -6919,10 +7577,7 @@ class MultiWordDomain private constructor() {
         fun aaaAad_(
             vararg dField: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAad =
-            MultiWordDomain.AaaAad(
-                dField = dField.toList(),
-                metas = metas)
+        ): MultiWordDomain.AaaAad
         
         
         /**
@@ -6931,10 +7586,7 @@ class MultiWordDomain private constructor() {
         fun aaaAae(
             dField: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAae =
-            MultiWordDomain.AaaAae(
-                dField = dField.map { it.asPrimitive() },
-                metas = metas)
+        ): MultiWordDomain.AaaAae
         
         /**
          * Creates an instance of [MultiWordDomain.AaaAae].
@@ -6946,10 +7598,7 @@ class MultiWordDomain private constructor() {
         fun aaaAae_(
             dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAae =
-            MultiWordDomain.AaaAae(
-                dField = dField,
-                metas = metas)
+        ): MultiWordDomain.AaaAae
         
         /**
          * Creates an instance of [MultiWordDomain.AaaAae].
@@ -6959,10 +7608,7 @@ class MultiWordDomain private constructor() {
             dField1: Long,
             vararg dField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAae =
-            MultiWordDomain.AaaAae(
-                dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
-                metas = metas)
+        ): MultiWordDomain.AaaAae
         
         /**
          * Creates an instance of [MultiWordDomain.AaaAae].
@@ -6976,10 +7622,7 @@ class MultiWordDomain private constructor() {
             dField1: org.partiql.pig.runtime.LongPrimitive,
             vararg dField: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAae =
-            MultiWordDomain.AaaAae(
-                dField = listOfPrimitives(dField0, dField1) + dField.toList(),
-                metas = metas)
+        ): MultiWordDomain.AaaAae
         
         
         /**
@@ -6989,11 +7632,7 @@ class MultiWordDomain private constructor() {
             bField: Long,
             cField: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAaa =
-            MultiWordDomain.AabAaa(
-                bField = bField.asPrimitive(),
-                cField = cField.asPrimitive(),
-                metas = metas)
+        ): MultiWordDomain.AabAaa
         
         /**
          * Creates an instance of [MultiWordDomain.AabAaa].
@@ -7006,11 +7645,7 @@ class MultiWordDomain private constructor() {
             bField: org.partiql.pig.runtime.LongPrimitive,
             cField: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAaa =
-            MultiWordDomain.AabAaa(
-                bField = bField,
-                cField = cField,
-                metas = metas)
+        ): MultiWordDomain.AabAaa
         
         
         /**
@@ -7021,12 +7656,7 @@ class MultiWordDomain private constructor() {
             cField: String,
             dField: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAab =
-            MultiWordDomain.AabAab(
-                bField = bField.asPrimitive(),
-                cField = cField.asPrimitive(),
-                dField = dField?.asPrimitive(),
-                metas = metas)
+        ): MultiWordDomain.AabAab
         
         /**
          * Creates an instance of [MultiWordDomain.AabAab].
@@ -7040,12 +7670,7 @@ class MultiWordDomain private constructor() {
             cField: org.partiql.pig.runtime.SymbolPrimitive,
             dField: org.partiql.pig.runtime.LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAab =
-            MultiWordDomain.AabAab(
-                bField = bField,
-                cField = cField,
-                dField = dField,
-                metas = metas)
+        ): MultiWordDomain.AabAab
         
         
         /**
@@ -7057,13 +7682,7 @@ class MultiWordDomain private constructor() {
             dField: Long? = null,
             eField: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAac =
-            MultiWordDomain.AabAac(
-                bField = bField.asPrimitive(),
-                cField = cField.asPrimitive(),
-                dField = dField?.asPrimitive(),
-                eField = eField?.asPrimitive(),
-                metas = metas)
+        ): MultiWordDomain.AabAac
         
         /**
          * Creates an instance of [MultiWordDomain.AabAac].
@@ -7078,13 +7697,7 @@ class MultiWordDomain private constructor() {
             dField: org.partiql.pig.runtime.LongPrimitive? = null,
             eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAac =
-            MultiWordDomain.AabAac(
-                bField = bField,
-                cField = cField,
-                dField = dField,
-                eField = eField,
-                metas = metas)
+        ): MultiWordDomain.AabAac
         
         
         /**
@@ -7095,12 +7708,7 @@ class MultiWordDomain private constructor() {
             cField: String,
             dField: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAad =
-            MultiWordDomain.AabAad(
-                bField = bField.asPrimitive(),
-                cField = cField.asPrimitive(),
-                dField = dField.map { it.asPrimitive() },
-                metas = metas)
+        ): MultiWordDomain.AabAad
         
         /**
          * Creates an instance of [MultiWordDomain.AabAad].
@@ -7114,12 +7722,7 @@ class MultiWordDomain private constructor() {
             cField: org.partiql.pig.runtime.SymbolPrimitive,
             dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAad =
-            MultiWordDomain.AabAad(
-                bField = bField,
-                cField = cField,
-                dField = dField,
-                metas = metas)
+        ): MultiWordDomain.AabAad
         
         /**
          * Creates an instance of [MultiWordDomain.AabAad].
@@ -7129,12 +7732,7 @@ class MultiWordDomain private constructor() {
             cField: String,
             vararg dField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAad =
-            MultiWordDomain.AabAad(
-                bField = bField.asPrimitive(),
-                cField = cField.asPrimitive(),
-                dField = dField.map { it.asPrimitive() },
-                metas = metas)
+        ): MultiWordDomain.AabAad
         
         /**
          * Creates an instance of [MultiWordDomain.AabAad].
@@ -7148,12 +7746,7 @@ class MultiWordDomain private constructor() {
             cField: org.partiql.pig.runtime.SymbolPrimitive,
             vararg dField: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAad =
-            MultiWordDomain.AabAad(
-                bField = bField,
-                cField = cField,
-                dField = dField.toList(),
-                metas = metas)
+        ): MultiWordDomain.AabAad
         
         
         /**
@@ -7164,12 +7757,7 @@ class MultiWordDomain private constructor() {
             cField: String,
             dField: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAae =
-            MultiWordDomain.AabAae(
-                bField = bField.asPrimitive(),
-                cField = cField.asPrimitive(),
-                dField = dField.map { it.asPrimitive() },
-                metas = metas)
+        ): MultiWordDomain.AabAae
         
         /**
          * Creates an instance of [MultiWordDomain.AabAae].
@@ -7183,12 +7771,7 @@ class MultiWordDomain private constructor() {
             cField: org.partiql.pig.runtime.SymbolPrimitive,
             dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAae =
-            MultiWordDomain.AabAae(
-                bField = bField,
-                cField = cField,
-                dField = dField,
-                metas = metas)
+        ): MultiWordDomain.AabAae
         
         /**
          * Creates an instance of [MultiWordDomain.AabAae].
@@ -7200,12 +7783,7 @@ class MultiWordDomain private constructor() {
             dField1: Long,
             vararg dField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAae =
-            MultiWordDomain.AabAae(
-                bField = bField.asPrimitive(),
-                cField = cField.asPrimitive(),
-                dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
-                metas = metas)
+        ): MultiWordDomain.AabAae
         
         /**
          * Creates an instance of [MultiWordDomain.AabAae].
@@ -7221,12 +7799,7 @@ class MultiWordDomain private constructor() {
             dField1: org.partiql.pig.runtime.LongPrimitive,
             vararg dField: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAae =
-            MultiWordDomain.AabAae(
-                bField = bField,
-                cField = cField,
-                dField = listOfPrimitives(dField0, dField1) + dField.toList(),
-                metas = metas)
+        ): MultiWordDomain.AabAae
         
         
         /**
@@ -7236,11 +7809,7 @@ class MultiWordDomain private constructor() {
             aField: Long,
             bbbField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.Rrr =
-            MultiWordDomain.Rrr(
-                aField = aField.asPrimitive(),
-                bbbField = bbbField.asPrimitive(),
-                metas = metas)
+        ): MultiWordDomain.Rrr
         
         /**
          * Creates an instance of [MultiWordDomain.Rrr].
@@ -7253,11 +7822,7 @@ class MultiWordDomain private constructor() {
             aField: org.partiql.pig.runtime.LongPrimitive,
             bbbField: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.Rrr =
-            MultiWordDomain.Rrr(
-                aField = aField,
-                bbbField = bbbField,
-                metas = metas)
+        ): MultiWordDomain.Rrr
         
         
         // Variants for Sum: SssTtt 
@@ -7267,10 +7832,7 @@ class MultiWordDomain private constructor() {
         fun lll(
             uField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.SssTtt.Lll =
-            MultiWordDomain.SssTtt.Lll(
-                uField = uField.asPrimitive(),
-                metas = metas)
+        ): MultiWordDomain.SssTtt.Lll
         
         /**
          * Creates an instance of [MultiWordDomain.SssTtt.Lll].
@@ -7282,10 +7844,7 @@ class MultiWordDomain private constructor() {
         fun lll_(
             uField: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.SssTtt.Lll =
-            MultiWordDomain.SssTtt.Lll(
-                uField = uField,
-                metas = metas)
+        ): MultiWordDomain.SssTtt.Lll
         
         
         /**
@@ -7294,10 +7853,7 @@ class MultiWordDomain private constructor() {
         fun mmm(
             vField: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.SssTtt.Mmm =
-            MultiWordDomain.SssTtt.Mmm(
-                vField = vField.asPrimitive(),
-                metas = metas)
+        ): MultiWordDomain.SssTtt.Mmm
         
         /**
          * Creates an instance of [MultiWordDomain.SssTtt.Mmm].
@@ -7309,6 +7865,353 @@ class MultiWordDomain private constructor() {
         fun mmm_(
             vField: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
+        ): MultiWordDomain.SssTtt.Mmm
+    }
+    
+    private object MultiWordDomainBuilder : Builder {
+                // Tuples
+        override fun aaaAaa(
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAaa =
+            MultiWordDomain.AaaAaa(
+                metas = metas)
+        
+        
+        override fun aaaAab(
+            dField: Long?,
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAab =
+            MultiWordDomain.AaaAab(
+                dField = dField?.asPrimitive(),
+                metas = metas)
+        
+        override fun aaaAab_(
+            dField: org.partiql.pig.runtime.LongPrimitive?,
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAab =
+            MultiWordDomain.AaaAab(
+                dField = dField,
+                metas = metas)
+        
+        
+        override fun aaaAac(
+            dField: Long?,
+            eField: String?,
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAac =
+            MultiWordDomain.AaaAac(
+                dField = dField?.asPrimitive(),
+                eField = eField?.asPrimitive(),
+                metas = metas)
+        
+        override fun aaaAac_(
+            dField: org.partiql.pig.runtime.LongPrimitive?,
+            eField: org.partiql.pig.runtime.SymbolPrimitive?,
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAac =
+            MultiWordDomain.AaaAac(
+                dField = dField,
+                eField = eField,
+                metas = metas)
+        
+        
+        override fun aaaAad(
+            dField: kotlin.collections.List<Long>,
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAad =
+            MultiWordDomain.AaaAad(
+                dField = dField.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun aaaAad_(
+            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAad =
+            MultiWordDomain.AaaAad(
+                dField = dField,
+                metas = metas)
+        
+        override fun aaaAad(
+            vararg dField: Long,
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAad =
+            MultiWordDomain.AaaAad(
+                dField = dField.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun aaaAad_(
+            vararg dField: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAad =
+            MultiWordDomain.AaaAad(
+                dField = dField.toList(),
+                metas = metas)
+        
+        
+        override fun aaaAae(
+            dField: kotlin.collections.List<Long>,
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAae =
+            MultiWordDomain.AaaAae(
+                dField = dField.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun aaaAae_(
+            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAae =
+            MultiWordDomain.AaaAae(
+                dField = dField,
+                metas = metas)
+        
+        override fun aaaAae(
+            dField0: Long,
+            dField1: Long,
+            vararg dField: Long,
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAae =
+            MultiWordDomain.AaaAae(
+                dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun aaaAae_(
+            dField0: org.partiql.pig.runtime.LongPrimitive,
+            dField1: org.partiql.pig.runtime.LongPrimitive,
+            vararg dField: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): MultiWordDomain.AaaAae =
+            MultiWordDomain.AaaAae(
+                dField = listOfPrimitives(dField0, dField1) + dField.toList(),
+                metas = metas)
+        
+        
+        override fun aabAaa(
+            bField: Long,
+            cField: String,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAaa =
+            MultiWordDomain.AabAaa(
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
+                metas = metas)
+        
+        override fun aabAaa_(
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAaa =
+            MultiWordDomain.AabAaa(
+                bField = bField,
+                cField = cField,
+                metas = metas)
+        
+        
+        override fun aabAab(
+            bField: Long,
+            cField: String,
+            dField: Long?,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAab =
+            MultiWordDomain.AabAab(
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
+                dField = dField?.asPrimitive(),
+                metas = metas)
+        
+        override fun aabAab_(
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            dField: org.partiql.pig.runtime.LongPrimitive?,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAab =
+            MultiWordDomain.AabAab(
+                bField = bField,
+                cField = cField,
+                dField = dField,
+                metas = metas)
+        
+        
+        override fun aabAac(
+            bField: Long,
+            cField: String,
+            dField: Long?,
+            eField: String?,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAac =
+            MultiWordDomain.AabAac(
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
+                dField = dField?.asPrimitive(),
+                eField = eField?.asPrimitive(),
+                metas = metas)
+        
+        override fun aabAac_(
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            dField: org.partiql.pig.runtime.LongPrimitive?,
+            eField: org.partiql.pig.runtime.SymbolPrimitive?,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAac =
+            MultiWordDomain.AabAac(
+                bField = bField,
+                cField = cField,
+                dField = dField,
+                eField = eField,
+                metas = metas)
+        
+        
+        override fun aabAad(
+            bField: Long,
+            cField: String,
+            dField: kotlin.collections.List<Long>,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAad =
+            MultiWordDomain.AabAad(
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
+                dField = dField.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun aabAad_(
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAad =
+            MultiWordDomain.AabAad(
+                bField = bField,
+                cField = cField,
+                dField = dField,
+                metas = metas)
+        
+        override fun aabAad(
+            bField: Long,
+            cField: String,
+            vararg dField: Long,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAad =
+            MultiWordDomain.AabAad(
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
+                dField = dField.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun aabAad_(
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            vararg dField: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAad =
+            MultiWordDomain.AabAad(
+                bField = bField,
+                cField = cField,
+                dField = dField.toList(),
+                metas = metas)
+        
+        
+        override fun aabAae(
+            bField: Long,
+            cField: String,
+            dField: kotlin.collections.List<Long>,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAae =
+            MultiWordDomain.AabAae(
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
+                dField = dField.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun aabAae_(
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAae =
+            MultiWordDomain.AabAae(
+                bField = bField,
+                cField = cField,
+                dField = dField,
+                metas = metas)
+        
+        override fun aabAae(
+            bField: Long,
+            cField: String,
+            dField0: Long,
+            dField1: Long,
+            vararg dField: Long,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAae =
+            MultiWordDomain.AabAae(
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
+                dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
+                metas = metas)
+        
+        override fun aabAae_(
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            dField0: org.partiql.pig.runtime.LongPrimitive,
+            dField1: org.partiql.pig.runtime.LongPrimitive,
+            vararg dField: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): MultiWordDomain.AabAae =
+            MultiWordDomain.AabAae(
+                bField = bField,
+                cField = cField,
+                dField = listOfPrimitives(dField0, dField1) + dField.toList(),
+                metas = metas)
+        
+        
+        override fun rrr(
+            aField: Long,
+            bbbField: Long,
+            metas: MetaContainer
+        ): MultiWordDomain.Rrr =
+            MultiWordDomain.Rrr(
+                aField = aField.asPrimitive(),
+                bbbField = bbbField.asPrimitive(),
+                metas = metas)
+        
+        override fun rrr_(
+            aField: org.partiql.pig.runtime.LongPrimitive,
+            bbbField: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): MultiWordDomain.Rrr =
+            MultiWordDomain.Rrr(
+                aField = aField,
+                bbbField = bbbField,
+                metas = metas)
+        
+        
+        // Variants for Sum: SssTtt 
+        override fun lll(
+            uField: Long,
+            metas: MetaContainer
+        ): MultiWordDomain.SssTtt.Lll =
+            MultiWordDomain.SssTtt.Lll(
+                uField = uField.asPrimitive(),
+                metas = metas)
+        
+        override fun lll_(
+            uField: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): MultiWordDomain.SssTtt.Lll =
+            MultiWordDomain.SssTtt.Lll(
+                uField = uField,
+                metas = metas)
+        
+        
+        override fun mmm(
+            vField: String,
+            metas: MetaContainer
+        ): MultiWordDomain.SssTtt.Mmm =
+            MultiWordDomain.SssTtt.Mmm(
+                vField = vField.asPrimitive(),
+                metas = metas)
+        
+        override fun mmm_(
+            vField: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer
         ): MultiWordDomain.SssTtt.Mmm =
             MultiWordDomain.SssTtt.Mmm(
                 vField = vField,
@@ -8563,8 +9466,11 @@ class PartiqlBasic private constructor() {
     // Builder
     /////////////////////////////////////////////////////////////////////////////
     companion object {
+        @JvmStatic
+        fun BUILDER() : Builder = PartiqlBasicBuilder
+    
         fun <T: PartiqlBasicNode> build(block: Builder.() -> T) =
-            Builder.block()
+            PartiqlBasicBuilder.block()
     
         fun transform(element: AnyElement): PartiqlBasicNode =
             transform(element.asSexp())
@@ -8573,7 +9479,7 @@ class PartiqlBasic private constructor() {
             Transformer().transform(element)
     }
     
-    object Builder {
+    interface Builder {
                 // Tuples
         /**
          * Creates an instance of [PartiqlBasic.ExprPair].
@@ -8582,11 +9488,7 @@ class PartiqlBasic private constructor() {
             first: Expr,
             second: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.ExprPair =
-            PartiqlBasic.ExprPair(
-                first = first,
-                second = second,
-                metas = metas)
+        ): PartiqlBasic.ExprPair
         
         
         /**
@@ -8596,11 +9498,7 @@ class PartiqlBasic private constructor() {
             value: Expr,
             asAlias: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.GroupByItem =
-            PartiqlBasic.GroupByItem(
-                value = value,
-                asAlias = asAlias?.asPrimitive(),
-                metas = metas)
+        ): PartiqlBasic.GroupByItem
         
         /**
          * Creates an instance of [PartiqlBasic.GroupByItem].
@@ -8613,11 +9511,7 @@ class PartiqlBasic private constructor() {
             value: Expr,
             asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.GroupByItem =
-            PartiqlBasic.GroupByItem(
-                value = value,
-                asAlias = asAlias,
-                metas = metas)
+        ): PartiqlBasic.GroupByItem
         
         
         /**
@@ -8626,10 +9520,7 @@ class PartiqlBasic private constructor() {
         fun groupByList(
             items: kotlin.collections.List<GroupByItem>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.GroupByList =
-            PartiqlBasic.GroupByList(
-                items = items,
-                metas = metas)
+        ): PartiqlBasic.GroupByList
         
         /**
          * Creates an instance of [PartiqlBasic.GroupByList].
@@ -8638,10 +9529,7 @@ class PartiqlBasic private constructor() {
             items0: GroupByItem,
             vararg items: GroupByItem,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.GroupByList =
-            PartiqlBasic.GroupByList(
-                items = listOf(items0) + items.toList(),
-                metas = metas)
+        ): PartiqlBasic.GroupByList
         
         
         /**
@@ -8651,11 +9539,7 @@ class PartiqlBasic private constructor() {
             items: GroupByList,
             groupAsAlias: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.GroupBy =
-            PartiqlBasic.GroupBy(
-                items = items,
-                groupAsAlias = groupAsAlias?.asPrimitive(),
-                metas = metas)
+        ): PartiqlBasic.GroupBy
         
         /**
          * Creates an instance of [PartiqlBasic.GroupBy].
@@ -8668,11 +9552,7 @@ class PartiqlBasic private constructor() {
             items: GroupByList,
             groupAsAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.GroupBy =
-            PartiqlBasic.GroupBy(
-                items = items,
-                groupAsAlias = groupAsAlias,
-                metas = metas)
+        ): PartiqlBasic.GroupBy
         
         
         // Variants for Sum: Projection 
@@ -8682,10 +9562,7 @@ class PartiqlBasic private constructor() {
         fun projectList(
             items: kotlin.collections.List<ProjectItem>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Projection.ProjectList =
-            PartiqlBasic.Projection.ProjectList(
-                items = items,
-                metas = metas)
+        ): PartiqlBasic.Projection.ProjectList
         
         /**
          * Creates an instance of [PartiqlBasic.Projection.ProjectList].
@@ -8694,10 +9571,7 @@ class PartiqlBasic private constructor() {
             items0: ProjectItem,
             vararg items: ProjectItem,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Projection.ProjectList =
-            PartiqlBasic.Projection.ProjectList(
-                items = listOf(items0) + items.toList(),
-                metas = metas)
+        ): PartiqlBasic.Projection.ProjectList
         
         
         /**
@@ -8706,10 +9580,7 @@ class PartiqlBasic private constructor() {
         fun projectValue(
             value: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Projection.ProjectValue =
-            PartiqlBasic.Projection.ProjectValue(
-                value = value,
-                metas = metas)
+        ): PartiqlBasic.Projection.ProjectValue
         
         
         // Variants for Sum: ProjectItem 
@@ -8718,9 +9589,7 @@ class PartiqlBasic private constructor() {
          */
         fun projectAll(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.ProjectItem.ProjectAll =
-            PartiqlBasic.ProjectItem.ProjectAll(
-                metas = metas)
+        ): PartiqlBasic.ProjectItem.ProjectAll
         
         
         /**
@@ -8730,11 +9599,7 @@ class PartiqlBasic private constructor() {
             value: Expr,
             asAlias: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.ProjectItem.ProjectExpr =
-            PartiqlBasic.ProjectItem.ProjectExpr(
-                value = value,
-                asAlias = asAlias?.asPrimitive(),
-                metas = metas)
+        ): PartiqlBasic.ProjectItem.ProjectExpr
         
         /**
          * Creates an instance of [PartiqlBasic.ProjectItem.ProjectExpr].
@@ -8747,11 +9612,7 @@ class PartiqlBasic private constructor() {
             value: Expr,
             asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.ProjectItem.ProjectExpr =
-            PartiqlBasic.ProjectItem.ProjectExpr(
-                value = value,
-                asAlias = asAlias,
-                metas = metas)
+        ): PartiqlBasic.ProjectItem.ProjectExpr
         
         
         // Variants for Sum: JoinType 
@@ -8760,9 +9621,7 @@ class PartiqlBasic private constructor() {
          */
         fun inner(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.JoinType.Inner =
-            PartiqlBasic.JoinType.Inner(
-                metas = metas)
+        ): PartiqlBasic.JoinType.Inner
         
         
         /**
@@ -8770,9 +9629,7 @@ class PartiqlBasic private constructor() {
          */
         fun left(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.JoinType.Left =
-            PartiqlBasic.JoinType.Left(
-                metas = metas)
+        ): PartiqlBasic.JoinType.Left
         
         
         /**
@@ -8780,9 +9637,7 @@ class PartiqlBasic private constructor() {
          */
         fun right(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.JoinType.Right =
-            PartiqlBasic.JoinType.Right(
-                metas = metas)
+        ): PartiqlBasic.JoinType.Right
         
         
         /**
@@ -8790,9 +9645,7 @@ class PartiqlBasic private constructor() {
          */
         fun outer(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.JoinType.Outer =
-            PartiqlBasic.JoinType.Outer(
-                metas = metas)
+        ): PartiqlBasic.JoinType.Outer
         
         
         // Variants for Sum: FromSource 
@@ -8805,13 +9658,7 @@ class PartiqlBasic private constructor() {
             atAlias: String? = null,
             byAlias: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.FromSource.Scan =
-            PartiqlBasic.FromSource.Scan(
-                expr = expr,
-                asAlias = asAlias?.asPrimitive(),
-                atAlias = atAlias?.asPrimitive(),
-                byAlias = byAlias?.asPrimitive(),
-                metas = metas)
+        ): PartiqlBasic.FromSource.Scan
         
         /**
          * Creates an instance of [PartiqlBasic.FromSource.Scan].
@@ -8826,13 +9673,7 @@ class PartiqlBasic private constructor() {
             atAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
             byAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.FromSource.Scan =
-            PartiqlBasic.FromSource.Scan(
-                expr = expr,
-                asAlias = asAlias,
-                atAlias = atAlias,
-                byAlias = byAlias,
-                metas = metas)
+        ): PartiqlBasic.FromSource.Scan
         
         
         /**
@@ -8844,13 +9685,7 @@ class PartiqlBasic private constructor() {
             right: FromSource,
             predicate: Expr? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.FromSource.Join =
-            PartiqlBasic.FromSource.Join(
-                type = type,
-                left = left,
-                right = right,
-                predicate = predicate,
-                metas = metas)
+        ): PartiqlBasic.FromSource.Join
         
         
         // Variants for Sum: CaseSensitivity 
@@ -8859,9 +9694,7 @@ class PartiqlBasic private constructor() {
          */
         fun caseSensitive(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.CaseSensitivity.CaseSensitive =
-            PartiqlBasic.CaseSensitivity.CaseSensitive(
-                metas = metas)
+        ): PartiqlBasic.CaseSensitivity.CaseSensitive
         
         
         /**
@@ -8869,9 +9702,7 @@ class PartiqlBasic private constructor() {
          */
         fun caseInsensitive(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.CaseSensitivity.CaseInsensitive =
-            PartiqlBasic.CaseSensitivity.CaseInsensitive(
-                metas = metas)
+        ): PartiqlBasic.CaseSensitivity.CaseInsensitive
         
         
         // Variants for Sum: ScopeQualifier 
@@ -8880,9 +9711,7 @@ class PartiqlBasic private constructor() {
          */
         fun unqualified(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.ScopeQualifier.Unqualified =
-            PartiqlBasic.ScopeQualifier.Unqualified(
-                metas = metas)
+        ): PartiqlBasic.ScopeQualifier.Unqualified
         
         
         /**
@@ -8890,9 +9719,7 @@ class PartiqlBasic private constructor() {
          */
         fun qualified(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.ScopeQualifier.Qualified =
-            PartiqlBasic.ScopeQualifier.Qualified(
-                metas = metas)
+        ): PartiqlBasic.ScopeQualifier.Qualified
         
         
         // Variants for Sum: SetQuantifier 
@@ -8901,9 +9728,7 @@ class PartiqlBasic private constructor() {
          */
         fun all(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.SetQuantifier.All =
-            PartiqlBasic.SetQuantifier.All(
-                metas = metas)
+        ): PartiqlBasic.SetQuantifier.All
         
         
         /**
@@ -8911,9 +9736,7 @@ class PartiqlBasic private constructor() {
          */
         fun distinct(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.SetQuantifier.Distinct =
-            PartiqlBasic.SetQuantifier.Distinct(
-                metas = metas)
+        ): PartiqlBasic.SetQuantifier.Distinct
         
         
         // Variants for Sum: PathElement 
@@ -8923,10 +9746,7 @@ class PartiqlBasic private constructor() {
         fun pathExpr(
             expr: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.PathElement.PathExpr =
-            PartiqlBasic.PathElement.PathExpr(
-                expr = expr,
-                metas = metas)
+        ): PartiqlBasic.PathElement.PathExpr
         
         
         /**
@@ -8934,9 +9754,7 @@ class PartiqlBasic private constructor() {
          */
         fun pathWildcard(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.PathElement.PathWildcard =
-            PartiqlBasic.PathElement.PathWildcard(
-                metas = metas)
+        ): PartiqlBasic.PathElement.PathWildcard
         
         
         /**
@@ -8944,9 +9762,7 @@ class PartiqlBasic private constructor() {
          */
         fun pathUnpivot(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.PathElement.PathUnpivot =
-            PartiqlBasic.PathElement.PathUnpivot(
-                metas = metas)
+        ): PartiqlBasic.PathElement.PathUnpivot
         
         
         // Variants for Sum: Expr 
@@ -8956,10 +9772,7 @@ class PartiqlBasic private constructor() {
         fun lit(
             value: com.amazon.ionelement.api.IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Lit =
-            PartiqlBasic.Expr.Lit(
-                value = value.asAnyElement(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Lit
         
         
         /**
@@ -8970,12 +9783,7 @@ class PartiqlBasic private constructor() {
             case: CaseSensitivity,
             scopeQualifier: ScopeQualifier,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Id =
-            PartiqlBasic.Expr.Id(
-                name = name.asPrimitive(),
-                case = case,
-                scopeQualifier = scopeQualifier,
-                metas = metas)
+        ): PartiqlBasic.Expr.Id
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Id].
@@ -8989,12 +9797,7 @@ class PartiqlBasic private constructor() {
             case: CaseSensitivity,
             scopeQualifier: ScopeQualifier,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Id =
-            PartiqlBasic.Expr.Id(
-                name = name,
-                case = case,
-                scopeQualifier = scopeQualifier,
-                metas = metas)
+        ): PartiqlBasic.Expr.Id
         
         
         /**
@@ -9003,10 +9806,7 @@ class PartiqlBasic private constructor() {
         fun parameter(
             index: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Parameter =
-            PartiqlBasic.Expr.Parameter(
-                index = index.asPrimitive(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Parameter
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Parameter].
@@ -9018,10 +9818,7 @@ class PartiqlBasic private constructor() {
         fun parameter_(
             index: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Parameter =
-            PartiqlBasic.Expr.Parameter(
-                index = index,
-                metas = metas)
+        ): PartiqlBasic.Expr.Parameter
         
         
         /**
@@ -9030,10 +9827,7 @@ class PartiqlBasic private constructor() {
         fun not(
             expr: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Not =
-            PartiqlBasic.Expr.Not(
-                expr = expr,
-                metas = metas)
+        ): PartiqlBasic.Expr.Not
         
         
         /**
@@ -9042,10 +9836,7 @@ class PartiqlBasic private constructor() {
         fun plus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Plus =
-            PartiqlBasic.Expr.Plus(
-                operands = operands,
-                metas = metas)
+        ): PartiqlBasic.Expr.Plus
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Plus].
@@ -9055,10 +9846,7 @@ class PartiqlBasic private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Plus =
-            PartiqlBasic.Expr.Plus(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Plus
         
         
         /**
@@ -9067,10 +9855,7 @@ class PartiqlBasic private constructor() {
         fun minus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Minus =
-            PartiqlBasic.Expr.Minus(
-                operands = operands,
-                metas = metas)
+        ): PartiqlBasic.Expr.Minus
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Minus].
@@ -9080,10 +9865,7 @@ class PartiqlBasic private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Minus =
-            PartiqlBasic.Expr.Minus(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Minus
         
         
         /**
@@ -9092,10 +9874,7 @@ class PartiqlBasic private constructor() {
         fun times(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Times =
-            PartiqlBasic.Expr.Times(
-                operands = operands,
-                metas = metas)
+        ): PartiqlBasic.Expr.Times
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Times].
@@ -9105,10 +9884,7 @@ class PartiqlBasic private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Times =
-            PartiqlBasic.Expr.Times(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Times
         
         
         /**
@@ -9117,10 +9893,7 @@ class PartiqlBasic private constructor() {
         fun divide(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Divide =
-            PartiqlBasic.Expr.Divide(
-                operands = operands,
-                metas = metas)
+        ): PartiqlBasic.Expr.Divide
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Divide].
@@ -9130,10 +9903,7 @@ class PartiqlBasic private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Divide =
-            PartiqlBasic.Expr.Divide(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Divide
         
         
         /**
@@ -9142,10 +9912,7 @@ class PartiqlBasic private constructor() {
         fun modulo(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Modulo =
-            PartiqlBasic.Expr.Modulo(
-                operands = operands,
-                metas = metas)
+        ): PartiqlBasic.Expr.Modulo
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Modulo].
@@ -9155,10 +9922,7 @@ class PartiqlBasic private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Modulo =
-            PartiqlBasic.Expr.Modulo(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Modulo
         
         
         /**
@@ -9167,10 +9931,7 @@ class PartiqlBasic private constructor() {
         fun concat(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Concat =
-            PartiqlBasic.Expr.Concat(
-                operands = operands,
-                metas = metas)
+        ): PartiqlBasic.Expr.Concat
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Concat].
@@ -9180,10 +9941,7 @@ class PartiqlBasic private constructor() {
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Concat =
-            PartiqlBasic.Expr.Concat(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Concat
         
         
         /**
@@ -9194,12 +9952,7 @@ class PartiqlBasic private constructor() {
             right: Expr,
             escape: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Like =
-            PartiqlBasic.Expr.Like(
-                left = left,
-                right = right,
-                escape = escape,
-                metas = metas)
+        ): PartiqlBasic.Expr.Like
         
         
         /**
@@ -9210,12 +9963,7 @@ class PartiqlBasic private constructor() {
             from: Expr,
             to: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Between =
-            PartiqlBasic.Expr.Between(
-                value = value,
-                from = from,
-                to = to,
-                metas = metas)
+        ): PartiqlBasic.Expr.Between
         
         
         /**
@@ -9225,11 +9973,7 @@ class PartiqlBasic private constructor() {
             root: Expr,
             elements: kotlin.collections.List<PathElement>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Path =
-            PartiqlBasic.Expr.Path(
-                root = root,
-                elements = elements,
-                metas = metas)
+        ): PartiqlBasic.Expr.Path
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Path].
@@ -9239,11 +9983,7 @@ class PartiqlBasic private constructor() {
             elements0: PathElement,
             vararg elements: PathElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Path =
-            PartiqlBasic.Expr.Path(
-                root = root,
-                elements = listOf(elements0) + elements.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Path
         
         
         /**
@@ -9253,11 +9993,7 @@ class PartiqlBasic private constructor() {
             name: String,
             args: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Call =
-            PartiqlBasic.Expr.Call(
-                name = name.asPrimitive(),
-                args = args,
-                metas = metas)
+        ): PartiqlBasic.Expr.Call
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Call].
@@ -9270,11 +10006,7 @@ class PartiqlBasic private constructor() {
             name: org.partiql.pig.runtime.SymbolPrimitive,
             args: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Call =
-            PartiqlBasic.Expr.Call(
-                name = name,
-                args = args,
-                metas = metas)
+        ): PartiqlBasic.Expr.Call
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Call].
@@ -9284,11 +10016,7 @@ class PartiqlBasic private constructor() {
             args0: Expr,
             vararg args: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Call =
-            PartiqlBasic.Expr.Call(
-                name = name.asPrimitive(),
-                args = listOf(args0) + args.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Call
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Call].
@@ -9302,11 +10030,7 @@ class PartiqlBasic private constructor() {
             args0: Expr,
             vararg args: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Call =
-            PartiqlBasic.Expr.Call(
-                name = name,
-                args = listOf(args0) + args.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Call
         
         
         /**
@@ -9317,12 +10041,7 @@ class PartiqlBasic private constructor() {
             setQuantifier: SetQuantifier,
             arg: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.CallAgg =
-            PartiqlBasic.Expr.CallAgg(
-                name = name.asPrimitive(),
-                setQuantifier = setQuantifier,
-                arg = arg,
-                metas = metas)
+        ): PartiqlBasic.Expr.CallAgg
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.CallAgg].
@@ -9336,12 +10055,7 @@ class PartiqlBasic private constructor() {
             setQuantifier: SetQuantifier,
             arg: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.CallAgg =
-            PartiqlBasic.Expr.CallAgg(
-                name = name,
-                setQuantifier = setQuantifier,
-                arg = arg,
-                metas = metas)
+        ): PartiqlBasic.Expr.CallAgg
         
         
         /**
@@ -9351,11 +10065,7 @@ class PartiqlBasic private constructor() {
             value: Expr,
             branches: kotlin.collections.List<ExprPair>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.SimpleCase =
-            PartiqlBasic.Expr.SimpleCase(
-                value = value,
-                branches = branches,
-                metas = metas)
+        ): PartiqlBasic.Expr.SimpleCase
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
@@ -9365,11 +10075,7 @@ class PartiqlBasic private constructor() {
             branches0: ExprPair,
             vararg branches: ExprPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.SimpleCase =
-            PartiqlBasic.Expr.SimpleCase(
-                value = value,
-                branches = listOf(branches0) + branches.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.SimpleCase
         
         
         /**
@@ -9378,10 +10084,7 @@ class PartiqlBasic private constructor() {
         fun searchedCase(
             branches: kotlin.collections.List<ExprPair>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.SearchedCase =
-            PartiqlBasic.Expr.SearchedCase(
-                branches = branches,
-                metas = metas)
+        ): PartiqlBasic.Expr.SearchedCase
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
@@ -9390,10 +10093,7 @@ class PartiqlBasic private constructor() {
             branches0: ExprPair,
             vararg branches: ExprPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.SearchedCase =
-            PartiqlBasic.Expr.SearchedCase(
-                branches = listOf(branches0) + branches.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.SearchedCase
         
         
         /**
@@ -9402,10 +10102,7 @@ class PartiqlBasic private constructor() {
         fun struct(
             fields: kotlin.collections.List<ExprPair>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Struct =
-            PartiqlBasic.Expr.Struct(
-                fields = fields,
-                metas = metas)
+        ): PartiqlBasic.Expr.Struct
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Struct].
@@ -9413,10 +10110,7 @@ class PartiqlBasic private constructor() {
         fun struct(
             vararg fields: ExprPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Struct =
-            PartiqlBasic.Expr.Struct(
-                fields = fields.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Struct
         
         
         /**
@@ -9425,10 +10119,7 @@ class PartiqlBasic private constructor() {
         fun bag(
             values: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Bag =
-            PartiqlBasic.Expr.Bag(
-                values = values,
-                metas = metas)
+        ): PartiqlBasic.Expr.Bag
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.Bag].
@@ -9436,10 +10127,7 @@ class PartiqlBasic private constructor() {
         fun bag(
             vararg values: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Bag =
-            PartiqlBasic.Expr.Bag(
-                values = values.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.Bag
         
         
         /**
@@ -9448,10 +10136,7 @@ class PartiqlBasic private constructor() {
         fun list(
             values: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.List =
-            PartiqlBasic.Expr.List(
-                values = values,
-                metas = metas)
+        ): PartiqlBasic.Expr.List
         
         /**
          * Creates an instance of [PartiqlBasic.Expr.List].
@@ -9459,10 +10144,7 @@ class PartiqlBasic private constructor() {
         fun list(
             vararg values: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.List =
-            PartiqlBasic.Expr.List(
-                values = values.toList(),
-                metas = metas)
+        ): PartiqlBasic.Expr.List
         
         
         /**
@@ -9477,6 +10159,673 @@ class PartiqlBasic private constructor() {
             having: Expr? = null,
             limit: Expr? = null,
             metas: MetaContainer = emptyMetaContainer()
+        ): PartiqlBasic.Expr.Select
+    }
+    
+    private object PartiqlBasicBuilder : Builder {
+                // Tuples
+        override fun exprPair(
+            first: Expr,
+            second: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.ExprPair =
+            PartiqlBasic.ExprPair(
+                first = first,
+                second = second,
+                metas = metas)
+        
+        
+        override fun groupByItem(
+            value: Expr,
+            asAlias: String?,
+            metas: MetaContainer
+        ): PartiqlBasic.GroupByItem =
+            PartiqlBasic.GroupByItem(
+                value = value,
+                asAlias = asAlias?.asPrimitive(),
+                metas = metas)
+        
+        override fun groupByItem_(
+            value: Expr,
+            asAlias: org.partiql.pig.runtime.SymbolPrimitive?,
+            metas: MetaContainer
+        ): PartiqlBasic.GroupByItem =
+            PartiqlBasic.GroupByItem(
+                value = value,
+                asAlias = asAlias,
+                metas = metas)
+        
+        
+        override fun groupByList(
+            items: kotlin.collections.List<GroupByItem>,
+            metas: MetaContainer
+        ): PartiqlBasic.GroupByList =
+            PartiqlBasic.GroupByList(
+                items = items,
+                metas = metas)
+        
+        override fun groupByList(
+            items0: GroupByItem,
+            vararg items: GroupByItem,
+            metas: MetaContainer
+        ): PartiqlBasic.GroupByList =
+            PartiqlBasic.GroupByList(
+                items = listOf(items0) + items.toList(),
+                metas = metas)
+        
+        
+        override fun groupBy(
+            items: GroupByList,
+            groupAsAlias: String?,
+            metas: MetaContainer
+        ): PartiqlBasic.GroupBy =
+            PartiqlBasic.GroupBy(
+                items = items,
+                groupAsAlias = groupAsAlias?.asPrimitive(),
+                metas = metas)
+        
+        override fun groupBy_(
+            items: GroupByList,
+            groupAsAlias: org.partiql.pig.runtime.SymbolPrimitive?,
+            metas: MetaContainer
+        ): PartiqlBasic.GroupBy =
+            PartiqlBasic.GroupBy(
+                items = items,
+                groupAsAlias = groupAsAlias,
+                metas = metas)
+        
+        
+        // Variants for Sum: Projection 
+        override fun projectList(
+            items: kotlin.collections.List<ProjectItem>,
+            metas: MetaContainer
+        ): PartiqlBasic.Projection.ProjectList =
+            PartiqlBasic.Projection.ProjectList(
+                items = items,
+                metas = metas)
+        
+        override fun projectList(
+            items0: ProjectItem,
+            vararg items: ProjectItem,
+            metas: MetaContainer
+        ): PartiqlBasic.Projection.ProjectList =
+            PartiqlBasic.Projection.ProjectList(
+                items = listOf(items0) + items.toList(),
+                metas = metas)
+        
+        
+        override fun projectValue(
+            value: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Projection.ProjectValue =
+            PartiqlBasic.Projection.ProjectValue(
+                value = value,
+                metas = metas)
+        
+        
+        // Variants for Sum: ProjectItem 
+        override fun projectAll(
+            metas: MetaContainer
+        ): PartiqlBasic.ProjectItem.ProjectAll =
+            PartiqlBasic.ProjectItem.ProjectAll(
+                metas = metas)
+        
+        
+        override fun projectExpr(
+            value: Expr,
+            asAlias: String?,
+            metas: MetaContainer
+        ): PartiqlBasic.ProjectItem.ProjectExpr =
+            PartiqlBasic.ProjectItem.ProjectExpr(
+                value = value,
+                asAlias = asAlias?.asPrimitive(),
+                metas = metas)
+        
+        override fun projectExpr_(
+            value: Expr,
+            asAlias: org.partiql.pig.runtime.SymbolPrimitive?,
+            metas: MetaContainer
+        ): PartiqlBasic.ProjectItem.ProjectExpr =
+            PartiqlBasic.ProjectItem.ProjectExpr(
+                value = value,
+                asAlias = asAlias,
+                metas = metas)
+        
+        
+        // Variants for Sum: JoinType 
+        override fun inner(
+            metas: MetaContainer
+        ): PartiqlBasic.JoinType.Inner =
+            PartiqlBasic.JoinType.Inner(
+                metas = metas)
+        
+        
+        override fun left(
+            metas: MetaContainer
+        ): PartiqlBasic.JoinType.Left =
+            PartiqlBasic.JoinType.Left(
+                metas = metas)
+        
+        
+        override fun right(
+            metas: MetaContainer
+        ): PartiqlBasic.JoinType.Right =
+            PartiqlBasic.JoinType.Right(
+                metas = metas)
+        
+        
+        override fun outer(
+            metas: MetaContainer
+        ): PartiqlBasic.JoinType.Outer =
+            PartiqlBasic.JoinType.Outer(
+                metas = metas)
+        
+        
+        // Variants for Sum: FromSource 
+        override fun scan(
+            expr: Expr,
+            asAlias: String?,
+            atAlias: String?,
+            byAlias: String?,
+            metas: MetaContainer
+        ): PartiqlBasic.FromSource.Scan =
+            PartiqlBasic.FromSource.Scan(
+                expr = expr,
+                asAlias = asAlias?.asPrimitive(),
+                atAlias = atAlias?.asPrimitive(),
+                byAlias = byAlias?.asPrimitive(),
+                metas = metas)
+        
+        override fun scan_(
+            expr: Expr,
+            asAlias: org.partiql.pig.runtime.SymbolPrimitive?,
+            atAlias: org.partiql.pig.runtime.SymbolPrimitive?,
+            byAlias: org.partiql.pig.runtime.SymbolPrimitive?,
+            metas: MetaContainer
+        ): PartiqlBasic.FromSource.Scan =
+            PartiqlBasic.FromSource.Scan(
+                expr = expr,
+                asAlias = asAlias,
+                atAlias = atAlias,
+                byAlias = byAlias,
+                metas = metas)
+        
+        
+        override fun join(
+            type: JoinType,
+            left: FromSource,
+            right: FromSource,
+            predicate: Expr?,
+            metas: MetaContainer
+        ): PartiqlBasic.FromSource.Join =
+            PartiqlBasic.FromSource.Join(
+                type = type,
+                left = left,
+                right = right,
+                predicate = predicate,
+                metas = metas)
+        
+        
+        // Variants for Sum: CaseSensitivity 
+        override fun caseSensitive(
+            metas: MetaContainer
+        ): PartiqlBasic.CaseSensitivity.CaseSensitive =
+            PartiqlBasic.CaseSensitivity.CaseSensitive(
+                metas = metas)
+        
+        
+        override fun caseInsensitive(
+            metas: MetaContainer
+        ): PartiqlBasic.CaseSensitivity.CaseInsensitive =
+            PartiqlBasic.CaseSensitivity.CaseInsensitive(
+                metas = metas)
+        
+        
+        // Variants for Sum: ScopeQualifier 
+        override fun unqualified(
+            metas: MetaContainer
+        ): PartiqlBasic.ScopeQualifier.Unqualified =
+            PartiqlBasic.ScopeQualifier.Unqualified(
+                metas = metas)
+        
+        
+        override fun qualified(
+            metas: MetaContainer
+        ): PartiqlBasic.ScopeQualifier.Qualified =
+            PartiqlBasic.ScopeQualifier.Qualified(
+                metas = metas)
+        
+        
+        // Variants for Sum: SetQuantifier 
+        override fun all(
+            metas: MetaContainer
+        ): PartiqlBasic.SetQuantifier.All =
+            PartiqlBasic.SetQuantifier.All(
+                metas = metas)
+        
+        
+        override fun distinct(
+            metas: MetaContainer
+        ): PartiqlBasic.SetQuantifier.Distinct =
+            PartiqlBasic.SetQuantifier.Distinct(
+                metas = metas)
+        
+        
+        // Variants for Sum: PathElement 
+        override fun pathExpr(
+            expr: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.PathElement.PathExpr =
+            PartiqlBasic.PathElement.PathExpr(
+                expr = expr,
+                metas = metas)
+        
+        
+        override fun pathWildcard(
+            metas: MetaContainer
+        ): PartiqlBasic.PathElement.PathWildcard =
+            PartiqlBasic.PathElement.PathWildcard(
+                metas = metas)
+        
+        
+        override fun pathUnpivot(
+            metas: MetaContainer
+        ): PartiqlBasic.PathElement.PathUnpivot =
+            PartiqlBasic.PathElement.PathUnpivot(
+                metas = metas)
+        
+        
+        // Variants for Sum: Expr 
+        override fun lit(
+            value: com.amazon.ionelement.api.IonElement,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Lit =
+            PartiqlBasic.Expr.Lit(
+                value = value.asAnyElement(),
+                metas = metas)
+        
+        
+        override fun id(
+            name: String,
+            case: CaseSensitivity,
+            scopeQualifier: ScopeQualifier,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Id =
+            PartiqlBasic.Expr.Id(
+                name = name.asPrimitive(),
+                case = case,
+                scopeQualifier = scopeQualifier,
+                metas = metas)
+        
+        override fun id_(
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            case: CaseSensitivity,
+            scopeQualifier: ScopeQualifier,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Id =
+            PartiqlBasic.Expr.Id(
+                name = name,
+                case = case,
+                scopeQualifier = scopeQualifier,
+                metas = metas)
+        
+        
+        override fun parameter(
+            index: Long,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Parameter =
+            PartiqlBasic.Expr.Parameter(
+                index = index.asPrimitive(),
+                metas = metas)
+        
+        override fun parameter_(
+            index: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Parameter =
+            PartiqlBasic.Expr.Parameter(
+                index = index,
+                metas = metas)
+        
+        
+        override fun not(
+            expr: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Not =
+            PartiqlBasic.Expr.Not(
+                expr = expr,
+                metas = metas)
+        
+        
+        override fun plus(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Plus =
+            PartiqlBasic.Expr.Plus(
+                operands = operands,
+                metas = metas)
+        
+        override fun plus(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Plus =
+            PartiqlBasic.Expr.Plus(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun minus(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Minus =
+            PartiqlBasic.Expr.Minus(
+                operands = operands,
+                metas = metas)
+        
+        override fun minus(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Minus =
+            PartiqlBasic.Expr.Minus(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun times(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Times =
+            PartiqlBasic.Expr.Times(
+                operands = operands,
+                metas = metas)
+        
+        override fun times(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Times =
+            PartiqlBasic.Expr.Times(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun divide(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Divide =
+            PartiqlBasic.Expr.Divide(
+                operands = operands,
+                metas = metas)
+        
+        override fun divide(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Divide =
+            PartiqlBasic.Expr.Divide(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun modulo(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Modulo =
+            PartiqlBasic.Expr.Modulo(
+                operands = operands,
+                metas = metas)
+        
+        override fun modulo(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Modulo =
+            PartiqlBasic.Expr.Modulo(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun concat(
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Concat =
+            PartiqlBasic.Expr.Concat(
+                operands = operands,
+                metas = metas)
+        
+        override fun concat(
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Concat =
+            PartiqlBasic.Expr.Concat(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas)
+        
+        
+        override fun like(
+            left: Expr,
+            right: Expr,
+            escape: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Like =
+            PartiqlBasic.Expr.Like(
+                left = left,
+                right = right,
+                escape = escape,
+                metas = metas)
+        
+        
+        override fun between(
+            value: Expr,
+            from: Expr,
+            to: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Between =
+            PartiqlBasic.Expr.Between(
+                value = value,
+                from = from,
+                to = to,
+                metas = metas)
+        
+        
+        override fun path(
+            root: Expr,
+            elements: kotlin.collections.List<PathElement>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Path =
+            PartiqlBasic.Expr.Path(
+                root = root,
+                elements = elements,
+                metas = metas)
+        
+        override fun path(
+            root: Expr,
+            elements0: PathElement,
+            vararg elements: PathElement,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Path =
+            PartiqlBasic.Expr.Path(
+                root = root,
+                elements = listOf(elements0) + elements.toList(),
+                metas = metas)
+        
+        
+        override fun call(
+            name: String,
+            args: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Call =
+            PartiqlBasic.Expr.Call(
+                name = name.asPrimitive(),
+                args = args,
+                metas = metas)
+        
+        override fun call_(
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            args: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Call =
+            PartiqlBasic.Expr.Call(
+                name = name,
+                args = args,
+                metas = metas)
+        
+        override fun call(
+            name: String,
+            args0: Expr,
+            vararg args: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Call =
+            PartiqlBasic.Expr.Call(
+                name = name.asPrimitive(),
+                args = listOf(args0) + args.toList(),
+                metas = metas)
+        
+        override fun call_(
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            args0: Expr,
+            vararg args: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Call =
+            PartiqlBasic.Expr.Call(
+                name = name,
+                args = listOf(args0) + args.toList(),
+                metas = metas)
+        
+        
+        override fun callAgg(
+            name: String,
+            setQuantifier: SetQuantifier,
+            arg: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.CallAgg =
+            PartiqlBasic.Expr.CallAgg(
+                name = name.asPrimitive(),
+                setQuantifier = setQuantifier,
+                arg = arg,
+                metas = metas)
+        
+        override fun callAgg_(
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            setQuantifier: SetQuantifier,
+            arg: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.CallAgg =
+            PartiqlBasic.Expr.CallAgg(
+                name = name,
+                setQuantifier = setQuantifier,
+                arg = arg,
+                metas = metas)
+        
+        
+        override fun simpleCase(
+            value: Expr,
+            branches: kotlin.collections.List<ExprPair>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.SimpleCase =
+            PartiqlBasic.Expr.SimpleCase(
+                value = value,
+                branches = branches,
+                metas = metas)
+        
+        override fun simpleCase(
+            value: Expr,
+            branches0: ExprPair,
+            vararg branches: ExprPair,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.SimpleCase =
+            PartiqlBasic.Expr.SimpleCase(
+                value = value,
+                branches = listOf(branches0) + branches.toList(),
+                metas = metas)
+        
+        
+        override fun searchedCase(
+            branches: kotlin.collections.List<ExprPair>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.SearchedCase =
+            PartiqlBasic.Expr.SearchedCase(
+                branches = branches,
+                metas = metas)
+        
+        override fun searchedCase(
+            branches0: ExprPair,
+            vararg branches: ExprPair,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.SearchedCase =
+            PartiqlBasic.Expr.SearchedCase(
+                branches = listOf(branches0) + branches.toList(),
+                metas = metas)
+        
+        
+        override fun struct(
+            fields: kotlin.collections.List<ExprPair>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Struct =
+            PartiqlBasic.Expr.Struct(
+                fields = fields,
+                metas = metas)
+        
+        override fun struct(
+            vararg fields: ExprPair,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Struct =
+            PartiqlBasic.Expr.Struct(
+                fields = fields.toList(),
+                metas = metas)
+        
+        
+        override fun bag(
+            values: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Bag =
+            PartiqlBasic.Expr.Bag(
+                values = values,
+                metas = metas)
+        
+        override fun bag(
+            vararg values: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.Bag =
+            PartiqlBasic.Expr.Bag(
+                values = values.toList(),
+                metas = metas)
+        
+        
+        override fun list(
+            values: kotlin.collections.List<Expr>,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.List =
+            PartiqlBasic.Expr.List(
+                values = values,
+                metas = metas)
+        
+        override fun list(
+            vararg values: Expr,
+            metas: MetaContainer
+        ): PartiqlBasic.Expr.List =
+            PartiqlBasic.Expr.List(
+                values = values.toList(),
+                metas = metas)
+        
+        
+        override fun select(
+            setq: SetQuantifier?,
+            project: Projection,
+            from: FromSource,
+            where: Expr?,
+            group: GroupBy?,
+            having: Expr?,
+            limit: Expr?,
+            metas: MetaContainer
         ): PartiqlBasic.Expr.Select =
             PartiqlBasic.Expr.Select(
                 setq = setq,


### PR DESCRIPTION
Fixes #48. Refactors the PIG `Builder` so the builder functions are defined in an interface with a private implementation. This ensures the builder functions can't be imported directly.

Also adds `@JvmStatic` for Java interop.

This is a potentially **breaking** change to any existing code that relies on importing these builder functions directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
