### PR TITLE
Avoid unnecessary copies in generated VisitorTransforms

### DIFF
--- a/pig-runtime/src/org/partiql/pig/runtime/DomainVisitorTransformBase.kt
+++ b/pig-runtime/src/org/partiql/pig/runtime/DomainVisitorTransformBase.kt
@@ -26,23 +26,39 @@ import com.amazon.ionelement.api.MetaContainer
 abstract class DomainVisitorTransformBase {
     open fun transformMetas(metas: MetaContainer) = metas
 
-    open fun transformAnyElement(node: AnyElement): AnyElement =
-        // TODO:  remove .asAnyElement() below when https://github.com/amzn/ion-element-kotlin/issues/36 is fixed.
-        node.copy(metas = transformMetas(node.metas)).asAnyElement()
+    open fun transformAnyElement(node: AnyElement): AnyElement {
+        val newMetas = transformMetas(node.metas)
+        return if(node.metas !== newMetas) {
+            // TODO:  remove .asAnyElement() below when https://github.com/amzn/ion-element-kotlin/issues/36 is fixed.
+            node.copy(metas = newMetas).asAnyElement()
+        } else {
+            node
+        }
+    }
 
-    open fun transformSymbolPrimitive(sym: SymbolPrimitive) =
-        SymbolPrimitive(
-            transformSymbolPrimitiveText(sym),
-            transformSymbolPrimitiveMetas(sym))
+    open fun transformSymbolPrimitive(sym: SymbolPrimitive): SymbolPrimitive {
+        val newText = transformSymbolPrimitiveText(sym)
+        val newMetas = transformSymbolPrimitiveMetas(sym)
+        return if(sym.text != newText || sym.metas !== newMetas) {
+            SymbolPrimitive(newText, newMetas)
+        } else {
+            sym
+        }
+    }
 
     open fun transformSymbolPrimitiveText(sym: SymbolPrimitive) = sym.text
 
     open fun transformSymbolPrimitiveMetas(sym: SymbolPrimitive) = transformMetas(sym.metas)
 
-    open fun transformLongPrimitive(lng: LongPrimitive) =
-        LongPrimitive(
-            transformLongPrimitiveValue(lng),
-            transformLongPrimitiveMetas(lng))
+    open fun transformLongPrimitive(lng: LongPrimitive): LongPrimitive {
+        val newValue = transformLongPrimitiveValue(lng)
+        val newMetas = transformLongPrimitiveMetas(lng)
+        return if(lng.value != newValue || lng.metas !== newMetas) {
+            LongPrimitive(newValue, newMetas)
+        } else {
+            lng
+        }
+    }
 
     open fun transformLongPrimitiveValue(sym: LongPrimitive): Long = sym.value
 

--- a/pig-runtime/src/org/partiql/pig/runtime/DomainVisitorTransformBase.kt
+++ b/pig-runtime/src/org/partiql/pig/runtime/DomainVisitorTransformBase.kt
@@ -29,7 +29,6 @@ abstract class DomainVisitorTransformBase {
     open fun transformAnyElement(node: AnyElement): AnyElement {
         val newMetas = transformMetas(node.metas)
         return if(node.metas !== newMetas) {
-            // TODO:  remove .asAnyElement() below when https://github.com/amzn/ion-element-kotlin/issues/36 is fixed.
             node.copy(metas = newMetas).asAnyElement()
         } else {
             node

--- a/pig-tests/src/org/partiql/pig/tests/generated/partiql-basic.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/partiql-basic.kt
@@ -5180,11 +5180,19 @@ class PartiqlBasic private constructor() {
             val new_first = transformExprPair_first(node)
             val new_second = transformExprPair_second(node)
             val new_metas = transformExprPair_metas(node)
-            return PartiqlBasic.ExprPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.ExprPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprPair_first(node: PartiqlBasic.ExprPair) =
             transformExpr(node.first)
@@ -5198,11 +5206,19 @@ class PartiqlBasic private constructor() {
             val new_value = transformGroupByItem_value(node)
             val new_asAlias = transformGroupByItem_asAlias(node)
             val new_metas = transformGroupByItem_metas(node)
-            return PartiqlBasic.GroupByItem(
+            return if (
+                node.value !== new_value ||
+                node.asAlias !== new_asAlias ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.GroupByItem(
                     value = new_value,
                     asAlias = new_asAlias,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformGroupByItem_value(node: PartiqlBasic.GroupByItem) =
             transformExpr(node.value)
@@ -5215,10 +5231,17 @@ class PartiqlBasic private constructor() {
         open fun transformGroupByList(node: PartiqlBasic.GroupByList): PartiqlBasic.GroupByList {
             val new_items = transformGroupByList_items(node)
             val new_metas = transformGroupByList_metas(node)
-            return PartiqlBasic.GroupByList(
+            return if (
+                node.items !== new_items ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.GroupByList(
                     items = new_items,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformGroupByList_items(node: PartiqlBasic.GroupByList) =
             node.items.map { transformGroupByItem(it) }
@@ -5230,11 +5253,19 @@ class PartiqlBasic private constructor() {
             val new_items = transformGroupBy_items(node)
             val new_groupAsAlias = transformGroupBy_groupAsAlias(node)
             val new_metas = transformGroupBy_metas(node)
-            return PartiqlBasic.GroupBy(
+            return if (
+                node.items !== new_items ||
+                node.groupAsAlias !== new_groupAsAlias ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.GroupBy(
                     items = new_items,
                     groupAsAlias = new_groupAsAlias,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformGroupBy_items(node: PartiqlBasic.GroupBy) =
             transformGroupByList(node.items)
@@ -5255,10 +5286,17 @@ class PartiqlBasic private constructor() {
         open fun transformProjectionProjectList(node: PartiqlBasic.Projection.ProjectList): PartiqlBasic.Projection  {
             val new_items = transformProjectionProjectList_items(node)
             val new_metas = transformProjectionProjectList_metas(node)
-            return PartiqlBasic.Projection.ProjectList(
+            return if (
+                node.items !== new_items ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Projection.ProjectList(
                     items = new_items,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformProjectionProjectList_items(node: PartiqlBasic.Projection.ProjectList) =
             node.items.map { transformProjectItem(it) }
@@ -5269,10 +5307,17 @@ class PartiqlBasic private constructor() {
         open fun transformProjectionProjectValue(node: PartiqlBasic.Projection.ProjectValue): PartiqlBasic.Projection  {
             val new_value = transformProjectionProjectValue_value(node)
             val new_metas = transformProjectionProjectValue_metas(node)
-            return PartiqlBasic.Projection.ProjectValue(
+            return if (
+                node.value !== new_value ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Projection.ProjectValue(
                     value = new_value,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformProjectionProjectValue_value(node: PartiqlBasic.Projection.ProjectValue) =
             transformExpr(node.value)
@@ -5290,9 +5335,15 @@ class PartiqlBasic private constructor() {
         // Variant ProjectItemProjectAll
         open fun transformProjectItemProjectAll(node: PartiqlBasic.ProjectItem.ProjectAll): PartiqlBasic.ProjectItem  {
             val new_metas = transformProjectItemProjectAll_metas(node)
-            return PartiqlBasic.ProjectItem.ProjectAll(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.ProjectItem.ProjectAll(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformProjectItemProjectAll_metas(node: PartiqlBasic.ProjectItem.ProjectAll) =
             transformMetas(node.metas)
@@ -5302,11 +5353,19 @@ class PartiqlBasic private constructor() {
             val new_value = transformProjectItemProjectExpr_value(node)
             val new_asAlias = transformProjectItemProjectExpr_asAlias(node)
             val new_metas = transformProjectItemProjectExpr_metas(node)
-            return PartiqlBasic.ProjectItem.ProjectExpr(
+            return if (
+                node.value !== new_value ||
+                node.asAlias !== new_asAlias ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.ProjectItem.ProjectExpr(
                     value = new_value,
                     asAlias = new_asAlias,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformProjectItemProjectExpr_value(node: PartiqlBasic.ProjectItem.ProjectExpr) =
             transformExpr(node.value)
@@ -5328,9 +5387,15 @@ class PartiqlBasic private constructor() {
         // Variant JoinTypeInner
         open fun transformJoinTypeInner(node: PartiqlBasic.JoinType.Inner): PartiqlBasic.JoinType  {
             val new_metas = transformJoinTypeInner_metas(node)
-            return PartiqlBasic.JoinType.Inner(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.JoinType.Inner(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformJoinTypeInner_metas(node: PartiqlBasic.JoinType.Inner) =
             transformMetas(node.metas)
@@ -5338,9 +5403,15 @@ class PartiqlBasic private constructor() {
         // Variant JoinTypeLeft
         open fun transformJoinTypeLeft(node: PartiqlBasic.JoinType.Left): PartiqlBasic.JoinType  {
             val new_metas = transformJoinTypeLeft_metas(node)
-            return PartiqlBasic.JoinType.Left(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.JoinType.Left(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformJoinTypeLeft_metas(node: PartiqlBasic.JoinType.Left) =
             transformMetas(node.metas)
@@ -5348,9 +5419,15 @@ class PartiqlBasic private constructor() {
         // Variant JoinTypeRight
         open fun transformJoinTypeRight(node: PartiqlBasic.JoinType.Right): PartiqlBasic.JoinType  {
             val new_metas = transformJoinTypeRight_metas(node)
-            return PartiqlBasic.JoinType.Right(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.JoinType.Right(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformJoinTypeRight_metas(node: PartiqlBasic.JoinType.Right) =
             transformMetas(node.metas)
@@ -5358,9 +5435,15 @@ class PartiqlBasic private constructor() {
         // Variant JoinTypeOuter
         open fun transformJoinTypeOuter(node: PartiqlBasic.JoinType.Outer): PartiqlBasic.JoinType  {
             val new_metas = transformJoinTypeOuter_metas(node)
-            return PartiqlBasic.JoinType.Outer(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.JoinType.Outer(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformJoinTypeOuter_metas(node: PartiqlBasic.JoinType.Outer) =
             transformMetas(node.metas)
@@ -5380,13 +5463,23 @@ class PartiqlBasic private constructor() {
             val new_atAlias = transformFromSourceScan_atAlias(node)
             val new_byAlias = transformFromSourceScan_byAlias(node)
             val new_metas = transformFromSourceScan_metas(node)
-            return PartiqlBasic.FromSource.Scan(
+            return if (
+                node.expr !== new_expr ||
+                node.asAlias !== new_asAlias ||
+                node.atAlias !== new_atAlias ||
+                node.byAlias !== new_byAlias ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.FromSource.Scan(
                     expr = new_expr,
                     asAlias = new_asAlias,
                     atAlias = new_atAlias,
                     byAlias = new_byAlias,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformFromSourceScan_expr(node: PartiqlBasic.FromSource.Scan) =
             transformExpr(node.expr)
@@ -5406,13 +5499,23 @@ class PartiqlBasic private constructor() {
             val new_right = transformFromSourceJoin_right(node)
             val new_predicate = transformFromSourceJoin_predicate(node)
             val new_metas = transformFromSourceJoin_metas(node)
-            return PartiqlBasic.FromSource.Join(
+            return if (
+                node.type !== new_type ||
+                node.left !== new_left ||
+                node.right !== new_right ||
+                node.predicate !== new_predicate ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.FromSource.Join(
                     type = new_type,
                     left = new_left,
                     right = new_right,
                     predicate = new_predicate,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformFromSourceJoin_type(node: PartiqlBasic.FromSource.Join) =
             transformJoinType(node.type)
@@ -5436,9 +5539,15 @@ class PartiqlBasic private constructor() {
         // Variant CaseSensitivityCaseSensitive
         open fun transformCaseSensitivityCaseSensitive(node: PartiqlBasic.CaseSensitivity.CaseSensitive): PartiqlBasic.CaseSensitivity  {
             val new_metas = transformCaseSensitivityCaseSensitive_metas(node)
-            return PartiqlBasic.CaseSensitivity.CaseSensitive(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.CaseSensitivity.CaseSensitive(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformCaseSensitivityCaseSensitive_metas(node: PartiqlBasic.CaseSensitivity.CaseSensitive) =
             transformMetas(node.metas)
@@ -5446,9 +5555,15 @@ class PartiqlBasic private constructor() {
         // Variant CaseSensitivityCaseInsensitive
         open fun transformCaseSensitivityCaseInsensitive(node: PartiqlBasic.CaseSensitivity.CaseInsensitive): PartiqlBasic.CaseSensitivity  {
             val new_metas = transformCaseSensitivityCaseInsensitive_metas(node)
-            return PartiqlBasic.CaseSensitivity.CaseInsensitive(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.CaseSensitivity.CaseInsensitive(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformCaseSensitivityCaseInsensitive_metas(node: PartiqlBasic.CaseSensitivity.CaseInsensitive) =
             transformMetas(node.metas)
@@ -5464,9 +5579,15 @@ class PartiqlBasic private constructor() {
         // Variant ScopeQualifierUnqualified
         open fun transformScopeQualifierUnqualified(node: PartiqlBasic.ScopeQualifier.Unqualified): PartiqlBasic.ScopeQualifier  {
             val new_metas = transformScopeQualifierUnqualified_metas(node)
-            return PartiqlBasic.ScopeQualifier.Unqualified(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.ScopeQualifier.Unqualified(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformScopeQualifierUnqualified_metas(node: PartiqlBasic.ScopeQualifier.Unqualified) =
             transformMetas(node.metas)
@@ -5474,9 +5595,15 @@ class PartiqlBasic private constructor() {
         // Variant ScopeQualifierQualified
         open fun transformScopeQualifierQualified(node: PartiqlBasic.ScopeQualifier.Qualified): PartiqlBasic.ScopeQualifier  {
             val new_metas = transformScopeQualifierQualified_metas(node)
-            return PartiqlBasic.ScopeQualifier.Qualified(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.ScopeQualifier.Qualified(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformScopeQualifierQualified_metas(node: PartiqlBasic.ScopeQualifier.Qualified) =
             transformMetas(node.metas)
@@ -5492,9 +5619,15 @@ class PartiqlBasic private constructor() {
         // Variant SetQuantifierAll
         open fun transformSetQuantifierAll(node: PartiqlBasic.SetQuantifier.All): PartiqlBasic.SetQuantifier  {
             val new_metas = transformSetQuantifierAll_metas(node)
-            return PartiqlBasic.SetQuantifier.All(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.SetQuantifier.All(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSetQuantifierAll_metas(node: PartiqlBasic.SetQuantifier.All) =
             transformMetas(node.metas)
@@ -5502,9 +5635,15 @@ class PartiqlBasic private constructor() {
         // Variant SetQuantifierDistinct
         open fun transformSetQuantifierDistinct(node: PartiqlBasic.SetQuantifier.Distinct): PartiqlBasic.SetQuantifier  {
             val new_metas = transformSetQuantifierDistinct_metas(node)
-            return PartiqlBasic.SetQuantifier.Distinct(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.SetQuantifier.Distinct(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSetQuantifierDistinct_metas(node: PartiqlBasic.SetQuantifier.Distinct) =
             transformMetas(node.metas)
@@ -5522,10 +5661,17 @@ class PartiqlBasic private constructor() {
         open fun transformPathElementPathExpr(node: PartiqlBasic.PathElement.PathExpr): PartiqlBasic.PathElement  {
             val new_expr = transformPathElementPathExpr_expr(node)
             val new_metas = transformPathElementPathExpr_metas(node)
-            return PartiqlBasic.PathElement.PathExpr(
+            return if (
+                node.expr !== new_expr ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.PathElement.PathExpr(
                     expr = new_expr,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformPathElementPathExpr_expr(node: PartiqlBasic.PathElement.PathExpr) =
             transformExpr(node.expr)
@@ -5535,9 +5681,15 @@ class PartiqlBasic private constructor() {
         // Variant PathElementPathWildcard
         open fun transformPathElementPathWildcard(node: PartiqlBasic.PathElement.PathWildcard): PartiqlBasic.PathElement  {
             val new_metas = transformPathElementPathWildcard_metas(node)
-            return PartiqlBasic.PathElement.PathWildcard(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.PathElement.PathWildcard(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformPathElementPathWildcard_metas(node: PartiqlBasic.PathElement.PathWildcard) =
             transformMetas(node.metas)
@@ -5545,9 +5697,15 @@ class PartiqlBasic private constructor() {
         // Variant PathElementPathUnpivot
         open fun transformPathElementPathUnpivot(node: PartiqlBasic.PathElement.PathUnpivot): PartiqlBasic.PathElement  {
             val new_metas = transformPathElementPathUnpivot_metas(node)
-            return PartiqlBasic.PathElement.PathUnpivot(
+            return if (
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.PathElement.PathUnpivot(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformPathElementPathUnpivot_metas(node: PartiqlBasic.PathElement.PathUnpivot) =
             transformMetas(node.metas)
@@ -5583,10 +5741,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprLit(node: PartiqlBasic.Expr.Lit): PartiqlBasic.Expr  {
             val new_value = transformExprLit_value(node)
             val new_metas = transformExprLit_metas(node)
-            return PartiqlBasic.Expr.Lit(
+            return if (
+                node.value !== new_value ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Lit(
                     value = new_value,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprLit_value(node: PartiqlBasic.Expr.Lit) =
             transformAnyElement(node.value)
@@ -5599,12 +5764,21 @@ class PartiqlBasic private constructor() {
             val new_case = transformExprId_case(node)
             val new_scopeQualifier = transformExprId_scopeQualifier(node)
             val new_metas = transformExprId_metas(node)
-            return PartiqlBasic.Expr.Id(
+            return if (
+                node.name !== new_name ||
+                node.case !== new_case ||
+                node.scopeQualifier !== new_scopeQualifier ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Id(
                     name = new_name,
                     case = new_case,
                     scopeQualifier = new_scopeQualifier,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprId_name(node: PartiqlBasic.Expr.Id) =
             transformSymbolPrimitive(node.name)
@@ -5619,10 +5793,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprParameter(node: PartiqlBasic.Expr.Parameter): PartiqlBasic.Expr  {
             val new_index = transformExprParameter_index(node)
             val new_metas = transformExprParameter_metas(node)
-            return PartiqlBasic.Expr.Parameter(
+            return if (
+                node.index !== new_index ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Parameter(
                     index = new_index,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprParameter_index(node: PartiqlBasic.Expr.Parameter) =
             transformLongPrimitive(node.index)
@@ -5633,10 +5814,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprNot(node: PartiqlBasic.Expr.Not): PartiqlBasic.Expr  {
             val new_expr = transformExprNot_expr(node)
             val new_metas = transformExprNot_metas(node)
-            return PartiqlBasic.Expr.Not(
+            return if (
+                node.expr !== new_expr ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Not(
                     expr = new_expr,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprNot_expr(node: PartiqlBasic.Expr.Not) =
             transformExpr(node.expr)
@@ -5647,10 +5835,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprPlus(node: PartiqlBasic.Expr.Plus): PartiqlBasic.Expr  {
             val new_operands = transformExprPlus_operands(node)
             val new_metas = transformExprPlus_metas(node)
-            return PartiqlBasic.Expr.Plus(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Plus(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprPlus_operands(node: PartiqlBasic.Expr.Plus) =
             node.operands.map { transformExpr(it) }
@@ -5661,10 +5856,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprMinus(node: PartiqlBasic.Expr.Minus): PartiqlBasic.Expr  {
             val new_operands = transformExprMinus_operands(node)
             val new_metas = transformExprMinus_metas(node)
-            return PartiqlBasic.Expr.Minus(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Minus(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprMinus_operands(node: PartiqlBasic.Expr.Minus) =
             node.operands.map { transformExpr(it) }
@@ -5675,10 +5877,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprTimes(node: PartiqlBasic.Expr.Times): PartiqlBasic.Expr  {
             val new_operands = transformExprTimes_operands(node)
             val new_metas = transformExprTimes_metas(node)
-            return PartiqlBasic.Expr.Times(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Times(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprTimes_operands(node: PartiqlBasic.Expr.Times) =
             node.operands.map { transformExpr(it) }
@@ -5689,10 +5898,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprDivide(node: PartiqlBasic.Expr.Divide): PartiqlBasic.Expr  {
             val new_operands = transformExprDivide_operands(node)
             val new_metas = transformExprDivide_metas(node)
-            return PartiqlBasic.Expr.Divide(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Divide(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprDivide_operands(node: PartiqlBasic.Expr.Divide) =
             node.operands.map { transformExpr(it) }
@@ -5703,10 +5919,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprModulo(node: PartiqlBasic.Expr.Modulo): PartiqlBasic.Expr  {
             val new_operands = transformExprModulo_operands(node)
             val new_metas = transformExprModulo_metas(node)
-            return PartiqlBasic.Expr.Modulo(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Modulo(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprModulo_operands(node: PartiqlBasic.Expr.Modulo) =
             node.operands.map { transformExpr(it) }
@@ -5717,10 +5940,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprConcat(node: PartiqlBasic.Expr.Concat): PartiqlBasic.Expr  {
             val new_operands = transformExprConcat_operands(node)
             val new_metas = transformExprConcat_metas(node)
-            return PartiqlBasic.Expr.Concat(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Concat(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprConcat_operands(node: PartiqlBasic.Expr.Concat) =
             node.operands.map { transformExpr(it) }
@@ -5733,12 +5963,21 @@ class PartiqlBasic private constructor() {
             val new_right = transformExprLike_right(node)
             val new_escape = transformExprLike_escape(node)
             val new_metas = transformExprLike_metas(node)
-            return PartiqlBasic.Expr.Like(
+            return if (
+                node.left !== new_left ||
+                node.right !== new_right ||
+                node.escape !== new_escape ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Like(
                     left = new_left,
                     right = new_right,
                     escape = new_escape,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprLike_left(node: PartiqlBasic.Expr.Like) =
             transformExpr(node.left)
@@ -5755,12 +5994,21 @@ class PartiqlBasic private constructor() {
             val new_from = transformExprBetween_from(node)
             val new_to = transformExprBetween_to(node)
             val new_metas = transformExprBetween_metas(node)
-            return PartiqlBasic.Expr.Between(
+            return if (
+                node.value !== new_value ||
+                node.from !== new_from ||
+                node.to !== new_to ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Between(
                     value = new_value,
                     from = new_from,
                     to = new_to,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprBetween_value(node: PartiqlBasic.Expr.Between) =
             transformExpr(node.value)
@@ -5776,11 +6024,19 @@ class PartiqlBasic private constructor() {
             val new_root = transformExprPath_root(node)
             val new_elements = transformExprPath_elements(node)
             val new_metas = transformExprPath_metas(node)
-            return PartiqlBasic.Expr.Path(
+            return if (
+                node.root !== new_root ||
+                node.elements !== new_elements ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Path(
                     root = new_root,
                     elements = new_elements,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprPath_root(node: PartiqlBasic.Expr.Path) =
             transformExpr(node.root)
@@ -5794,11 +6050,19 @@ class PartiqlBasic private constructor() {
             val new_name = transformExprCall_name(node)
             val new_args = transformExprCall_args(node)
             val new_metas = transformExprCall_metas(node)
-            return PartiqlBasic.Expr.Call(
+            return if (
+                node.name !== new_name ||
+                node.args !== new_args ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Call(
                     name = new_name,
                     args = new_args,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprCall_name(node: PartiqlBasic.Expr.Call) =
             transformSymbolPrimitive(node.name)
@@ -5813,12 +6077,21 @@ class PartiqlBasic private constructor() {
             val new_setQuantifier = transformExprCallAgg_setQuantifier(node)
             val new_arg = transformExprCallAgg_arg(node)
             val new_metas = transformExprCallAgg_metas(node)
-            return PartiqlBasic.Expr.CallAgg(
+            return if (
+                node.name !== new_name ||
+                node.setQuantifier !== new_setQuantifier ||
+                node.arg !== new_arg ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.CallAgg(
                     name = new_name,
                     setQuantifier = new_setQuantifier,
                     arg = new_arg,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprCallAgg_name(node: PartiqlBasic.Expr.CallAgg) =
             transformSymbolPrimitive(node.name)
@@ -5834,11 +6107,19 @@ class PartiqlBasic private constructor() {
             val new_value = transformExprSimpleCase_value(node)
             val new_branches = transformExprSimpleCase_branches(node)
             val new_metas = transformExprSimpleCase_metas(node)
-            return PartiqlBasic.Expr.SimpleCase(
+            return if (
+                node.value !== new_value ||
+                node.branches !== new_branches ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.SimpleCase(
                     value = new_value,
                     branches = new_branches,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprSimpleCase_value(node: PartiqlBasic.Expr.SimpleCase) =
             transformExpr(node.value)
@@ -5851,10 +6132,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprSearchedCase(node: PartiqlBasic.Expr.SearchedCase): PartiqlBasic.Expr  {
             val new_branches = transformExprSearchedCase_branches(node)
             val new_metas = transformExprSearchedCase_metas(node)
-            return PartiqlBasic.Expr.SearchedCase(
+            return if (
+                node.branches !== new_branches ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.SearchedCase(
                     branches = new_branches,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprSearchedCase_branches(node: PartiqlBasic.Expr.SearchedCase) =
             node.branches.map { transformExprPair(it) }
@@ -5865,10 +6153,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprStruct(node: PartiqlBasic.Expr.Struct): PartiqlBasic.Expr  {
             val new_fields = transformExprStruct_fields(node)
             val new_metas = transformExprStruct_metas(node)
-            return PartiqlBasic.Expr.Struct(
+            return if (
+                node.fields !== new_fields ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Struct(
                     fields = new_fields,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprStruct_fields(node: PartiqlBasic.Expr.Struct) =
             node.fields.map { transformExprPair(it) }
@@ -5879,10 +6174,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprBag(node: PartiqlBasic.Expr.Bag): PartiqlBasic.Expr  {
             val new_values = transformExprBag_values(node)
             val new_metas = transformExprBag_metas(node)
-            return PartiqlBasic.Expr.Bag(
+            return if (
+                node.values !== new_values ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Bag(
                     values = new_values,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprBag_values(node: PartiqlBasic.Expr.Bag) =
             node.values.map { transformExpr(it) }
@@ -5893,10 +6195,17 @@ class PartiqlBasic private constructor() {
         open fun transformExprList(node: PartiqlBasic.Expr.List): PartiqlBasic.Expr  {
             val new_values = transformExprList_values(node)
             val new_metas = transformExprList_metas(node)
-            return PartiqlBasic.Expr.List(
+            return if (
+                node.values !== new_values ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.List(
                     values = new_values,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprList_values(node: PartiqlBasic.Expr.List) =
             node.values.map { transformExpr(it) }
@@ -5913,7 +6222,17 @@ class PartiqlBasic private constructor() {
             val new_having = transformExprSelect_having(node)
             val new_limit = transformExprSelect_limit(node)
             val new_metas = transformExprSelect_metas(node)
-            return PartiqlBasic.Expr.Select(
+            return if (
+                node.setq !== new_setq ||
+                node.project !== new_project ||
+                node.from !== new_from ||
+                node.where !== new_where ||
+                node.group !== new_group ||
+                node.having !== new_having ||
+                node.limit !== new_limit ||
+                node.metas !== new_metas
+            ) {
+                PartiqlBasic.Expr.Select(
                     setq = new_setq,
                     project = new_project,
                     from = new_from,
@@ -5923,6 +6242,9 @@ class PartiqlBasic private constructor() {
                     limit = new_limit,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprSelect_setq(node: PartiqlBasic.Expr.Select) =
             node.setq?.let { transformSetQuantifier(it) }

--- a/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
@@ -4419,11 +4419,19 @@ class TestDomain private constructor() {
             val new_first = transformIntPair_first(node)
             val new_second = transformIntPair_second(node)
             val new_metas = transformIntPair_metas(node)
-            return TestDomain.IntPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.IntPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformIntPair_first(node: TestDomain.IntPair) =
             transformLongPrimitive(node.first)
@@ -4437,11 +4445,19 @@ class TestDomain private constructor() {
             val new_first = transformSymbolPair_first(node)
             val new_second = transformSymbolPair_second(node)
             val new_metas = transformSymbolPair_metas(node)
-            return TestDomain.SymbolPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.SymbolPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSymbolPair_first(node: TestDomain.SymbolPair) =
             transformSymbolPrimitive(node.first)
@@ -4455,11 +4471,19 @@ class TestDomain private constructor() {
             val new_first = transformIonPair_first(node)
             val new_second = transformIonPair_second(node)
             val new_metas = transformIonPair_metas(node)
-            return TestDomain.IonPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.IonPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformIonPair_first(node: TestDomain.IonPair) =
             transformAnyElement(node.first)
@@ -4473,11 +4497,19 @@ class TestDomain private constructor() {
             val new_first = transformIntSymbolPair_first(node)
             val new_second = transformIntSymbolPair_second(node)
             val new_metas = transformIntSymbolPair_metas(node)
-            return TestDomain.IntSymbolPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.IntSymbolPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformIntSymbolPair_first(node: TestDomain.IntSymbolPair) =
             transformLongPrimitive(node.first)
@@ -4491,11 +4523,19 @@ class TestDomain private constructor() {
             val new_first = transformSymbolIntPair_first(node)
             val new_second = transformSymbolIntPair_second(node)
             val new_metas = transformSymbolIntPair_metas(node)
-            return TestDomain.SymbolIntPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.SymbolIntPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSymbolIntPair_first(node: TestDomain.SymbolIntPair) =
             transformSymbolPrimitive(node.first)
@@ -4509,11 +4549,19 @@ class TestDomain private constructor() {
             val new_first = transformIonIntPair_first(node)
             val new_second = transformIonIntPair_second(node)
             val new_metas = transformIonIntPair_metas(node)
-            return TestDomain.IonIntPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.IonIntPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformIonIntPair_first(node: TestDomain.IonIntPair) =
             transformAnyElement(node.first)
@@ -4527,11 +4575,19 @@ class TestDomain private constructor() {
             val new_first = transformIonSymbolPair_first(node)
             val new_second = transformIonSymbolPair_second(node)
             val new_metas = transformIonSymbolPair_metas(node)
-            return TestDomain.IonSymbolPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.IonSymbolPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformIonSymbolPair_first(node: TestDomain.IonSymbolPair) =
             transformAnyElement(node.first)
@@ -4545,11 +4601,19 @@ class TestDomain private constructor() {
             val new_first = transformIntPairPair_first(node)
             val new_second = transformIntPairPair_second(node)
             val new_metas = transformIntPairPair_metas(node)
-            return TestDomain.IntPairPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.IntPairPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformIntPairPair_first(node: TestDomain.IntPairPair) =
             transformIntPair(node.first)
@@ -4563,11 +4627,19 @@ class TestDomain private constructor() {
             val new_first = transformSymbolPairPair_first(node)
             val new_second = transformSymbolPairPair_second(node)
             val new_metas = transformSymbolPairPair_metas(node)
-            return TestDomain.SymbolPairPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.SymbolPairPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSymbolPairPair_first(node: TestDomain.SymbolPairPair) =
             transformSymbolPair(node.first)
@@ -4581,11 +4653,19 @@ class TestDomain private constructor() {
             val new_first = transformIonPairPair_first(node)
             val new_second = transformIonPairPair_second(node)
             val new_metas = transformIonPairPair_metas(node)
-            return TestDomain.IonPairPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.IonPairPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformIonPairPair_first(node: TestDomain.IonPairPair) =
             transformIonPair(node.first)
@@ -4599,11 +4679,19 @@ class TestDomain private constructor() {
             val new_first = transformRecursivePair_first(node)
             val new_second = transformRecursivePair_second(node)
             val new_metas = transformRecursivePair_metas(node)
-            return TestDomain.RecursivePair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.RecursivePair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformRecursivePair_first(node: TestDomain.RecursivePair) =
             transformLongPrimitive(node.first)
@@ -4617,11 +4705,19 @@ class TestDomain private constructor() {
             val new_first = transformAnswerPair_first(node)
             val new_second = transformAnswerPair_second(node)
             val new_metas = transformAnswerPair_metas(node)
-            return TestDomain.AnswerPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.AnswerPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAnswerPair_first(node: TestDomain.AnswerPair) =
             transformAnswer(node.first)
@@ -4635,11 +4731,19 @@ class TestDomain private constructor() {
             val new_first = transformAnswerIntPair_first(node)
             val new_second = transformAnswerIntPair_second(node)
             val new_metas = transformAnswerIntPair_metas(node)
-            return TestDomain.AnswerIntPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.AnswerIntPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAnswerIntPair_first(node: TestDomain.AnswerIntPair) =
             transformAnswer(node.first)
@@ -4653,11 +4757,19 @@ class TestDomain private constructor() {
             val new_first = transformIntAnswerPair_first(node)
             val new_second = transformIntAnswerPair_second(node)
             val new_metas = transformIntAnswerPair_metas(node)
-            return TestDomain.IntAnswerPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.IntAnswerPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformIntAnswerPair_first(node: TestDomain.IntAnswerPair) =
             transformLongPrimitive(node.first)
@@ -4671,11 +4783,19 @@ class TestDomain private constructor() {
             val new_first = transformSymbolAnswerPair_first(node)
             val new_second = transformSymbolAnswerPair_second(node)
             val new_metas = transformSymbolAnswerPair_metas(node)
-            return TestDomain.SymbolAnswerPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.SymbolAnswerPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSymbolAnswerPair_first(node: TestDomain.SymbolAnswerPair) =
             transformSymbolPrimitive(node.first)
@@ -4689,11 +4809,19 @@ class TestDomain private constructor() {
             val new_first = transformAnswerSymbolPair_first(node)
             val new_second = transformAnswerSymbolPair_second(node)
             val new_metas = transformAnswerSymbolPair_metas(node)
-            return TestDomain.AnswerSymbolPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.AnswerSymbolPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAnswerSymbolPair_first(node: TestDomain.AnswerSymbolPair) =
             transformAnswer(node.first)
@@ -4706,10 +4834,17 @@ class TestDomain private constructor() {
         open fun transformVariadicMin0(node: TestDomain.VariadicMin0): TestDomain.VariadicMin0 {
             val new_ints = transformVariadicMin0_ints(node)
             val new_metas = transformVariadicMin0_metas(node)
-            return TestDomain.VariadicMin0(
+            return if (
+                node.ints !== new_ints ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.VariadicMin0(
                     ints = new_ints,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformVariadicMin0_ints(node: TestDomain.VariadicMin0) =
             node.ints.map { transformLongPrimitive(it) }
@@ -4720,10 +4855,17 @@ class TestDomain private constructor() {
         open fun transformVariadicMin1(node: TestDomain.VariadicMin1): TestDomain.VariadicMin1 {
             val new_ints = transformVariadicMin1_ints(node)
             val new_metas = transformVariadicMin1_metas(node)
-            return TestDomain.VariadicMin1(
+            return if (
+                node.ints !== new_ints ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.VariadicMin1(
                     ints = new_ints,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformVariadicMin1_ints(node: TestDomain.VariadicMin1) =
             node.ints.map { transformLongPrimitive(it) }
@@ -4735,11 +4877,19 @@ class TestDomain private constructor() {
             val new_name = transformElementVariadic_name(node)
             val new_ints = transformElementVariadic_ints(node)
             val new_metas = transformElementVariadic_metas(node)
-            return TestDomain.ElementVariadic(
+            return if (
+                node.name !== new_name ||
+                node.ints !== new_ints ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.ElementVariadic(
                     name = new_name,
                     ints = new_ints,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformElementVariadic_name(node: TestDomain.ElementVariadic) =
             transformSymbolPrimitive(node.name)
@@ -4752,10 +4902,17 @@ class TestDomain private constructor() {
         open fun transformOptional1(node: TestDomain.Optional1): TestDomain.Optional1 {
             val new_value = transformOptional1_value(node)
             val new_metas = transformOptional1_metas(node)
-            return TestDomain.Optional1(
+            return if (
+                node.value !== new_value ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.Optional1(
                     value = new_value,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformOptional1_value(node: TestDomain.Optional1) =
             node.value?.let { transformLongPrimitive(it) }
@@ -4767,11 +4924,19 @@ class TestDomain private constructor() {
             val new_first = transformOptional2_first(node)
             val new_second = transformOptional2_second(node)
             val new_metas = transformOptional2_metas(node)
-            return TestDomain.Optional2(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.Optional2(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformOptional2_first(node: TestDomain.Optional2) =
             node.first?.let { transformLongPrimitive(it) }
@@ -4786,12 +4951,21 @@ class TestDomain private constructor() {
             val new_anotherField = transformDomainLevelRecord_anotherField(node)
             val new_optionalField = transformDomainLevelRecord_optionalField(node)
             val new_metas = transformDomainLevelRecord_metas(node)
-            return TestDomain.DomainLevelRecord(
+            return if (
+                node.someField !== new_someField ||
+                node.anotherField !== new_anotherField ||
+                node.optionalField !== new_optionalField ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.DomainLevelRecord(
                     someField = new_someField,
                     anotherField = new_anotherField,
                     optionalField = new_optionalField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformDomainLevelRecord_someField(node: TestDomain.DomainLevelRecord) =
             transformLongPrimitive(node.someField)
@@ -4807,11 +4981,19 @@ class TestDomain private constructor() {
             val new_value = transformProductWithRecord_value(node)
             val new_dlr = transformProductWithRecord_dlr(node)
             val new_metas = transformProductWithRecord_metas(node)
-            return TestDomain.ProductWithRecord(
+            return if (
+                node.value !== new_value ||
+                node.dlr !== new_dlr ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.ProductWithRecord(
                     value = new_value,
                     dlr = new_dlr,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformProductWithRecord_value(node: TestDomain.ProductWithRecord) =
             transformLongPrimitive(node.value)
@@ -4826,12 +5008,21 @@ class TestDomain private constructor() {
             val new_b = transformTestSumTriplet_b(node)
             val new_c = transformTestSumTriplet_c(node)
             val new_metas = transformTestSumTriplet_metas(node)
-            return TestDomain.TestSumTriplet(
+            return if (
+                node.a !== new_a ||
+                node.b !== new_b ||
+                node.c !== new_c ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.TestSumTriplet(
                     a = new_a,
                     b = new_b,
                     c = new_c,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformTestSumTriplet_a(node: TestDomain.TestSumTriplet) =
             transformTestSum(node.a)
@@ -4847,11 +5038,19 @@ class TestDomain private constructor() {
             val new_first = transformEntityPair_first(node)
             val new_second = transformEntityPair_second(node)
             val new_metas = transformEntityPair_metas(node)
-            return TestDomain.EntityPair(
+            return if (
+                node.first !== new_first ||
+                node.second !== new_second ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.EntityPair(
                     first = new_first,
                     second = new_second,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformEntityPair_first(node: TestDomain.EntityPair) =
             transformEntity(node.first)
@@ -4871,9 +5070,15 @@ class TestDomain private constructor() {
         // Variant AnswerNo
         open fun transformAnswerNo(node: TestDomain.Answer.No): TestDomain.Answer  {
             val new_metas = transformAnswerNo_metas(node)
-            return TestDomain.Answer.No(
+            return if (
+                node.metas !== new_metas
+            ) {
+                TestDomain.Answer.No(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAnswerNo_metas(node: TestDomain.Answer.No) =
             transformMetas(node.metas)
@@ -4881,9 +5086,15 @@ class TestDomain private constructor() {
         // Variant AnswerYes
         open fun transformAnswerYes(node: TestDomain.Answer.Yes): TestDomain.Answer  {
             val new_metas = transformAnswerYes_metas(node)
-            return TestDomain.Answer.Yes(
+            return if (
+                node.metas !== new_metas
+            ) {
+                TestDomain.Answer.Yes(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAnswerYes_metas(node: TestDomain.Answer.Yes) =
             transformMetas(node.metas)
@@ -4900,11 +5111,19 @@ class TestDomain private constructor() {
             val new_value = transformSumWithRecordVariantWithRecord_value(node)
             val new_dlr = transformSumWithRecordVariantWithRecord_dlr(node)
             val new_metas = transformSumWithRecordVariantWithRecord_metas(node)
-            return TestDomain.SumWithRecord.VariantWithRecord(
+            return if (
+                node.value !== new_value ||
+                node.dlr !== new_dlr ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.SumWithRecord.VariantWithRecord(
                     value = new_value,
                     dlr = new_dlr,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSumWithRecordVariantWithRecord_value(node: TestDomain.SumWithRecord.VariantWithRecord) =
             transformLongPrimitive(node.value)
@@ -4926,10 +5145,17 @@ class TestDomain private constructor() {
         open fun transformTestSumOne(node: TestDomain.TestSum.One): TestDomain.TestSum  {
             val new_a = transformTestSumOne_a(node)
             val new_metas = transformTestSumOne_metas(node)
-            return TestDomain.TestSum.One(
+            return if (
+                node.a !== new_a ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.TestSum.One(
                     a = new_a,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformTestSumOne_a(node: TestDomain.TestSum.One) =
             transformLongPrimitive(node.a)
@@ -4941,11 +5167,19 @@ class TestDomain private constructor() {
             val new_a = transformTestSumTwo_a(node)
             val new_b = transformTestSumTwo_b(node)
             val new_metas = transformTestSumTwo_metas(node)
-            return TestDomain.TestSum.Two(
+            return if (
+                node.a !== new_a ||
+                node.b !== new_b ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.TestSum.Two(
                     a = new_a,
                     b = new_b,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformTestSumTwo_a(node: TestDomain.TestSum.Two) =
             transformLongPrimitive(node.a)
@@ -4960,12 +5194,21 @@ class TestDomain private constructor() {
             val new_b = transformTestSumThree_b(node)
             val new_c = transformTestSumThree_c(node)
             val new_metas = transformTestSumThree_metas(node)
-            return TestDomain.TestSum.Three(
+            return if (
+                node.a !== new_a ||
+                node.b !== new_b ||
+                node.c !== new_c ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.TestSum.Three(
                     a = new_a,
                     b = new_b,
                     c = new_c,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformTestSumThree_a(node: TestDomain.TestSum.Three) =
             transformLongPrimitive(node.a)
@@ -4988,9 +5231,15 @@ class TestDomain private constructor() {
         // Variant EntitySlug
         open fun transformEntitySlug(node: TestDomain.Entity.Slug): TestDomain.Entity  {
             val new_metas = transformEntitySlug_metas(node)
-            return TestDomain.Entity.Slug(
+            return if (
+                node.metas !== new_metas
+            ) {
+                TestDomain.Entity.Slug(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformEntitySlug_metas(node: TestDomain.Entity.Slug) =
             transformMetas(node.metas)
@@ -4999,10 +5248,17 @@ class TestDomain private constructor() {
         open fun transformEntityAndroid(node: TestDomain.Entity.Android): TestDomain.Entity  {
             val new_id = transformEntityAndroid_id(node)
             val new_metas = transformEntityAndroid_metas(node)
-            return TestDomain.Entity.Android(
+            return if (
+                node.id !== new_id ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.Entity.Android(
                     id = new_id,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformEntityAndroid_id(node: TestDomain.Entity.Android) =
             transformLongPrimitive(node.id)
@@ -5017,7 +5273,15 @@ class TestDomain private constructor() {
             val new_title = transformEntityHuman_title(node)
             val new_parent = transformEntityHuman_parent(node)
             val new_metas = transformEntityHuman_metas(node)
-            return TestDomain.Entity.Human(
+            return if (
+                node.firstName !== new_firstName ||
+                node.middleNames !== new_middleNames ||
+                node.lastName !== new_lastName ||
+                node.title !== new_title ||
+                node.parent !== new_parent ||
+                node.metas !== new_metas
+            ) {
+                TestDomain.Entity.Human(
                     firstName = new_firstName,
                     middleNames = new_middleNames,
                     lastName = new_lastName,
@@ -5025,6 +5289,9 @@ class TestDomain private constructor() {
                     parent = new_parent,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformEntityHuman_firstName(node: TestDomain.Entity.Human) =
             transformSymbolPrimitive(node.firstName)
@@ -6979,9 +7246,15 @@ class MultiWordDomain private constructor() {
         // Tuple AaaAaa
         open fun transformAaaAaa(node: MultiWordDomain.AaaAaa): MultiWordDomain.AaaAaa {
             val new_metas = transformAaaAaa_metas(node)
-            return MultiWordDomain.AaaAaa(
+            return if (
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.AaaAaa(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAaaAaa_metas(node: MultiWordDomain.AaaAaa) =
             transformMetas(node.metas)
@@ -6990,10 +7263,17 @@ class MultiWordDomain private constructor() {
         open fun transformAaaAab(node: MultiWordDomain.AaaAab): MultiWordDomain.AaaAab {
             val new_dField = transformAaaAab_dField(node)
             val new_metas = transformAaaAab_metas(node)
-            return MultiWordDomain.AaaAab(
+            return if (
+                node.dField !== new_dField ||
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.AaaAab(
                     dField = new_dField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAaaAab_dField(node: MultiWordDomain.AaaAab) =
             node.dField?.let { transformLongPrimitive(it) }
@@ -7005,11 +7285,19 @@ class MultiWordDomain private constructor() {
             val new_dField = transformAaaAac_dField(node)
             val new_eField = transformAaaAac_eField(node)
             val new_metas = transformAaaAac_metas(node)
-            return MultiWordDomain.AaaAac(
+            return if (
+                node.dField !== new_dField ||
+                node.eField !== new_eField ||
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.AaaAac(
                     dField = new_dField,
                     eField = new_eField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAaaAac_dField(node: MultiWordDomain.AaaAac) =
             node.dField?.let { transformLongPrimitive(it) }
@@ -7022,10 +7310,17 @@ class MultiWordDomain private constructor() {
         open fun transformAaaAad(node: MultiWordDomain.AaaAad): MultiWordDomain.AaaAad {
             val new_dField = transformAaaAad_dField(node)
             val new_metas = transformAaaAad_metas(node)
-            return MultiWordDomain.AaaAad(
+            return if (
+                node.dField !== new_dField ||
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.AaaAad(
                     dField = new_dField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAaaAad_dField(node: MultiWordDomain.AaaAad) =
             node.dField.map { transformLongPrimitive(it) }
@@ -7036,10 +7331,17 @@ class MultiWordDomain private constructor() {
         open fun transformAaaAae(node: MultiWordDomain.AaaAae): MultiWordDomain.AaaAae {
             val new_dField = transformAaaAae_dField(node)
             val new_metas = transformAaaAae_metas(node)
-            return MultiWordDomain.AaaAae(
+            return if (
+                node.dField !== new_dField ||
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.AaaAae(
                     dField = new_dField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAaaAae_dField(node: MultiWordDomain.AaaAae) =
             node.dField.map { transformLongPrimitive(it) }
@@ -7051,11 +7353,19 @@ class MultiWordDomain private constructor() {
             val new_bField = transformAabAaa_bField(node)
             val new_cField = transformAabAaa_cField(node)
             val new_metas = transformAabAaa_metas(node)
-            return MultiWordDomain.AabAaa(
+            return if (
+                node.bField !== new_bField ||
+                node.cField !== new_cField ||
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.AabAaa(
                     bField = new_bField,
                     cField = new_cField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAabAaa_bField(node: MultiWordDomain.AabAaa) =
             transformLongPrimitive(node.bField)
@@ -7070,12 +7380,21 @@ class MultiWordDomain private constructor() {
             val new_cField = transformAabAab_cField(node)
             val new_dField = transformAabAab_dField(node)
             val new_metas = transformAabAab_metas(node)
-            return MultiWordDomain.AabAab(
+            return if (
+                node.bField !== new_bField ||
+                node.cField !== new_cField ||
+                node.dField !== new_dField ||
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.AabAab(
                     bField = new_bField,
                     cField = new_cField,
                     dField = new_dField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAabAab_bField(node: MultiWordDomain.AabAab) =
             transformLongPrimitive(node.bField)
@@ -7093,13 +7412,23 @@ class MultiWordDomain private constructor() {
             val new_dField = transformAabAac_dField(node)
             val new_eField = transformAabAac_eField(node)
             val new_metas = transformAabAac_metas(node)
-            return MultiWordDomain.AabAac(
+            return if (
+                node.bField !== new_bField ||
+                node.cField !== new_cField ||
+                node.dField !== new_dField ||
+                node.eField !== new_eField ||
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.AabAac(
                     bField = new_bField,
                     cField = new_cField,
                     dField = new_dField,
                     eField = new_eField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAabAac_bField(node: MultiWordDomain.AabAac) =
             transformLongPrimitive(node.bField)
@@ -7118,12 +7447,21 @@ class MultiWordDomain private constructor() {
             val new_cField = transformAabAad_cField(node)
             val new_dField = transformAabAad_dField(node)
             val new_metas = transformAabAad_metas(node)
-            return MultiWordDomain.AabAad(
+            return if (
+                node.bField !== new_bField ||
+                node.cField !== new_cField ||
+                node.dField !== new_dField ||
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.AabAad(
                     bField = new_bField,
                     cField = new_cField,
                     dField = new_dField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAabAad_bField(node: MultiWordDomain.AabAad) =
             transformLongPrimitive(node.bField)
@@ -7140,12 +7478,21 @@ class MultiWordDomain private constructor() {
             val new_cField = transformAabAae_cField(node)
             val new_dField = transformAabAae_dField(node)
             val new_metas = transformAabAae_metas(node)
-            return MultiWordDomain.AabAae(
+            return if (
+                node.bField !== new_bField ||
+                node.cField !== new_cField ||
+                node.dField !== new_dField ||
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.AabAae(
                     bField = new_bField,
                     cField = new_cField,
                     dField = new_dField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformAabAae_bField(node: MultiWordDomain.AabAae) =
             transformLongPrimitive(node.bField)
@@ -7161,11 +7508,19 @@ class MultiWordDomain private constructor() {
             val new_aField = transformRrr_aField(node)
             val new_bbbField = transformRrr_bbbField(node)
             val new_metas = transformRrr_metas(node)
-            return MultiWordDomain.Rrr(
+            return if (
+                node.aField !== new_aField ||
+                node.bbbField !== new_bbbField ||
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.Rrr(
                     aField = new_aField,
                     bbbField = new_bbbField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformRrr_aField(node: MultiWordDomain.Rrr) =
             transformLongPrimitive(node.aField)
@@ -7186,10 +7541,17 @@ class MultiWordDomain private constructor() {
         open fun transformSssTttLll(node: MultiWordDomain.SssTtt.Lll): MultiWordDomain.SssTtt  {
             val new_uField = transformSssTttLll_uField(node)
             val new_metas = transformSssTttLll_metas(node)
-            return MultiWordDomain.SssTtt.Lll(
+            return if (
+                node.uField !== new_uField ||
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.SssTtt.Lll(
                     uField = new_uField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSssTttLll_uField(node: MultiWordDomain.SssTtt.Lll) =
             transformLongPrimitive(node.uField)
@@ -7200,10 +7562,17 @@ class MultiWordDomain private constructor() {
         open fun transformSssTttMmm(node: MultiWordDomain.SssTtt.Mmm): MultiWordDomain.SssTtt  {
             val new_vField = transformSssTttMmm_vField(node)
             val new_metas = transformSssTttMmm_metas(node)
-            return MultiWordDomain.SssTtt.Mmm(
+            return if (
+                node.vField !== new_vField ||
+                node.metas !== new_metas
+            ) {
+                MultiWordDomain.SssTtt.Mmm(
                     vField = new_vField,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSssTttMmm_vField(node: MultiWordDomain.SssTtt.Mmm) =
             transformSymbolPrimitive(node.vField)
@@ -8986,10 +9355,17 @@ class DomainA private constructor() {
         open fun transformProductToRemove(node: DomainA.ProductToRemove): DomainA.ProductToRemove {
             val new_whatever = transformProductToRemove_whatever(node)
             val new_metas = transformProductToRemove_metas(node)
-            return DomainA.ProductToRemove(
+            return if (
+                node.whatever !== new_whatever ||
+                node.metas !== new_metas
+            ) {
+                DomainA.ProductToRemove(
                     whatever = new_whatever,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformProductToRemove_whatever(node: DomainA.ProductToRemove) =
             transformSymbolPrimitive(node.whatever)
@@ -9000,10 +9376,17 @@ class DomainA private constructor() {
         open fun transformRecordToRemove(node: DomainA.RecordToRemove): DomainA.RecordToRemove {
             val new_irrelevant = transformRecordToRemove_irrelevant(node)
             val new_metas = transformRecordToRemove_metas(node)
-            return DomainA.RecordToRemove(
+            return if (
+                node.irrelevant !== new_irrelevant ||
+                node.metas !== new_metas
+            ) {
+                DomainA.RecordToRemove(
                     irrelevant = new_irrelevant,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformRecordToRemove_irrelevant(node: DomainA.RecordToRemove) =
             transformLongPrimitive(node.irrelevant)
@@ -9014,10 +9397,17 @@ class DomainA private constructor() {
         open fun transformProductA(node: DomainA.ProductA): DomainA.ProductA {
             val new_one = transformProductA_one(node)
             val new_metas = transformProductA_metas(node)
-            return DomainA.ProductA(
+            return if (
+                node.one !== new_one ||
+                node.metas !== new_metas
+            ) {
+                DomainA.ProductA(
                     one = new_one,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformProductA_one(node: DomainA.ProductA) =
             transformLongPrimitive(node.one)
@@ -9028,10 +9418,17 @@ class DomainA private constructor() {
         open fun transformRecordA(node: DomainA.RecordA): DomainA.RecordA {
             val new_one = transformRecordA_one(node)
             val new_metas = transformRecordA_metas(node)
-            return DomainA.RecordA(
+            return if (
+                node.one !== new_one ||
+                node.metas !== new_metas
+            ) {
+                DomainA.RecordA(
                     one = new_one,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformRecordA_one(node: DomainA.RecordA) =
             transformLongPrimitive(node.one)
@@ -9043,11 +9440,19 @@ class DomainA private constructor() {
             val new_foo = transformUnpermutedProduct_foo(node)
             val new_bar = transformUnpermutedProduct_bar(node)
             val new_metas = transformUnpermutedProduct_metas(node)
-            return DomainA.UnpermutedProduct(
+            return if (
+                node.foo !== new_foo ||
+                node.bar !== new_bar ||
+                node.metas !== new_metas
+            ) {
+                DomainA.UnpermutedProduct(
                     foo = new_foo,
                     bar = new_bar,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformUnpermutedProduct_foo(node: DomainA.UnpermutedProduct) =
             transformSymbolPrimitive(node.foo)
@@ -9061,11 +9466,19 @@ class DomainA private constructor() {
             val new_foo = transformUnpermutedRecord_foo(node)
             val new_bar = transformUnpermutedRecord_bar(node)
             val new_metas = transformUnpermutedRecord_metas(node)
-            return DomainA.UnpermutedRecord(
+            return if (
+                node.foo !== new_foo ||
+                node.bar !== new_bar ||
+                node.metas !== new_metas
+            ) {
+                DomainA.UnpermutedRecord(
                     foo = new_foo,
                     bar = new_bar,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformUnpermutedRecord_foo(node: DomainA.UnpermutedRecord) =
             transformSymbolPrimitive(node.foo)
@@ -9085,9 +9498,15 @@ class DomainA private constructor() {
         // Variant SumToRemoveDoesnt
         open fun transformSumToRemoveDoesnt(node: DomainA.SumToRemove.Doesnt): DomainA.SumToRemove  {
             val new_metas = transformSumToRemoveDoesnt_metas(node)
-            return DomainA.SumToRemove.Doesnt(
+            return if (
+                node.metas !== new_metas
+            ) {
+                DomainA.SumToRemove.Doesnt(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSumToRemoveDoesnt_metas(node: DomainA.SumToRemove.Doesnt) =
             transformMetas(node.metas)
@@ -9095,9 +9514,15 @@ class DomainA private constructor() {
         // Variant SumToRemoveMatter
         open fun transformSumToRemoveMatter(node: DomainA.SumToRemove.Matter): DomainA.SumToRemove  {
             val new_metas = transformSumToRemoveMatter_metas(node)
-            return DomainA.SumToRemove.Matter(
+            return if (
+                node.metas !== new_metas
+            ) {
+                DomainA.SumToRemove.Matter(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSumToRemoveMatter_metas(node: DomainA.SumToRemove.Matter) =
             transformMetas(node.metas)
@@ -9113,9 +9538,15 @@ class DomainA private constructor() {
         // Variant SumAWho
         open fun transformSumAWho(node: DomainA.SumA.Who): DomainA.SumA  {
             val new_metas = transformSumAWho_metas(node)
-            return DomainA.SumA.Who(
+            return if (
+                node.metas !== new_metas
+            ) {
+                DomainA.SumA.Who(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSumAWho_metas(node: DomainA.SumA.Who) =
             transformMetas(node.metas)
@@ -9123,9 +9554,15 @@ class DomainA private constructor() {
         // Variant SumACares
         open fun transformSumACares(node: DomainA.SumA.Cares): DomainA.SumA  {
             val new_metas = transformSumACares_metas(node)
-            return DomainA.SumA.Cares(
+            return if (
+                node.metas !== new_metas
+            ) {
+                DomainA.SumA.Cares(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSumACares_metas(node: DomainA.SumA.Cares) =
             transformMetas(node.metas)
@@ -9142,9 +9579,15 @@ class DomainA private constructor() {
         // Variant SumBWillBeUnchanged
         open fun transformSumBWillBeUnchanged(node: DomainA.SumB.WillBeUnchanged): DomainA.SumB  {
             val new_metas = transformSumBWillBeUnchanged_metas(node)
-            return DomainA.SumB.WillBeUnchanged(
+            return if (
+                node.metas !== new_metas
+            ) {
+                DomainA.SumB.WillBeUnchanged(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSumBWillBeUnchanged_metas(node: DomainA.SumB.WillBeUnchanged) =
             transformMetas(node.metas)
@@ -9152,9 +9595,15 @@ class DomainA private constructor() {
         // Variant SumBWillBeRemoved
         open fun transformSumBWillBeRemoved(node: DomainA.SumB.WillBeRemoved): DomainA.SumB  {
             val new_metas = transformSumBWillBeRemoved_metas(node)
-            return DomainA.SumB.WillBeRemoved(
+            return if (
+                node.metas !== new_metas
+            ) {
+                DomainA.SumB.WillBeRemoved(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSumBWillBeRemoved_metas(node: DomainA.SumB.WillBeRemoved) =
             transformMetas(node.metas)
@@ -9163,10 +9612,17 @@ class DomainA private constructor() {
         open fun transformSumBWillBeReplaced(node: DomainA.SumB.WillBeReplaced): DomainA.SumB  {
             val new_something = transformSumBWillBeReplaced_something(node)
             val new_metas = transformSumBWillBeReplaced_metas(node)
-            return DomainA.SumB.WillBeReplaced(
+            return if (
+                node.something !== new_something ||
+                node.metas !== new_metas
+            ) {
+                DomainA.SumB.WillBeReplaced(
                     something = new_something,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSumBWillBeReplaced_something(node: DomainA.SumB.WillBeReplaced) =
             transformLongPrimitive(node.something)
@@ -9186,11 +9642,19 @@ class DomainA private constructor() {
             val new_foo = transformUnpermutedSumUnpermutedProductVariant_foo(node)
             val new_bar = transformUnpermutedSumUnpermutedProductVariant_bar(node)
             val new_metas = transformUnpermutedSumUnpermutedProductVariant_metas(node)
-            return DomainA.UnpermutedSum.UnpermutedProductVariant(
+            return if (
+                node.foo !== new_foo ||
+                node.bar !== new_bar ||
+                node.metas !== new_metas
+            ) {
+                DomainA.UnpermutedSum.UnpermutedProductVariant(
                     foo = new_foo,
                     bar = new_bar,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformUnpermutedSumUnpermutedProductVariant_foo(node: DomainA.UnpermutedSum.UnpermutedProductVariant) =
             transformSymbolPrimitive(node.foo)
@@ -9204,11 +9668,19 @@ class DomainA private constructor() {
             val new_foo = transformUnpermutedSumUnpermutedRecordVariant_foo(node)
             val new_bar = transformUnpermutedSumUnpermutedRecordVariant_bar(node)
             val new_metas = transformUnpermutedSumUnpermutedRecordVariant_metas(node)
-            return DomainA.UnpermutedSum.UnpermutedRecordVariant(
+            return if (
+                node.foo !== new_foo ||
+                node.bar !== new_bar ||
+                node.metas !== new_metas
+            ) {
+                DomainA.UnpermutedSum.UnpermutedRecordVariant(
                     foo = new_foo,
                     bar = new_bar,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformUnpermutedSumUnpermutedRecordVariant_foo(node: DomainA.UnpermutedSum.UnpermutedRecordVariant) =
             transformSymbolPrimitive(node.foo)
@@ -10737,11 +11209,19 @@ class DomainB private constructor() {
             val new_foo = transformUnpermutedProduct_foo(node)
             val new_bar = transformUnpermutedProduct_bar(node)
             val new_metas = transformUnpermutedProduct_metas(node)
-            return DomainB.UnpermutedProduct(
+            return if (
+                node.foo !== new_foo ||
+                node.bar !== new_bar ||
+                node.metas !== new_metas
+            ) {
+                DomainB.UnpermutedProduct(
                     foo = new_foo,
                     bar = new_bar,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformUnpermutedProduct_foo(node: DomainB.UnpermutedProduct) =
             transformSymbolPrimitive(node.foo)
@@ -10755,11 +11235,19 @@ class DomainB private constructor() {
             val new_foo = transformUnpermutedRecord_foo(node)
             val new_bar = transformUnpermutedRecord_bar(node)
             val new_metas = transformUnpermutedRecord_metas(node)
-            return DomainB.UnpermutedRecord(
+            return if (
+                node.foo !== new_foo ||
+                node.bar !== new_bar ||
+                node.metas !== new_metas
+            ) {
+                DomainB.UnpermutedRecord(
                     foo = new_foo,
                     bar = new_bar,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformUnpermutedRecord_foo(node: DomainB.UnpermutedRecord) =
             transformSymbolPrimitive(node.foo)
@@ -10772,10 +11260,17 @@ class DomainB private constructor() {
         open fun transformProductA(node: DomainB.ProductA): DomainB.ProductA {
             val new_one = transformProductA_one(node)
             val new_metas = transformProductA_metas(node)
-            return DomainB.ProductA(
+            return if (
+                node.one !== new_one ||
+                node.metas !== new_metas
+            ) {
+                DomainB.ProductA(
                     one = new_one,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformProductA_one(node: DomainB.ProductA) =
             transformSymbolPrimitive(node.one)
@@ -10786,10 +11281,17 @@ class DomainB private constructor() {
         open fun transformRecordA(node: DomainB.RecordA): DomainB.RecordA {
             val new_one = transformRecordA_one(node)
             val new_metas = transformRecordA_metas(node)
-            return DomainB.RecordA(
+            return if (
+                node.one !== new_one ||
+                node.metas !== new_metas
+            ) {
+                DomainB.RecordA(
                     one = new_one,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformRecordA_one(node: DomainB.RecordA) =
             transformSymbolPrimitive(node.one)
@@ -10800,10 +11302,17 @@ class DomainB private constructor() {
         open fun transformNewProduct(node: DomainB.NewProduct): DomainB.NewProduct {
             val new_foo = transformNewProduct_foo(node)
             val new_metas = transformNewProduct_metas(node)
-            return DomainB.NewProduct(
+            return if (
+                node.foo !== new_foo ||
+                node.metas !== new_metas
+            ) {
+                DomainB.NewProduct(
                     foo = new_foo,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformNewProduct_foo(node: DomainB.NewProduct) =
             transformLongPrimitive(node.foo)
@@ -10814,10 +11323,17 @@ class DomainB private constructor() {
         open fun transformNewRecord(node: DomainB.NewRecord): DomainB.NewRecord {
             val new_foo = transformNewRecord_foo(node)
             val new_metas = transformNewRecord_metas(node)
-            return DomainB.NewRecord(
+            return if (
+                node.foo !== new_foo ||
+                node.metas !== new_metas
+            ) {
+                DomainB.NewRecord(
                     foo = new_foo,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformNewRecord_foo(node: DomainB.NewRecord) =
             transformLongPrimitive(node.foo)
@@ -10837,11 +11353,19 @@ class DomainB private constructor() {
             val new_foo = transformUnpermutedSumUnpermutedProductVariant_foo(node)
             val new_bar = transformUnpermutedSumUnpermutedProductVariant_bar(node)
             val new_metas = transformUnpermutedSumUnpermutedProductVariant_metas(node)
-            return DomainB.UnpermutedSum.UnpermutedProductVariant(
+            return if (
+                node.foo !== new_foo ||
+                node.bar !== new_bar ||
+                node.metas !== new_metas
+            ) {
+                DomainB.UnpermutedSum.UnpermutedProductVariant(
                     foo = new_foo,
                     bar = new_bar,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformUnpermutedSumUnpermutedProductVariant_foo(node: DomainB.UnpermutedSum.UnpermutedProductVariant) =
             transformSymbolPrimitive(node.foo)
@@ -10855,11 +11379,19 @@ class DomainB private constructor() {
             val new_foo = transformUnpermutedSumUnpermutedRecordVariant_foo(node)
             val new_bar = transformUnpermutedSumUnpermutedRecordVariant_bar(node)
             val new_metas = transformUnpermutedSumUnpermutedRecordVariant_metas(node)
-            return DomainB.UnpermutedSum.UnpermutedRecordVariant(
+            return if (
+                node.foo !== new_foo ||
+                node.bar !== new_bar ||
+                node.metas !== new_metas
+            ) {
+                DomainB.UnpermutedSum.UnpermutedRecordVariant(
                     foo = new_foo,
                     bar = new_bar,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformUnpermutedSumUnpermutedRecordVariant_foo(node: DomainB.UnpermutedSum.UnpermutedRecordVariant) =
             transformSymbolPrimitive(node.foo)
@@ -10879,9 +11411,15 @@ class DomainB private constructor() {
         // Variant SumBWillBeUnchanged
         open fun transformSumBWillBeUnchanged(node: DomainB.SumB.WillBeUnchanged): DomainB.SumB  {
             val new_metas = transformSumBWillBeUnchanged_metas(node)
-            return DomainB.SumB.WillBeUnchanged(
+            return if (
+                node.metas !== new_metas
+            ) {
+                DomainB.SumB.WillBeUnchanged(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSumBWillBeUnchanged_metas(node: DomainB.SumB.WillBeUnchanged) =
             transformMetas(node.metas)
@@ -10890,10 +11428,17 @@ class DomainB private constructor() {
         open fun transformSumBWillBeReplaced(node: DomainB.SumB.WillBeReplaced): DomainB.SumB  {
             val new_something = transformSumBWillBeReplaced_something(node)
             val new_metas = transformSumBWillBeReplaced_metas(node)
-            return DomainB.SumB.WillBeReplaced(
+            return if (
+                node.something !== new_something ||
+                node.metas !== new_metas
+            ) {
+                DomainB.SumB.WillBeReplaced(
                     something = new_something,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformSumBWillBeReplaced_something(node: DomainB.SumB.WillBeReplaced) =
             transformSymbolPrimitive(node.something)
@@ -10911,9 +11456,15 @@ class DomainB private constructor() {
         // Variant NewSumEek
         open fun transformNewSumEek(node: DomainB.NewSum.Eek): DomainB.NewSum  {
             val new_metas = transformNewSumEek_metas(node)
-            return DomainB.NewSum.Eek(
+            return if (
+                node.metas !== new_metas
+            ) {
+                DomainB.NewSum.Eek(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformNewSumEek_metas(node: DomainB.NewSum.Eek) =
             transformMetas(node.metas)
@@ -10921,9 +11472,15 @@ class DomainB private constructor() {
         // Variant NewSumWhatever
         open fun transformNewSumWhatever(node: DomainB.NewSum.Whatever): DomainB.NewSum  {
             val new_metas = transformNewSumWhatever_metas(node)
-            return DomainB.NewSum.Whatever(
+            return if (
+                node.metas !== new_metas
+            ) {
+                DomainB.NewSum.Whatever(
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformNewSumWhatever_metas(node: DomainB.NewSum.Whatever) =
             transformMetas(node.metas)
@@ -10950,7 +11507,7 @@ abstract class DomainAToDomainBVisitorTransform : DomainVisitorTransformBase() {
         val new_foo = transformUnpermutedProduct_foo(node)
         val new_bar = transformUnpermutedProduct_bar(node)
         val new_metas = transformUnpermutedProduct_metas(node)
-        return DomainB.UnpermutedProduct(
+        return             DomainB.UnpermutedProduct(
                 foo = new_foo,
                 bar = new_bar,
                 metas = new_metas
@@ -10968,7 +11525,7 @@ abstract class DomainAToDomainBVisitorTransform : DomainVisitorTransformBase() {
         val new_foo = transformUnpermutedRecord_foo(node)
         val new_bar = transformUnpermutedRecord_bar(node)
         val new_metas = transformUnpermutedRecord_metas(node)
-        return DomainB.UnpermutedRecord(
+        return             DomainB.UnpermutedRecord(
                 foo = new_foo,
                 bar = new_bar,
                 metas = new_metas
@@ -10993,7 +11550,7 @@ abstract class DomainAToDomainBVisitorTransform : DomainVisitorTransformBase() {
     // Variant SumBWillBeUnchanged
     open fun transformSumBWillBeUnchanged(node: DomainA.SumB.WillBeUnchanged): DomainB.SumB  {
         val new_metas = transformSumBWillBeUnchanged_metas(node)
-        return DomainB.SumB.WillBeUnchanged(
+        return             DomainB.SumB.WillBeUnchanged(
                 metas = new_metas
             )
     }
@@ -11017,7 +11574,7 @@ abstract class DomainAToDomainBVisitorTransform : DomainVisitorTransformBase() {
         val new_foo = transformUnpermutedSumUnpermutedProductVariant_foo(node)
         val new_bar = transformUnpermutedSumUnpermutedProductVariant_bar(node)
         val new_metas = transformUnpermutedSumUnpermutedProductVariant_metas(node)
-        return DomainB.UnpermutedSum.UnpermutedProductVariant(
+        return             DomainB.UnpermutedSum.UnpermutedProductVariant(
                 foo = new_foo,
                 bar = new_bar,
                 metas = new_metas
@@ -11035,7 +11592,7 @@ abstract class DomainAToDomainBVisitorTransform : DomainVisitorTransformBase() {
         val new_foo = transformUnpermutedSumUnpermutedRecordVariant_foo(node)
         val new_bar = transformUnpermutedSumUnpermutedRecordVariant_bar(node)
         val new_metas = transformUnpermutedSumUnpermutedRecordVariant_metas(node)
-        return DomainB.UnpermutedSum.UnpermutedRecordVariant(
+        return             DomainB.UnpermutedSum.UnpermutedRecordVariant(
                 foo = new_foo,
                 bar = new_bar,
                 metas = new_metas

--- a/pig-tests/src/org/partiql/pig/tests/generated/toy-lang.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/toy-lang.kt
@@ -1419,10 +1419,17 @@ class ToyLang private constructor() {
         open fun transformExprLit(node: ToyLang.Expr.Lit): ToyLang.Expr  {
             val new_value = transformExprLit_value(node)
             val new_metas = transformExprLit_metas(node)
-            return ToyLang.Expr.Lit(
+            return if (
+                node.value !== new_value ||
+                node.metas !== new_metas
+            ) {
+                ToyLang.Expr.Lit(
                     value = new_value,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprLit_value(node: ToyLang.Expr.Lit) =
             transformAnyElement(node.value)
@@ -1433,10 +1440,17 @@ class ToyLang private constructor() {
         open fun transformExprVariable(node: ToyLang.Expr.Variable): ToyLang.Expr  {
             val new_name = transformExprVariable_name(node)
             val new_metas = transformExprVariable_metas(node)
-            return ToyLang.Expr.Variable(
+            return if (
+                node.name !== new_name ||
+                node.metas !== new_metas
+            ) {
+                ToyLang.Expr.Variable(
                     name = new_name,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprVariable_name(node: ToyLang.Expr.Variable) =
             transformSymbolPrimitive(node.name)
@@ -1447,10 +1461,17 @@ class ToyLang private constructor() {
         open fun transformExprNot(node: ToyLang.Expr.Not): ToyLang.Expr  {
             val new_expr = transformExprNot_expr(node)
             val new_metas = transformExprNot_metas(node)
-            return ToyLang.Expr.Not(
+            return if (
+                node.expr !== new_expr ||
+                node.metas !== new_metas
+            ) {
+                ToyLang.Expr.Not(
                     expr = new_expr,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprNot_expr(node: ToyLang.Expr.Not) =
             transformExpr(node.expr)
@@ -1461,10 +1482,17 @@ class ToyLang private constructor() {
         open fun transformExprPlus(node: ToyLang.Expr.Plus): ToyLang.Expr  {
             val new_operands = transformExprPlus_operands(node)
             val new_metas = transformExprPlus_metas(node)
-            return ToyLang.Expr.Plus(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                ToyLang.Expr.Plus(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprPlus_operands(node: ToyLang.Expr.Plus) =
             node.operands.map { transformExpr(it) }
@@ -1475,10 +1503,17 @@ class ToyLang private constructor() {
         open fun transformExprMinus(node: ToyLang.Expr.Minus): ToyLang.Expr  {
             val new_operands = transformExprMinus_operands(node)
             val new_metas = transformExprMinus_metas(node)
-            return ToyLang.Expr.Minus(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                ToyLang.Expr.Minus(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprMinus_operands(node: ToyLang.Expr.Minus) =
             node.operands.map { transformExpr(it) }
@@ -1489,10 +1524,17 @@ class ToyLang private constructor() {
         open fun transformExprTimes(node: ToyLang.Expr.Times): ToyLang.Expr  {
             val new_operands = transformExprTimes_operands(node)
             val new_metas = transformExprTimes_metas(node)
-            return ToyLang.Expr.Times(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                ToyLang.Expr.Times(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprTimes_operands(node: ToyLang.Expr.Times) =
             node.operands.map { transformExpr(it) }
@@ -1503,10 +1545,17 @@ class ToyLang private constructor() {
         open fun transformExprDivide(node: ToyLang.Expr.Divide): ToyLang.Expr  {
             val new_operands = transformExprDivide_operands(node)
             val new_metas = transformExprDivide_metas(node)
-            return ToyLang.Expr.Divide(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                ToyLang.Expr.Divide(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprDivide_operands(node: ToyLang.Expr.Divide) =
             node.operands.map { transformExpr(it) }
@@ -1517,10 +1566,17 @@ class ToyLang private constructor() {
         open fun transformExprModulo(node: ToyLang.Expr.Modulo): ToyLang.Expr  {
             val new_operands = transformExprModulo_operands(node)
             val new_metas = transformExprModulo_metas(node)
-            return ToyLang.Expr.Modulo(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                ToyLang.Expr.Modulo(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprModulo_operands(node: ToyLang.Expr.Modulo) =
             node.operands.map { transformExpr(it) }
@@ -1532,11 +1588,19 @@ class ToyLang private constructor() {
             val new_name = transformExprCall_name(node)
             val new_argument = transformExprCall_argument(node)
             val new_metas = transformExprCall_metas(node)
-            return ToyLang.Expr.Call(
+            return if (
+                node.name !== new_name ||
+                node.argument !== new_argument ||
+                node.metas !== new_metas
+            ) {
+                ToyLang.Expr.Call(
                     name = new_name,
                     argument = new_argument,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprCall_name(node: ToyLang.Expr.Call) =
             transformSymbolPrimitive(node.name)
@@ -1551,12 +1615,21 @@ class ToyLang private constructor() {
             val new_value = transformExprLet_value(node)
             val new_body = transformExprLet_body(node)
             val new_metas = transformExprLet_metas(node)
-            return ToyLang.Expr.Let(
+            return if (
+                node.name !== new_name ||
+                node.value !== new_value ||
+                node.body !== new_body ||
+                node.metas !== new_metas
+            ) {
+                ToyLang.Expr.Let(
                     name = new_name,
                     value = new_value,
                     body = new_body,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprLet_name(node: ToyLang.Expr.Let) =
             transformSymbolPrimitive(node.name)
@@ -1572,11 +1645,19 @@ class ToyLang private constructor() {
             val new_varName = transformExprFunction_varName(node)
             val new_body = transformExprFunction_body(node)
             val new_metas = transformExprFunction_metas(node)
-            return ToyLang.Expr.Function(
+            return if (
+                node.varName !== new_varName ||
+                node.body !== new_body ||
+                node.metas !== new_metas
+            ) {
+                ToyLang.Expr.Function(
                     varName = new_varName,
                     body = new_body,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprFunction_varName(node: ToyLang.Expr.Function) =
             transformSymbolPrimitive(node.varName)
@@ -3033,10 +3114,17 @@ class ToyLangIndexed private constructor() {
         open fun transformExprLit(node: ToyLangIndexed.Expr.Lit): ToyLangIndexed.Expr  {
             val new_value = transformExprLit_value(node)
             val new_metas = transformExprLit_metas(node)
-            return ToyLangIndexed.Expr.Lit(
+            return if (
+                node.value !== new_value ||
+                node.metas !== new_metas
+            ) {
+                ToyLangIndexed.Expr.Lit(
                     value = new_value,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprLit_value(node: ToyLangIndexed.Expr.Lit) =
             transformAnyElement(node.value)
@@ -3047,10 +3135,17 @@ class ToyLangIndexed private constructor() {
         open fun transformExprNot(node: ToyLangIndexed.Expr.Not): ToyLangIndexed.Expr  {
             val new_expr = transformExprNot_expr(node)
             val new_metas = transformExprNot_metas(node)
-            return ToyLangIndexed.Expr.Not(
+            return if (
+                node.expr !== new_expr ||
+                node.metas !== new_metas
+            ) {
+                ToyLangIndexed.Expr.Not(
                     expr = new_expr,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprNot_expr(node: ToyLangIndexed.Expr.Not) =
             transformExpr(node.expr)
@@ -3061,10 +3156,17 @@ class ToyLangIndexed private constructor() {
         open fun transformExprPlus(node: ToyLangIndexed.Expr.Plus): ToyLangIndexed.Expr  {
             val new_operands = transformExprPlus_operands(node)
             val new_metas = transformExprPlus_metas(node)
-            return ToyLangIndexed.Expr.Plus(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                ToyLangIndexed.Expr.Plus(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprPlus_operands(node: ToyLangIndexed.Expr.Plus) =
             node.operands.map { transformExpr(it) }
@@ -3075,10 +3177,17 @@ class ToyLangIndexed private constructor() {
         open fun transformExprMinus(node: ToyLangIndexed.Expr.Minus): ToyLangIndexed.Expr  {
             val new_operands = transformExprMinus_operands(node)
             val new_metas = transformExprMinus_metas(node)
-            return ToyLangIndexed.Expr.Minus(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                ToyLangIndexed.Expr.Minus(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprMinus_operands(node: ToyLangIndexed.Expr.Minus) =
             node.operands.map { transformExpr(it) }
@@ -3089,10 +3198,17 @@ class ToyLangIndexed private constructor() {
         open fun transformExprTimes(node: ToyLangIndexed.Expr.Times): ToyLangIndexed.Expr  {
             val new_operands = transformExprTimes_operands(node)
             val new_metas = transformExprTimes_metas(node)
-            return ToyLangIndexed.Expr.Times(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                ToyLangIndexed.Expr.Times(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprTimes_operands(node: ToyLangIndexed.Expr.Times) =
             node.operands.map { transformExpr(it) }
@@ -3103,10 +3219,17 @@ class ToyLangIndexed private constructor() {
         open fun transformExprDivide(node: ToyLangIndexed.Expr.Divide): ToyLangIndexed.Expr  {
             val new_operands = transformExprDivide_operands(node)
             val new_metas = transformExprDivide_metas(node)
-            return ToyLangIndexed.Expr.Divide(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                ToyLangIndexed.Expr.Divide(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprDivide_operands(node: ToyLangIndexed.Expr.Divide) =
             node.operands.map { transformExpr(it) }
@@ -3117,10 +3240,17 @@ class ToyLangIndexed private constructor() {
         open fun transformExprModulo(node: ToyLangIndexed.Expr.Modulo): ToyLangIndexed.Expr  {
             val new_operands = transformExprModulo_operands(node)
             val new_metas = transformExprModulo_metas(node)
-            return ToyLangIndexed.Expr.Modulo(
+            return if (
+                node.operands !== new_operands ||
+                node.metas !== new_metas
+            ) {
+                ToyLangIndexed.Expr.Modulo(
                     operands = new_operands,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprModulo_operands(node: ToyLangIndexed.Expr.Modulo) =
             node.operands.map { transformExpr(it) }
@@ -3132,11 +3262,19 @@ class ToyLangIndexed private constructor() {
             val new_name = transformExprCall_name(node)
             val new_argument = transformExprCall_argument(node)
             val new_metas = transformExprCall_metas(node)
-            return ToyLangIndexed.Expr.Call(
+            return if (
+                node.name !== new_name ||
+                node.argument !== new_argument ||
+                node.metas !== new_metas
+            ) {
+                ToyLangIndexed.Expr.Call(
                     name = new_name,
                     argument = new_argument,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprCall_name(node: ToyLangIndexed.Expr.Call) =
             transformSymbolPrimitive(node.name)
@@ -3150,11 +3288,19 @@ class ToyLangIndexed private constructor() {
             val new_varName = transformExprFunction_varName(node)
             val new_body = transformExprFunction_body(node)
             val new_metas = transformExprFunction_metas(node)
-            return ToyLangIndexed.Expr.Function(
+            return if (
+                node.varName !== new_varName ||
+                node.body !== new_body ||
+                node.metas !== new_metas
+            ) {
+                ToyLangIndexed.Expr.Function(
                     varName = new_varName,
                     body = new_body,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprFunction_varName(node: ToyLangIndexed.Expr.Function) =
             transformSymbolPrimitive(node.varName)
@@ -3168,11 +3314,19 @@ class ToyLangIndexed private constructor() {
             val new_name = transformExprVariable_name(node)
             val new_index = transformExprVariable_index(node)
             val new_metas = transformExprVariable_metas(node)
-            return ToyLangIndexed.Expr.Variable(
+            return if (
+                node.name !== new_name ||
+                node.index !== new_index ||
+                node.metas !== new_metas
+            ) {
+                ToyLangIndexed.Expr.Variable(
                     name = new_name,
                     index = new_index,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprVariable_name(node: ToyLangIndexed.Expr.Variable) =
             transformSymbolPrimitive(node.name)
@@ -3188,13 +3342,23 @@ class ToyLangIndexed private constructor() {
             val new_value = transformExprLet_value(node)
             val new_body = transformExprLet_body(node)
             val new_metas = transformExprLet_metas(node)
-            return ToyLangIndexed.Expr.Let(
+            return if (
+                node.name !== new_name ||
+                node.index !== new_index ||
+                node.value !== new_value ||
+                node.body !== new_body ||
+                node.metas !== new_metas
+            ) {
+                ToyLangIndexed.Expr.Let(
                     name = new_name,
                     index = new_index,
                     value = new_value,
                     body = new_body,
                     metas = new_metas
                 )
+            } else {
+                node
+            }
         }
         open fun transformExprLet_name(node: ToyLangIndexed.Expr.Let) =
             transformSymbolPrimitive(node.name)
@@ -3238,7 +3402,7 @@ abstract class ToyLangToToyLangIndexedVisitorTransform : DomainVisitorTransformB
     open fun transformExprLit(node: ToyLang.Expr.Lit): ToyLangIndexed.Expr  {
         val new_value = transformExprLit_value(node)
         val new_metas = transformExprLit_metas(node)
-        return ToyLangIndexed.Expr.Lit(
+        return             ToyLangIndexed.Expr.Lit(
                 value = new_value,
                 metas = new_metas
             )
@@ -3254,7 +3418,7 @@ abstract class ToyLangToToyLangIndexedVisitorTransform : DomainVisitorTransformB
     open fun transformExprNot(node: ToyLang.Expr.Not): ToyLangIndexed.Expr  {
         val new_expr = transformExprNot_expr(node)
         val new_metas = transformExprNot_metas(node)
-        return ToyLangIndexed.Expr.Not(
+        return             ToyLangIndexed.Expr.Not(
                 expr = new_expr,
                 metas = new_metas
             )
@@ -3268,7 +3432,7 @@ abstract class ToyLangToToyLangIndexedVisitorTransform : DomainVisitorTransformB
     open fun transformExprPlus(node: ToyLang.Expr.Plus): ToyLangIndexed.Expr  {
         val new_operands = transformExprPlus_operands(node)
         val new_metas = transformExprPlus_metas(node)
-        return ToyLangIndexed.Expr.Plus(
+        return             ToyLangIndexed.Expr.Plus(
                 operands = new_operands,
                 metas = new_metas
             )
@@ -3282,7 +3446,7 @@ abstract class ToyLangToToyLangIndexedVisitorTransform : DomainVisitorTransformB
     open fun transformExprMinus(node: ToyLang.Expr.Minus): ToyLangIndexed.Expr  {
         val new_operands = transformExprMinus_operands(node)
         val new_metas = transformExprMinus_metas(node)
-        return ToyLangIndexed.Expr.Minus(
+        return             ToyLangIndexed.Expr.Minus(
                 operands = new_operands,
                 metas = new_metas
             )
@@ -3296,7 +3460,7 @@ abstract class ToyLangToToyLangIndexedVisitorTransform : DomainVisitorTransformB
     open fun transformExprTimes(node: ToyLang.Expr.Times): ToyLangIndexed.Expr  {
         val new_operands = transformExprTimes_operands(node)
         val new_metas = transformExprTimes_metas(node)
-        return ToyLangIndexed.Expr.Times(
+        return             ToyLangIndexed.Expr.Times(
                 operands = new_operands,
                 metas = new_metas
             )
@@ -3310,7 +3474,7 @@ abstract class ToyLangToToyLangIndexedVisitorTransform : DomainVisitorTransformB
     open fun transformExprDivide(node: ToyLang.Expr.Divide): ToyLangIndexed.Expr  {
         val new_operands = transformExprDivide_operands(node)
         val new_metas = transformExprDivide_metas(node)
-        return ToyLangIndexed.Expr.Divide(
+        return             ToyLangIndexed.Expr.Divide(
                 operands = new_operands,
                 metas = new_metas
             )
@@ -3324,7 +3488,7 @@ abstract class ToyLangToToyLangIndexedVisitorTransform : DomainVisitorTransformB
     open fun transformExprModulo(node: ToyLang.Expr.Modulo): ToyLangIndexed.Expr  {
         val new_operands = transformExprModulo_operands(node)
         val new_metas = transformExprModulo_metas(node)
-        return ToyLangIndexed.Expr.Modulo(
+        return             ToyLangIndexed.Expr.Modulo(
                 operands = new_operands,
                 metas = new_metas
             )
@@ -3339,7 +3503,7 @@ abstract class ToyLangToToyLangIndexedVisitorTransform : DomainVisitorTransformB
         val new_name = transformExprCall_name(node)
         val new_argument = transformExprCall_argument(node)
         val new_metas = transformExprCall_metas(node)
-        return ToyLangIndexed.Expr.Call(
+        return             ToyLangIndexed.Expr.Call(
                 name = new_name,
                 argument = new_argument,
                 metas = new_metas
@@ -3359,7 +3523,7 @@ abstract class ToyLangToToyLangIndexedVisitorTransform : DomainVisitorTransformB
         val new_varName = transformExprFunction_varName(node)
         val new_body = transformExprFunction_body(node)
         val new_metas = transformExprFunction_metas(node)
-        return ToyLangIndexed.Expr.Function(
+        return             ToyLangIndexed.Expr.Function(
                 varName = new_varName,
                 body = new_body,
                 metas = new_metas
@@ -3395,7 +3559,7 @@ abstract class ToyLangIndexedToToyLangVisitorTransform : DomainVisitorTransformB
     open fun transformExprLit(node: ToyLangIndexed.Expr.Lit): ToyLang.Expr  {
         val new_value = transformExprLit_value(node)
         val new_metas = transformExprLit_metas(node)
-        return ToyLang.Expr.Lit(
+        return             ToyLang.Expr.Lit(
                 value = new_value,
                 metas = new_metas
             )
@@ -3409,7 +3573,7 @@ abstract class ToyLangIndexedToToyLangVisitorTransform : DomainVisitorTransformB
     open fun transformExprNot(node: ToyLangIndexed.Expr.Not): ToyLang.Expr  {
         val new_expr = transformExprNot_expr(node)
         val new_metas = transformExprNot_metas(node)
-        return ToyLang.Expr.Not(
+        return             ToyLang.Expr.Not(
                 expr = new_expr,
                 metas = new_metas
             )
@@ -3423,7 +3587,7 @@ abstract class ToyLangIndexedToToyLangVisitorTransform : DomainVisitorTransformB
     open fun transformExprPlus(node: ToyLangIndexed.Expr.Plus): ToyLang.Expr  {
         val new_operands = transformExprPlus_operands(node)
         val new_metas = transformExprPlus_metas(node)
-        return ToyLang.Expr.Plus(
+        return             ToyLang.Expr.Plus(
                 operands = new_operands,
                 metas = new_metas
             )
@@ -3437,7 +3601,7 @@ abstract class ToyLangIndexedToToyLangVisitorTransform : DomainVisitorTransformB
     open fun transformExprMinus(node: ToyLangIndexed.Expr.Minus): ToyLang.Expr  {
         val new_operands = transformExprMinus_operands(node)
         val new_metas = transformExprMinus_metas(node)
-        return ToyLang.Expr.Minus(
+        return             ToyLang.Expr.Minus(
                 operands = new_operands,
                 metas = new_metas
             )
@@ -3451,7 +3615,7 @@ abstract class ToyLangIndexedToToyLangVisitorTransform : DomainVisitorTransformB
     open fun transformExprTimes(node: ToyLangIndexed.Expr.Times): ToyLang.Expr  {
         val new_operands = transformExprTimes_operands(node)
         val new_metas = transformExprTimes_metas(node)
-        return ToyLang.Expr.Times(
+        return             ToyLang.Expr.Times(
                 operands = new_operands,
                 metas = new_metas
             )
@@ -3465,7 +3629,7 @@ abstract class ToyLangIndexedToToyLangVisitorTransform : DomainVisitorTransformB
     open fun transformExprDivide(node: ToyLangIndexed.Expr.Divide): ToyLang.Expr  {
         val new_operands = transformExprDivide_operands(node)
         val new_metas = transformExprDivide_metas(node)
-        return ToyLang.Expr.Divide(
+        return             ToyLang.Expr.Divide(
                 operands = new_operands,
                 metas = new_metas
             )
@@ -3479,7 +3643,7 @@ abstract class ToyLangIndexedToToyLangVisitorTransform : DomainVisitorTransformB
     open fun transformExprModulo(node: ToyLangIndexed.Expr.Modulo): ToyLang.Expr  {
         val new_operands = transformExprModulo_operands(node)
         val new_metas = transformExprModulo_metas(node)
-        return ToyLang.Expr.Modulo(
+        return             ToyLang.Expr.Modulo(
                 operands = new_operands,
                 metas = new_metas
             )
@@ -3494,7 +3658,7 @@ abstract class ToyLangIndexedToToyLangVisitorTransform : DomainVisitorTransformB
         val new_name = transformExprCall_name(node)
         val new_argument = transformExprCall_argument(node)
         val new_metas = transformExprCall_metas(node)
-        return ToyLang.Expr.Call(
+        return             ToyLang.Expr.Call(
                 name = new_name,
                 argument = new_argument,
                 metas = new_metas
@@ -3512,7 +3676,7 @@ abstract class ToyLangIndexedToToyLangVisitorTransform : DomainVisitorTransformB
         val new_varName = transformExprFunction_varName(node)
         val new_body = transformExprFunction_body(node)
         val new_metas = transformExprFunction_metas(node)
-        return ToyLang.Expr.Function(
+        return             ToyLang.Expr.Function(
                 varName = new_varName,
                 body = new_body,
                 metas = new_metas

--- a/pig-tests/test/org/partiql/pig/tests/VisitorTransformTests.kt
+++ b/pig-tests/test/org/partiql/pig/tests/VisitorTransformTests.kt
@@ -136,7 +136,7 @@ class VisitorTransformTests {
     }
 
     @Test
-    fun doesNotMakeUneccessaryCopiesWithWithLongPrimitives() {
+    fun doesNotMakeUnnecessaryCopiesWithWithLongPrimitives() {
         val input = TestDomain.build { intPair(1, 2) }
         val output = object : TestDomain.VisitorTransform() { }.transformIntPair(input)
         assertSame(input, output, "Expected same instance of IntPair to be returned from a VisitorTransform " +
@@ -144,7 +144,7 @@ class VisitorTransformTests {
     }
 
     @Test
-    fun doesNotMakeUneccessaryCopiesWithWithSymbolPrimitives() {
+    fun doesNotMakeUnnecessaryCopiesWithWithSymbolPrimitives() {
         val input = TestDomain.build { symbolPair("a", "b") }
         val output = object : TestDomain.VisitorTransform() { }.transformSymbolPair(input)
         assertSame(input, output, "Expected same instance of SymbolPair to be returned from a VisitorTransform " +


### PR DESCRIPTION
I'm not sure why this didn't occur to me earlier, but previously, the generated `VisitorTransform` classes *always* made a deep copy of the input tree. With this commit, only those nodes which are actually changed will be copied.

In the `transform*()` functions of the `VisitorTransform` super classes, we now check to see if all of the new child nodes are the same instance as the original child nodes.  If so, there is no need to copy the original node.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
