### PR TITLE
Renames DomainNode.copyMetas -> copy

### DIFF
--- a/pig-runtime/src/org/partiql/pig/runtime/DomainNode.kt
+++ b/pig-runtime/src/org/partiql/pig/runtime/DomainNode.kt
@@ -21,8 +21,8 @@ import com.amazon.ionelement.api.MetaContainer
 /** All generated domain classes must implement this interface. */
 interface DomainNode : MetaContainingNode {
 
-    /** Creates a copy of the current node with [newMetas] as the new metas. */
-    fun copyMetas(newMetas : MetaContainer): DomainNode
+    /** Creates a copy of the current node with [metas] as the new metas. */
+    fun copy(metas : MetaContainer): DomainNode
 
     /** Converts the current node to an instance of `IonElement`. */
     fun toIonElement(): IonElement

--- a/pig-runtime/src/org/partiql/pig/runtime/LongPrimitive.kt
+++ b/pig-runtime/src/org/partiql/pig/runtime/LongPrimitive.kt
@@ -31,9 +31,9 @@ class LongPrimitive(val value: Long, override val metas: MetaContainer) : Domain
     fun copy(value: Long = this.value, metas: MetaContainer = this.metas): LongPrimitive =
         LongPrimitive(value, metas)
 
-    /** Creates a copy of the current [LongPrimitive] with [newMetas] as the new metas. */
-    override fun copyMetas(newMetas: MetaContainer): LongPrimitive =
-        LongPrimitive(value, newMetas)
+    /** Creates a copy of the current [LongPrimitive] with [metas] as the new metas. */
+    override fun copy(metas: MetaContainer): LongPrimitive =
+        LongPrimitive(value, metas)
 
     /** Creates a copy of the current [LongPrimitive] with the specified additional meta. */
     override fun withMeta(metaKey: String, metaValue: Any): LongPrimitive =

--- a/pig-runtime/src/org/partiql/pig/runtime/SymbolPrimitive.kt
+++ b/pig-runtime/src/org/partiql/pig/runtime/SymbolPrimitive.kt
@@ -31,9 +31,9 @@ class SymbolPrimitive(val text: String, override val metas: MetaContainer) : Dom
     fun copy(text: String = this.text, metas: MetaContainer = this.metas): SymbolPrimitive =
         SymbolPrimitive(text, metas)
 
-    /** Creates a copy of the current [SymbolPrimitive] with [newMetas] as the new metas. */
-    override fun copyMetas(newMetas: MetaContainer): SymbolPrimitive =
-        SymbolPrimitive(text, newMetas)
+    /** Creates a copy of the current [SymbolPrimitive] with [metas] as the new metas. */
+    override fun copy(metas: MetaContainer): SymbolPrimitive =
+        SymbolPrimitive(text, metas)
 
     /** Creates a copy of the current [SymbolPrimitive] with the specified additional meta. */
     override fun withMeta(metaKey: String, metaValue: Any): SymbolPrimitive =

--- a/pig-runtime/test/org/partiql/pig/runtime/IonElementTransformerBaseTests.kt
+++ b/pig-runtime/test/org/partiql/pig/runtime/IonElementTransformerBaseTests.kt
@@ -31,7 +31,7 @@ class  IonElementTransformerBaseTests {
     abstract class DummyDomainNode : DomainNode
 
     data class CorrectDomainNode(val someString: String, override val metas: MetaContainer = emptyMetaContainer()): DummyDomainNode() {
-        override fun copyMetas(newMetas: MetaContainer): DomainNode {
+        override fun copy(metas: MetaContainer): DomainNode {
             error("does not need to be implemented for tests")
         }
 
@@ -44,7 +44,7 @@ class  IonElementTransformerBaseTests {
     }
 
     data class IncorrectDomainNode(val someString: String): DummyDomainNode() {
-        override fun copyMetas(newMetas: MetaContainer): DomainNode {
+        override fun copy(metas: MetaContainer): DomainNode {
             error("does not need to be implemented for tests")
         }
 

--- a/pig-tests/src/org/partiql/pig/tests/generated/partiql-basic.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/partiql-basic.kt
@@ -1390,7 +1390,7 @@ class PartiqlBasic private constructor() {
     
     /** Base class for all PartiqlBasic types. */
     abstract class PartiqlBasicNode : DomainNode {
-        abstract override fun copyMetas(newMetas: MetaContainer): PartiqlBasicNode
+        abstract override fun copy(metas: MetaContainer): PartiqlBasicNode
         override fun toString() = toIonElement().toString()
         abstract override fun withMeta(metaKey: String, metaValue: Any): PartiqlBasicNode
         abstract override fun toIonElement(): SexpElement
@@ -1406,11 +1406,11 @@ class PartiqlBasic private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): PartiqlBasicNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): ExprPair =
+        override fun copy(metas: MetaContainer): ExprPair =
             ExprPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): ExprPair =
             ExprPair(
@@ -1463,11 +1463,11 @@ class PartiqlBasic private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): PartiqlBasicNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): GroupByItem =
+        override fun copy(metas: MetaContainer): GroupByItem =
             GroupByItem(
                 value = value,
                 asAlias = asAlias,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): GroupByItem =
             GroupByItem(
@@ -1519,10 +1519,10 @@ class PartiqlBasic private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): PartiqlBasicNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): GroupByList =
+        override fun copy(metas: MetaContainer): GroupByList =
             GroupByList(
                 items = items,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): GroupByList =
             GroupByList(
@@ -1569,11 +1569,11 @@ class PartiqlBasic private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): PartiqlBasicNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): GroupBy =
+        override fun copy(metas: MetaContainer): GroupBy =
             GroupBy(
                 items = items,
                 groupAsAlias = groupAsAlias,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): GroupBy =
             GroupBy(
@@ -1626,10 +1626,10 @@ class PartiqlBasic private constructor() {
     /////////////////////////////////////////////////////////////////////////////
     
     sealed class Projection(override val metas: MetaContainer = emptyMetaContainer()) : PartiqlBasicNode() {
-        override fun copyMetas(newMetas: MetaContainer): Projection =
+        override fun copy(metas: MetaContainer): Projection =
             when (this) {
-                is ProjectList -> copy(metas = newMetas)
-                is ProjectValue -> copy(metas = newMetas)
+                is ProjectList -> copy(metas = metas)
+                is ProjectValue -> copy(metas = metas)
             }
     
         class ProjectList(
@@ -1637,10 +1637,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Projection() {
         
-            override fun copyMetas(newMetas: MetaContainer): ProjectList =
+            override fun copy(metas: MetaContainer): ProjectList =
                 ProjectList(
                     items = items,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): ProjectList =
                 ProjectList(
@@ -1686,10 +1686,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Projection() {
         
-            override fun copyMetas(newMetas: MetaContainer): ProjectValue =
+            override fun copy(metas: MetaContainer): ProjectValue =
                 ProjectValue(
                     value = value,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): ProjectValue =
                 ProjectValue(
@@ -1733,19 +1733,19 @@ class PartiqlBasic private constructor() {
     }
     
     sealed class ProjectItem(override val metas: MetaContainer = emptyMetaContainer()) : PartiqlBasicNode() {
-        override fun copyMetas(newMetas: MetaContainer): ProjectItem =
+        override fun copy(metas: MetaContainer): ProjectItem =
             when (this) {
-                is ProjectAll -> copy(metas = newMetas)
-                is ProjectExpr -> copy(metas = newMetas)
+                is ProjectAll -> copy(metas = metas)
+                is ProjectExpr -> copy(metas = metas)
             }
     
         class ProjectAll(
             override val metas: MetaContainer = emptyMetaContainer()
         ): ProjectItem() {
         
-            override fun copyMetas(newMetas: MetaContainer): ProjectAll =
+            override fun copy(metas: MetaContainer): ProjectAll =
                 ProjectAll(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): ProjectAll =
                 ProjectAll(
@@ -1758,11 +1758,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                ProjectAll(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -1781,11 +1776,11 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): ProjectItem() {
         
-            override fun copyMetas(newMetas: MetaContainer): ProjectExpr =
+            override fun copy(metas: MetaContainer): ProjectExpr =
                 ProjectExpr(
                     value = value,
                     asAlias = asAlias,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): ProjectExpr =
                 ProjectExpr(
@@ -1835,21 +1830,21 @@ class PartiqlBasic private constructor() {
     }
     
     sealed class JoinType(override val metas: MetaContainer = emptyMetaContainer()) : PartiqlBasicNode() {
-        override fun copyMetas(newMetas: MetaContainer): JoinType =
+        override fun copy(metas: MetaContainer): JoinType =
             when (this) {
-                is Inner -> copy(metas = newMetas)
-                is Left -> copy(metas = newMetas)
-                is Right -> copy(metas = newMetas)
-                is Outer -> copy(metas = newMetas)
+                is Inner -> copy(metas = metas)
+                is Left -> copy(metas = metas)
+                is Right -> copy(metas = metas)
+                is Outer -> copy(metas = metas)
             }
     
         class Inner(
             override val metas: MetaContainer = emptyMetaContainer()
         ): JoinType() {
         
-            override fun copyMetas(newMetas: MetaContainer): Inner =
+            override fun copy(metas: MetaContainer): Inner =
                 Inner(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Inner =
                 Inner(
@@ -1862,11 +1857,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Inner(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -1883,9 +1873,9 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): JoinType() {
         
-            override fun copyMetas(newMetas: MetaContainer): Left =
+            override fun copy(metas: MetaContainer): Left =
                 Left(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Left =
                 Left(
@@ -1898,11 +1888,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Left(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -1919,9 +1904,9 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): JoinType() {
         
-            override fun copyMetas(newMetas: MetaContainer): Right =
+            override fun copy(metas: MetaContainer): Right =
                 Right(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Right =
                 Right(
@@ -1934,11 +1919,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Right(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -1955,9 +1935,9 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): JoinType() {
         
-            override fun copyMetas(newMetas: MetaContainer): Outer =
+            override fun copy(metas: MetaContainer): Outer =
                 Outer(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Outer =
                 Outer(
@@ -1970,11 +1950,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Outer(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -1990,10 +1965,10 @@ class PartiqlBasic private constructor() {
     }
     
     sealed class FromSource(override val metas: MetaContainer = emptyMetaContainer()) : PartiqlBasicNode() {
-        override fun copyMetas(newMetas: MetaContainer): FromSource =
+        override fun copy(metas: MetaContainer): FromSource =
             when (this) {
-                is Scan -> copy(metas = newMetas)
-                is Join -> copy(metas = newMetas)
+                is Scan -> copy(metas = metas)
+                is Join -> copy(metas = metas)
             }
     
         class Scan(
@@ -2004,13 +1979,13 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): FromSource() {
         
-            override fun copyMetas(newMetas: MetaContainer): Scan =
+            override fun copy(metas: MetaContainer): Scan =
                 Scan(
                     expr = expr,
                     asAlias = asAlias,
                     atAlias = atAlias,
                     byAlias = byAlias,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Scan =
                 Scan(
@@ -2077,13 +2052,13 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): FromSource() {
         
-            override fun copyMetas(newMetas: MetaContainer): Join =
+            override fun copy(metas: MetaContainer): Join =
                 Join(
                     type = type,
                     left = left,
                     right = right,
                     predicate = predicate,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Join =
                 Join(
@@ -2145,19 +2120,19 @@ class PartiqlBasic private constructor() {
     }
     
     sealed class CaseSensitivity(override val metas: MetaContainer = emptyMetaContainer()) : PartiqlBasicNode() {
-        override fun copyMetas(newMetas: MetaContainer): CaseSensitivity =
+        override fun copy(metas: MetaContainer): CaseSensitivity =
             when (this) {
-                is CaseSensitive -> copy(metas = newMetas)
-                is CaseInsensitive -> copy(metas = newMetas)
+                is CaseSensitive -> copy(metas = metas)
+                is CaseInsensitive -> copy(metas = metas)
             }
     
         class CaseSensitive(
             override val metas: MetaContainer = emptyMetaContainer()
         ): CaseSensitivity() {
         
-            override fun copyMetas(newMetas: MetaContainer): CaseSensitive =
+            override fun copy(metas: MetaContainer): CaseSensitive =
                 CaseSensitive(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): CaseSensitive =
                 CaseSensitive(
@@ -2170,11 +2145,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                CaseSensitive(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -2191,9 +2161,9 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): CaseSensitivity() {
         
-            override fun copyMetas(newMetas: MetaContainer): CaseInsensitive =
+            override fun copy(metas: MetaContainer): CaseInsensitive =
                 CaseInsensitive(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): CaseInsensitive =
                 CaseInsensitive(
@@ -2206,11 +2176,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                CaseInsensitive(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -2226,19 +2191,19 @@ class PartiqlBasic private constructor() {
     }
     
     sealed class ScopeQualifier(override val metas: MetaContainer = emptyMetaContainer()) : PartiqlBasicNode() {
-        override fun copyMetas(newMetas: MetaContainer): ScopeQualifier =
+        override fun copy(metas: MetaContainer): ScopeQualifier =
             when (this) {
-                is Unqualified -> copy(metas = newMetas)
-                is Qualified -> copy(metas = newMetas)
+                is Unqualified -> copy(metas = metas)
+                is Qualified -> copy(metas = metas)
             }
     
         class Unqualified(
             override val metas: MetaContainer = emptyMetaContainer()
         ): ScopeQualifier() {
         
-            override fun copyMetas(newMetas: MetaContainer): Unqualified =
+            override fun copy(metas: MetaContainer): Unqualified =
                 Unqualified(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Unqualified =
                 Unqualified(
@@ -2251,11 +2216,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Unqualified(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -2272,9 +2232,9 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): ScopeQualifier() {
         
-            override fun copyMetas(newMetas: MetaContainer): Qualified =
+            override fun copy(metas: MetaContainer): Qualified =
                 Qualified(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Qualified =
                 Qualified(
@@ -2287,11 +2247,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Qualified(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -2307,19 +2262,19 @@ class PartiqlBasic private constructor() {
     }
     
     sealed class SetQuantifier(override val metas: MetaContainer = emptyMetaContainer()) : PartiqlBasicNode() {
-        override fun copyMetas(newMetas: MetaContainer): SetQuantifier =
+        override fun copy(metas: MetaContainer): SetQuantifier =
             when (this) {
-                is All -> copy(metas = newMetas)
-                is Distinct -> copy(metas = newMetas)
+                is All -> copy(metas = metas)
+                is Distinct -> copy(metas = metas)
             }
     
         class All(
             override val metas: MetaContainer = emptyMetaContainer()
         ): SetQuantifier() {
         
-            override fun copyMetas(newMetas: MetaContainer): All =
+            override fun copy(metas: MetaContainer): All =
                 All(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): All =
                 All(
@@ -2332,11 +2287,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                All(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -2353,9 +2303,9 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): SetQuantifier() {
         
-            override fun copyMetas(newMetas: MetaContainer): Distinct =
+            override fun copy(metas: MetaContainer): Distinct =
                 Distinct(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Distinct =
                 Distinct(
@@ -2368,11 +2318,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Distinct(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -2388,11 +2333,11 @@ class PartiqlBasic private constructor() {
     }
     
     sealed class PathElement(override val metas: MetaContainer = emptyMetaContainer()) : PartiqlBasicNode() {
-        override fun copyMetas(newMetas: MetaContainer): PathElement =
+        override fun copy(metas: MetaContainer): PathElement =
             when (this) {
-                is PathExpr -> copy(metas = newMetas)
-                is PathWildcard -> copy(metas = newMetas)
-                is PathUnpivot -> copy(metas = newMetas)
+                is PathExpr -> copy(metas = metas)
+                is PathWildcard -> copy(metas = metas)
+                is PathUnpivot -> copy(metas = metas)
             }
     
         class PathExpr(
@@ -2400,10 +2345,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): PathElement() {
         
-            override fun copyMetas(newMetas: MetaContainer): PathExpr =
+            override fun copy(metas: MetaContainer): PathExpr =
                 PathExpr(
                     expr = expr,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): PathExpr =
                 PathExpr(
@@ -2448,9 +2393,9 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): PathElement() {
         
-            override fun copyMetas(newMetas: MetaContainer): PathWildcard =
+            override fun copy(metas: MetaContainer): PathWildcard =
                 PathWildcard(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): PathWildcard =
                 PathWildcard(
@@ -2463,11 +2408,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                PathWildcard(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -2484,9 +2424,9 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): PathElement() {
         
-            override fun copyMetas(newMetas: MetaContainer): PathUnpivot =
+            override fun copy(metas: MetaContainer): PathUnpivot =
                 PathUnpivot(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): PathUnpivot =
                 PathUnpivot(
@@ -2499,11 +2439,6 @@ class PartiqlBasic private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                PathUnpivot(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -2519,29 +2454,29 @@ class PartiqlBasic private constructor() {
     }
     
     sealed class Expr(override val metas: MetaContainer = emptyMetaContainer()) : PartiqlBasicNode() {
-        override fun copyMetas(newMetas: MetaContainer): Expr =
+        override fun copy(metas: MetaContainer): Expr =
             when (this) {
-                is Lit -> copy(metas = newMetas)
-                is Id -> copy(metas = newMetas)
-                is Parameter -> copy(metas = newMetas)
-                is Not -> copy(metas = newMetas)
-                is Plus -> copy(metas = newMetas)
-                is Minus -> copy(metas = newMetas)
-                is Times -> copy(metas = newMetas)
-                is Divide -> copy(metas = newMetas)
-                is Modulo -> copy(metas = newMetas)
-                is Concat -> copy(metas = newMetas)
-                is Like -> copy(metas = newMetas)
-                is Between -> copy(metas = newMetas)
-                is Path -> copy(metas = newMetas)
-                is Call -> copy(metas = newMetas)
-                is CallAgg -> copy(metas = newMetas)
-                is SimpleCase -> copy(metas = newMetas)
-                is SearchedCase -> copy(metas = newMetas)
-                is Struct -> copy(metas = newMetas)
-                is Bag -> copy(metas = newMetas)
-                is List -> copy(metas = newMetas)
-                is Select -> copy(metas = newMetas)
+                is Lit -> copy(metas = metas)
+                is Id -> copy(metas = metas)
+                is Parameter -> copy(metas = metas)
+                is Not -> copy(metas = metas)
+                is Plus -> copy(metas = metas)
+                is Minus -> copy(metas = metas)
+                is Times -> copy(metas = metas)
+                is Divide -> copy(metas = metas)
+                is Modulo -> copy(metas = metas)
+                is Concat -> copy(metas = metas)
+                is Like -> copy(metas = metas)
+                is Between -> copy(metas = metas)
+                is Path -> copy(metas = metas)
+                is Call -> copy(metas = metas)
+                is CallAgg -> copy(metas = metas)
+                is SimpleCase -> copy(metas = metas)
+                is SearchedCase -> copy(metas = metas)
+                is Struct -> copy(metas = metas)
+                is Bag -> copy(metas = metas)
+                is List -> copy(metas = metas)
+                is Select -> copy(metas = metas)
             }
     
         class Lit(
@@ -2549,10 +2484,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Lit =
+            override fun copy(metas: MetaContainer): Lit =
                 Lit(
                     value = value,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Lit =
                 Lit(
@@ -2600,12 +2535,12 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Id =
+            override fun copy(metas: MetaContainer): Id =
                 Id(
                     name = name,
                     case = case,
                     scopeQualifier = scopeQualifier,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Id =
                 Id(
@@ -2663,10 +2598,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Parameter =
+            override fun copy(metas: MetaContainer): Parameter =
                 Parameter(
                     index = index,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Parameter =
                 Parameter(
@@ -2712,10 +2647,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Not =
+            override fun copy(metas: MetaContainer): Not =
                 Not(
                     expr = expr,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Not =
                 Not(
@@ -2761,10 +2696,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Plus =
+            override fun copy(metas: MetaContainer): Plus =
                 Plus(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Plus =
                 Plus(
@@ -2810,10 +2745,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Minus =
+            override fun copy(metas: MetaContainer): Minus =
                 Minus(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Minus =
                 Minus(
@@ -2859,10 +2794,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Times =
+            override fun copy(metas: MetaContainer): Times =
                 Times(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Times =
                 Times(
@@ -2908,10 +2843,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Divide =
+            override fun copy(metas: MetaContainer): Divide =
                 Divide(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Divide =
                 Divide(
@@ -2957,10 +2892,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Modulo =
+            override fun copy(metas: MetaContainer): Modulo =
                 Modulo(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Modulo =
                 Modulo(
@@ -3006,10 +2941,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Concat =
+            override fun copy(metas: MetaContainer): Concat =
                 Concat(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Concat =
                 Concat(
@@ -3057,12 +2992,12 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Like =
+            override fun copy(metas: MetaContainer): Like =
                 Like(
                     left = left,
                     right = right,
                     escape = escape,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Like =
                 Like(
@@ -3122,12 +3057,12 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Between =
+            override fun copy(metas: MetaContainer): Between =
                 Between(
                     value = value,
                     from = from,
                     to = to,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Between =
                 Between(
@@ -3186,11 +3121,11 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Path =
+            override fun copy(metas: MetaContainer): Path =
                 Path(
                     root = root,
                     elements = elements,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Path =
                 Path(
@@ -3243,11 +3178,11 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Call =
+            override fun copy(metas: MetaContainer): Call =
                 Call(
                     name = name,
                     args = args,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Call =
                 Call(
@@ -3301,12 +3236,12 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): CallAgg =
+            override fun copy(metas: MetaContainer): CallAgg =
                 CallAgg(
                     name = name,
                     setQuantifier = setQuantifier,
                     arg = arg,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): CallAgg =
                 CallAgg(
@@ -3365,11 +3300,11 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): SimpleCase =
+            override fun copy(metas: MetaContainer): SimpleCase =
                 SimpleCase(
                     value = value,
                     branches = branches,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): SimpleCase =
                 SimpleCase(
@@ -3421,10 +3356,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): SearchedCase =
+            override fun copy(metas: MetaContainer): SearchedCase =
                 SearchedCase(
                     branches = branches,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): SearchedCase =
                 SearchedCase(
@@ -3470,10 +3405,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Struct =
+            override fun copy(metas: MetaContainer): Struct =
                 Struct(
                     fields = fields,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Struct =
                 Struct(
@@ -3519,10 +3454,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Bag =
+            override fun copy(metas: MetaContainer): Bag =
                 Bag(
                     values = values,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Bag =
                 Bag(
@@ -3568,10 +3503,10 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): List =
+            override fun copy(metas: MetaContainer): List =
                 List(
                     values = values,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): List =
                 List(
@@ -3623,7 +3558,7 @@ class PartiqlBasic private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Select =
+            override fun copy(metas: MetaContainer): Select =
                 Select(
                     setq = setq,
                     project = project,
@@ -3632,7 +3567,7 @@ class PartiqlBasic private constructor() {
                     group = group,
                     having = having,
                     limit = limit,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Select =
                 Select(

--- a/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
@@ -1389,7 +1389,7 @@ class TestDomain private constructor() {
     
     /** Base class for all TestDomain types. */
     abstract class TestDomainNode : DomainNode {
-        abstract override fun copyMetas(newMetas: MetaContainer): TestDomainNode
+        abstract override fun copy(metas: MetaContainer): TestDomainNode
         override fun toString() = toIonElement().toString()
         abstract override fun withMeta(metaKey: String, metaValue: Any): TestDomainNode
         abstract override fun toIonElement(): SexpElement
@@ -1405,11 +1405,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): IntPair =
+        override fun copy(metas: MetaContainer): IntPair =
             IntPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): IntPair =
             IntPair(
@@ -1462,11 +1462,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): SymbolPair =
+        override fun copy(metas: MetaContainer): SymbolPair =
             SymbolPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): SymbolPair =
             SymbolPair(
@@ -1519,11 +1519,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): IonPair =
+        override fun copy(metas: MetaContainer): IonPair =
             IonPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): IonPair =
             IonPair(
@@ -1576,11 +1576,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): IntSymbolPair =
+        override fun copy(metas: MetaContainer): IntSymbolPair =
             IntSymbolPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): IntSymbolPair =
             IntSymbolPair(
@@ -1633,11 +1633,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): SymbolIntPair =
+        override fun copy(metas: MetaContainer): SymbolIntPair =
             SymbolIntPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): SymbolIntPair =
             SymbolIntPair(
@@ -1690,11 +1690,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): IonIntPair =
+        override fun copy(metas: MetaContainer): IonIntPair =
             IonIntPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): IonIntPair =
             IonIntPair(
@@ -1747,11 +1747,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): IonSymbolPair =
+        override fun copy(metas: MetaContainer): IonSymbolPair =
             IonSymbolPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): IonSymbolPair =
             IonSymbolPair(
@@ -1804,11 +1804,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): IntPairPair =
+        override fun copy(metas: MetaContainer): IntPairPair =
             IntPairPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): IntPairPair =
             IntPairPair(
@@ -1861,11 +1861,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): SymbolPairPair =
+        override fun copy(metas: MetaContainer): SymbolPairPair =
             SymbolPairPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): SymbolPairPair =
             SymbolPairPair(
@@ -1918,11 +1918,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): IonPairPair =
+        override fun copy(metas: MetaContainer): IonPairPair =
             IonPairPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): IonPairPair =
             IonPairPair(
@@ -1975,11 +1975,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): RecursivePair =
+        override fun copy(metas: MetaContainer): RecursivePair =
             RecursivePair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): RecursivePair =
             RecursivePair(
@@ -2032,11 +2032,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AnswerPair =
+        override fun copy(metas: MetaContainer): AnswerPair =
             AnswerPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AnswerPair =
             AnswerPair(
@@ -2089,11 +2089,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AnswerIntPair =
+        override fun copy(metas: MetaContainer): AnswerIntPair =
             AnswerIntPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AnswerIntPair =
             AnswerIntPair(
@@ -2146,11 +2146,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): IntAnswerPair =
+        override fun copy(metas: MetaContainer): IntAnswerPair =
             IntAnswerPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): IntAnswerPair =
             IntAnswerPair(
@@ -2203,11 +2203,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): SymbolAnswerPair =
+        override fun copy(metas: MetaContainer): SymbolAnswerPair =
             SymbolAnswerPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): SymbolAnswerPair =
             SymbolAnswerPair(
@@ -2260,11 +2260,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AnswerSymbolPair =
+        override fun copy(metas: MetaContainer): AnswerSymbolPair =
             AnswerSymbolPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AnswerSymbolPair =
             AnswerSymbolPair(
@@ -2316,10 +2316,10 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): VariadicMin0 =
+        override fun copy(metas: MetaContainer): VariadicMin0 =
             VariadicMin0(
                 ints = ints,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): VariadicMin0 =
             VariadicMin0(
@@ -2365,10 +2365,10 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): VariadicMin1 =
+        override fun copy(metas: MetaContainer): VariadicMin1 =
             VariadicMin1(
                 ints = ints,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): VariadicMin1 =
             VariadicMin1(
@@ -2415,11 +2415,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): ElementVariadic =
+        override fun copy(metas: MetaContainer): ElementVariadic =
             ElementVariadic(
                 name = name,
                 ints = ints,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): ElementVariadic =
             ElementVariadic(
@@ -2471,10 +2471,10 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): Optional1 =
+        override fun copy(metas: MetaContainer): Optional1 =
             Optional1(
                 value = value,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): Optional1 =
             Optional1(
@@ -2521,11 +2521,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): Optional2 =
+        override fun copy(metas: MetaContainer): Optional2 =
             Optional2(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): Optional2 =
             Optional2(
@@ -2579,12 +2579,12 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): DomainLevelRecord =
+        override fun copy(metas: MetaContainer): DomainLevelRecord =
             DomainLevelRecord(
                 someField = someField,
                 anotherField = anotherField,
                 optionalField = optionalField,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): DomainLevelRecord =
             DomainLevelRecord(
@@ -2644,11 +2644,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): ProductWithRecord =
+        override fun copy(metas: MetaContainer): ProductWithRecord =
             ProductWithRecord(
                 value = value,
                 dlr = dlr,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): ProductWithRecord =
             ProductWithRecord(
@@ -2702,12 +2702,12 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): TestSumTriplet =
+        override fun copy(metas: MetaContainer): TestSumTriplet =
             TestSumTriplet(
                 a = a,
                 b = b,
                 c = c,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): TestSumTriplet =
             TestSumTriplet(
@@ -2766,11 +2766,11 @@ class TestDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): TestDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): EntityPair =
+        override fun copy(metas: MetaContainer): EntityPair =
             EntityPair(
                 first = first,
                 second = second,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): EntityPair =
             EntityPair(
@@ -2823,19 +2823,19 @@ class TestDomain private constructor() {
     /////////////////////////////////////////////////////////////////////////////
     
     sealed class Answer(override val metas: MetaContainer = emptyMetaContainer()) : TestDomainNode() {
-        override fun copyMetas(newMetas: MetaContainer): Answer =
+        override fun copy(metas: MetaContainer): Answer =
             when (this) {
-                is No -> copy(metas = newMetas)
-                is Yes -> copy(metas = newMetas)
+                is No -> copy(metas = metas)
+                is Yes -> copy(metas = metas)
             }
     
         class No(
             override val metas: MetaContainer = emptyMetaContainer()
         ): Answer() {
         
-            override fun copyMetas(newMetas: MetaContainer): No =
+            override fun copy(metas: MetaContainer): No =
                 No(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): No =
                 No(
@@ -2848,11 +2848,6 @@ class TestDomain private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                No(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -2869,9 +2864,9 @@ class TestDomain private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Answer() {
         
-            override fun copyMetas(newMetas: MetaContainer): Yes =
+            override fun copy(metas: MetaContainer): Yes =
                 Yes(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Yes =
                 Yes(
@@ -2884,11 +2879,6 @@ class TestDomain private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Yes(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -2904,9 +2894,9 @@ class TestDomain private constructor() {
     }
     
     sealed class SumWithRecord(override val metas: MetaContainer = emptyMetaContainer()) : TestDomainNode() {
-        override fun copyMetas(newMetas: MetaContainer): SumWithRecord =
+        override fun copy(metas: MetaContainer): SumWithRecord =
             when (this) {
-                is VariantWithRecord -> copy(metas = newMetas)
+                is VariantWithRecord -> copy(metas = metas)
             }
     
         class VariantWithRecord(
@@ -2915,11 +2905,11 @@ class TestDomain private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): SumWithRecord() {
         
-            override fun copyMetas(newMetas: MetaContainer): VariantWithRecord =
+            override fun copy(metas: MetaContainer): VariantWithRecord =
                 VariantWithRecord(
                     value = value,
                     dlr = dlr,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): VariantWithRecord =
                 VariantWithRecord(
@@ -2969,11 +2959,11 @@ class TestDomain private constructor() {
     }
     
     sealed class TestSum(override val metas: MetaContainer = emptyMetaContainer()) : TestDomainNode() {
-        override fun copyMetas(newMetas: MetaContainer): TestSum =
+        override fun copy(metas: MetaContainer): TestSum =
             when (this) {
-                is One -> copy(metas = newMetas)
-                is Two -> copy(metas = newMetas)
-                is Three -> copy(metas = newMetas)
+                is One -> copy(metas = metas)
+                is Two -> copy(metas = metas)
+                is Three -> copy(metas = metas)
             }
     
         class One(
@@ -2981,10 +2971,10 @@ class TestDomain private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): TestSum() {
         
-            override fun copyMetas(newMetas: MetaContainer): One =
+            override fun copy(metas: MetaContainer): One =
                 One(
                     a = a,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): One =
                 One(
@@ -3031,11 +3021,11 @@ class TestDomain private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): TestSum() {
         
-            override fun copyMetas(newMetas: MetaContainer): Two =
+            override fun copy(metas: MetaContainer): Two =
                 Two(
                     a = a,
                     b = b,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Two =
                 Two(
@@ -3089,12 +3079,12 @@ class TestDomain private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): TestSum() {
         
-            override fun copyMetas(newMetas: MetaContainer): Three =
+            override fun copy(metas: MetaContainer): Three =
                 Three(
                     a = a,
                     b = b,
                     c = c,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Three =
                 Three(
@@ -3150,20 +3140,20 @@ class TestDomain private constructor() {
     }
     
     sealed class Entity(override val metas: MetaContainer = emptyMetaContainer()) : TestDomainNode() {
-        override fun copyMetas(newMetas: MetaContainer): Entity =
+        override fun copy(metas: MetaContainer): Entity =
             when (this) {
-                is Slug -> copy(metas = newMetas)
-                is Android -> copy(metas = newMetas)
-                is Human -> copy(metas = newMetas)
+                is Slug -> copy(metas = metas)
+                is Android -> copy(metas = metas)
+                is Human -> copy(metas = metas)
             }
     
         class Slug(
             override val metas: MetaContainer = emptyMetaContainer()
         ): Entity() {
         
-            override fun copyMetas(newMetas: MetaContainer): Slug =
+            override fun copy(metas: MetaContainer): Slug =
                 Slug(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Slug =
                 Slug(
@@ -3176,11 +3166,6 @@ class TestDomain private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Slug(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -3198,10 +3183,10 @@ class TestDomain private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Entity() {
         
-            override fun copyMetas(newMetas: MetaContainer): Android =
+            override fun copy(metas: MetaContainer): Android =
                 Android(
                     id = id,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Android =
                 Android(
@@ -3251,14 +3236,14 @@ class TestDomain private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Entity() {
         
-            override fun copyMetas(newMetas: MetaContainer): Human =
+            override fun copy(metas: MetaContainer): Human =
                 Human(
                     firstName = firstName,
                     middleNames = middleNames,
                     lastName = lastName,
                     title = title,
                     parent = parent,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Human =
                 Human(
@@ -6063,7 +6048,7 @@ class MultiWordDomain private constructor() {
     
     /** Base class for all MultiWordDomain types. */
     abstract class MultiWordDomainNode : DomainNode {
-        abstract override fun copyMetas(newMetas: MetaContainer): MultiWordDomainNode
+        abstract override fun copy(metas: MetaContainer): MultiWordDomainNode
         override fun toString() = toIonElement().toString()
         abstract override fun withMeta(metaKey: String, metaValue: Any): MultiWordDomainNode
         abstract override fun toIonElement(): SexpElement
@@ -6077,9 +6062,9 @@ class MultiWordDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): MultiWordDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AaaAaa =
+        override fun copy(metas: MetaContainer): AaaAaa =
             AaaAaa(
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AaaAaa =
             AaaAaa(
@@ -6092,11 +6077,6 @@ class MultiWordDomain private constructor() {
             return elements
         }
     
-        fun copy(
-            metas: MetaContainer = this.metas
-        ) =
-            AaaAaa(
-                metas)
     
         override fun equals(other: Any?): Boolean {
             if (other == null) return false
@@ -6114,10 +6094,10 @@ class MultiWordDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): MultiWordDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AaaAab =
+        override fun copy(metas: MetaContainer): AaaAab =
             AaaAab(
                 dField = dField,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AaaAab =
             AaaAab(
@@ -6164,11 +6144,11 @@ class MultiWordDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): MultiWordDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AaaAac =
+        override fun copy(metas: MetaContainer): AaaAac =
             AaaAac(
                 dField = dField,
                 eField = eField,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AaaAac =
             AaaAac(
@@ -6220,10 +6200,10 @@ class MultiWordDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): MultiWordDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AaaAad =
+        override fun copy(metas: MetaContainer): AaaAad =
             AaaAad(
                 dField = dField,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AaaAad =
             AaaAad(
@@ -6269,10 +6249,10 @@ class MultiWordDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): MultiWordDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AaaAae =
+        override fun copy(metas: MetaContainer): AaaAae =
             AaaAae(
                 dField = dField,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AaaAae =
             AaaAae(
@@ -6319,11 +6299,11 @@ class MultiWordDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): MultiWordDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AabAaa =
+        override fun copy(metas: MetaContainer): AabAaa =
             AabAaa(
                 bField = bField,
                 cField = cField,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AabAaa =
             AabAaa(
@@ -6377,12 +6357,12 @@ class MultiWordDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): MultiWordDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AabAab =
+        override fun copy(metas: MetaContainer): AabAab =
             AabAab(
                 bField = bField,
                 cField = cField,
                 dField = dField,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AabAab =
             AabAab(
@@ -6443,13 +6423,13 @@ class MultiWordDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): MultiWordDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AabAac =
+        override fun copy(metas: MetaContainer): AabAac =
             AabAac(
                 bField = bField,
                 cField = cField,
                 dField = dField,
                 eField = eField,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AabAac =
             AabAac(
@@ -6515,12 +6495,12 @@ class MultiWordDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): MultiWordDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AabAad =
+        override fun copy(metas: MetaContainer): AabAad =
             AabAad(
                 bField = bField,
                 cField = cField,
                 dField = dField,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AabAad =
             AabAad(
@@ -6580,12 +6560,12 @@ class MultiWordDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): MultiWordDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): AabAae =
+        override fun copy(metas: MetaContainer): AabAae =
             AabAae(
                 bField = bField,
                 cField = cField,
                 dField = dField,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): AabAae =
             AabAae(
@@ -6644,11 +6624,11 @@ class MultiWordDomain private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): MultiWordDomainNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): Rrr =
+        override fun copy(metas: MetaContainer): Rrr =
             Rrr(
                 aField = aField,
                 bbbField = bbbField,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): Rrr =
             Rrr(
@@ -6702,10 +6682,10 @@ class MultiWordDomain private constructor() {
     /////////////////////////////////////////////////////////////////////////////
     
     sealed class SssTtt(override val metas: MetaContainer = emptyMetaContainer()) : MultiWordDomainNode() {
-        override fun copyMetas(newMetas: MetaContainer): SssTtt =
+        override fun copy(metas: MetaContainer): SssTtt =
             when (this) {
-                is Lll -> copy(metas = newMetas)
-                is Mmm -> copy(metas = newMetas)
+                is Lll -> copy(metas = metas)
+                is Mmm -> copy(metas = metas)
             }
     
         class Lll(
@@ -6713,10 +6693,10 @@ class MultiWordDomain private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): SssTtt() {
         
-            override fun copyMetas(newMetas: MetaContainer): Lll =
+            override fun copy(metas: MetaContainer): Lll =
                 Lll(
                     uField = uField,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Lll =
                 Lll(
@@ -6762,10 +6742,10 @@ class MultiWordDomain private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): SssTtt() {
         
-            override fun copyMetas(newMetas: MetaContainer): Mmm =
+            override fun copy(metas: MetaContainer): Mmm =
                 Mmm(
                     vField = vField,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Mmm =
                 Mmm(
@@ -8071,7 +8051,7 @@ class DomainA private constructor() {
     
     /** Base class for all DomainA types. */
     abstract class DomainANode : DomainNode {
-        abstract override fun copyMetas(newMetas: MetaContainer): DomainANode
+        abstract override fun copy(metas: MetaContainer): DomainANode
         override fun toString() = toIonElement().toString()
         abstract override fun withMeta(metaKey: String, metaValue: Any): DomainANode
         abstract override fun toIonElement(): SexpElement
@@ -8086,10 +8066,10 @@ class DomainA private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): DomainANode() {
     
-        override fun copyMetas(newMetas: MetaContainer): ProductToRemove =
+        override fun copy(metas: MetaContainer): ProductToRemove =
             ProductToRemove(
                 whatever = whatever,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): ProductToRemove =
             ProductToRemove(
@@ -8135,10 +8115,10 @@ class DomainA private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): DomainANode() {
     
-        override fun copyMetas(newMetas: MetaContainer): RecordToRemove =
+        override fun copy(metas: MetaContainer): RecordToRemove =
             RecordToRemove(
                 irrelevant = irrelevant,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): RecordToRemove =
             RecordToRemove(
@@ -8185,10 +8165,10 @@ class DomainA private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): DomainANode() {
     
-        override fun copyMetas(newMetas: MetaContainer): ProductA =
+        override fun copy(metas: MetaContainer): ProductA =
             ProductA(
                 one = one,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): ProductA =
             ProductA(
@@ -8234,10 +8214,10 @@ class DomainA private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): DomainANode() {
     
-        override fun copyMetas(newMetas: MetaContainer): RecordA =
+        override fun copy(metas: MetaContainer): RecordA =
             RecordA(
                 one = one,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): RecordA =
             RecordA(
@@ -8285,11 +8265,11 @@ class DomainA private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): DomainANode() {
     
-        override fun copyMetas(newMetas: MetaContainer): UnpermutedProduct =
+        override fun copy(metas: MetaContainer): UnpermutedProduct =
             UnpermutedProduct(
                 foo = foo,
                 bar = bar,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): UnpermutedProduct =
             UnpermutedProduct(
@@ -8342,11 +8322,11 @@ class DomainA private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): DomainANode() {
     
-        override fun copyMetas(newMetas: MetaContainer): UnpermutedRecord =
+        override fun copy(metas: MetaContainer): UnpermutedRecord =
             UnpermutedRecord(
                 foo = foo,
                 bar = bar,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): UnpermutedRecord =
             UnpermutedRecord(
@@ -8400,19 +8380,19 @@ class DomainA private constructor() {
     /////////////////////////////////////////////////////////////////////////////
     
     sealed class SumToRemove(override val metas: MetaContainer = emptyMetaContainer()) : DomainANode() {
-        override fun copyMetas(newMetas: MetaContainer): SumToRemove =
+        override fun copy(metas: MetaContainer): SumToRemove =
             when (this) {
-                is Doesnt -> copy(metas = newMetas)
-                is Matter -> copy(metas = newMetas)
+                is Doesnt -> copy(metas = metas)
+                is Matter -> copy(metas = metas)
             }
     
         class Doesnt(
             override val metas: MetaContainer = emptyMetaContainer()
         ): SumToRemove() {
         
-            override fun copyMetas(newMetas: MetaContainer): Doesnt =
+            override fun copy(metas: MetaContainer): Doesnt =
                 Doesnt(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Doesnt =
                 Doesnt(
@@ -8425,11 +8405,6 @@ class DomainA private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Doesnt(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -8446,9 +8421,9 @@ class DomainA private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): SumToRemove() {
         
-            override fun copyMetas(newMetas: MetaContainer): Matter =
+            override fun copy(metas: MetaContainer): Matter =
                 Matter(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Matter =
                 Matter(
@@ -8461,11 +8436,6 @@ class DomainA private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Matter(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -8481,19 +8451,19 @@ class DomainA private constructor() {
     }
     
     sealed class SumA(override val metas: MetaContainer = emptyMetaContainer()) : DomainANode() {
-        override fun copyMetas(newMetas: MetaContainer): SumA =
+        override fun copy(metas: MetaContainer): SumA =
             when (this) {
-                is Who -> copy(metas = newMetas)
-                is Cares -> copy(metas = newMetas)
+                is Who -> copy(metas = metas)
+                is Cares -> copy(metas = metas)
             }
     
         class Who(
             override val metas: MetaContainer = emptyMetaContainer()
         ): SumA() {
         
-            override fun copyMetas(newMetas: MetaContainer): Who =
+            override fun copy(metas: MetaContainer): Who =
                 Who(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Who =
                 Who(
@@ -8506,11 +8476,6 @@ class DomainA private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Who(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -8527,9 +8492,9 @@ class DomainA private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): SumA() {
         
-            override fun copyMetas(newMetas: MetaContainer): Cares =
+            override fun copy(metas: MetaContainer): Cares =
                 Cares(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Cares =
                 Cares(
@@ -8542,11 +8507,6 @@ class DomainA private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Cares(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -8562,20 +8522,20 @@ class DomainA private constructor() {
     }
     
     sealed class SumB(override val metas: MetaContainer = emptyMetaContainer()) : DomainANode() {
-        override fun copyMetas(newMetas: MetaContainer): SumB =
+        override fun copy(metas: MetaContainer): SumB =
             when (this) {
-                is WillBeUnchanged -> copy(metas = newMetas)
-                is WillBeRemoved -> copy(metas = newMetas)
-                is WillBeReplaced -> copy(metas = newMetas)
+                is WillBeUnchanged -> copy(metas = metas)
+                is WillBeRemoved -> copy(metas = metas)
+                is WillBeReplaced -> copy(metas = metas)
             }
     
         class WillBeUnchanged(
             override val metas: MetaContainer = emptyMetaContainer()
         ): SumB() {
         
-            override fun copyMetas(newMetas: MetaContainer): WillBeUnchanged =
+            override fun copy(metas: MetaContainer): WillBeUnchanged =
                 WillBeUnchanged(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): WillBeUnchanged =
                 WillBeUnchanged(
@@ -8588,11 +8548,6 @@ class DomainA private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                WillBeUnchanged(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -8609,9 +8564,9 @@ class DomainA private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): SumB() {
         
-            override fun copyMetas(newMetas: MetaContainer): WillBeRemoved =
+            override fun copy(metas: MetaContainer): WillBeRemoved =
                 WillBeRemoved(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): WillBeRemoved =
                 WillBeRemoved(
@@ -8624,11 +8579,6 @@ class DomainA private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                WillBeRemoved(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -8646,10 +8596,10 @@ class DomainA private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): SumB() {
         
-            override fun copyMetas(newMetas: MetaContainer): WillBeReplaced =
+            override fun copy(metas: MetaContainer): WillBeReplaced =
                 WillBeReplaced(
                     something = something,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): WillBeReplaced =
                 WillBeReplaced(
@@ -8693,10 +8643,10 @@ class DomainA private constructor() {
     }
     
     sealed class UnpermutedSum(override val metas: MetaContainer = emptyMetaContainer()) : DomainANode() {
-        override fun copyMetas(newMetas: MetaContainer): UnpermutedSum =
+        override fun copy(metas: MetaContainer): UnpermutedSum =
             when (this) {
-                is UnpermutedProductVariant -> copy(metas = newMetas)
-                is UnpermutedRecordVariant -> copy(metas = newMetas)
+                is UnpermutedProductVariant -> copy(metas = metas)
+                is UnpermutedRecordVariant -> copy(metas = metas)
             }
     
         class UnpermutedProductVariant(
@@ -8705,11 +8655,11 @@ class DomainA private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): UnpermutedSum() {
         
-            override fun copyMetas(newMetas: MetaContainer): UnpermutedProductVariant =
+            override fun copy(metas: MetaContainer): UnpermutedProductVariant =
                 UnpermutedProductVariant(
                     foo = foo,
                     bar = bar,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): UnpermutedProductVariant =
                 UnpermutedProductVariant(
@@ -8762,11 +8712,11 @@ class DomainA private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): UnpermutedSum() {
         
-            override fun copyMetas(newMetas: MetaContainer): UnpermutedRecordVariant =
+            override fun copy(metas: MetaContainer): UnpermutedRecordVariant =
                 UnpermutedRecordVariant(
                     foo = foo,
                     bar = bar,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): UnpermutedRecordVariant =
                 UnpermutedRecordVariant(
@@ -10134,7 +10084,7 @@ class DomainB private constructor() {
     
     /** Base class for all DomainB types. */
     abstract class DomainBNode : DomainNode {
-        abstract override fun copyMetas(newMetas: MetaContainer): DomainBNode
+        abstract override fun copy(metas: MetaContainer): DomainBNode
         override fun toString() = toIonElement().toString()
         abstract override fun withMeta(metaKey: String, metaValue: Any): DomainBNode
         abstract override fun toIonElement(): SexpElement
@@ -10150,11 +10100,11 @@ class DomainB private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): DomainBNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): UnpermutedProduct =
+        override fun copy(metas: MetaContainer): UnpermutedProduct =
             UnpermutedProduct(
                 foo = foo,
                 bar = bar,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): UnpermutedProduct =
             UnpermutedProduct(
@@ -10207,11 +10157,11 @@ class DomainB private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): DomainBNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): UnpermutedRecord =
+        override fun copy(metas: MetaContainer): UnpermutedRecord =
             UnpermutedRecord(
                 foo = foo,
                 bar = bar,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): UnpermutedRecord =
             UnpermutedRecord(
@@ -10264,10 +10214,10 @@ class DomainB private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): DomainBNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): ProductA =
+        override fun copy(metas: MetaContainer): ProductA =
             ProductA(
                 one = one,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): ProductA =
             ProductA(
@@ -10313,10 +10263,10 @@ class DomainB private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): DomainBNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): RecordA =
+        override fun copy(metas: MetaContainer): RecordA =
             RecordA(
                 one = one,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): RecordA =
             RecordA(
@@ -10363,10 +10313,10 @@ class DomainB private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): DomainBNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): NewProduct =
+        override fun copy(metas: MetaContainer): NewProduct =
             NewProduct(
                 foo = foo,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): NewProduct =
             NewProduct(
@@ -10412,10 +10362,10 @@ class DomainB private constructor() {
         override val metas: MetaContainer = emptyMetaContainer()
     ): DomainBNode() {
     
-        override fun copyMetas(newMetas: MetaContainer): NewRecord =
+        override fun copy(metas: MetaContainer): NewRecord =
             NewRecord(
                 foo = foo,
-                metas = newMetas)
+                metas = metas)
     
         override fun withMeta(metaKey: String, metaValue: Any): NewRecord =
             NewRecord(
@@ -10463,10 +10413,10 @@ class DomainB private constructor() {
     /////////////////////////////////////////////////////////////////////////////
     
     sealed class UnpermutedSum(override val metas: MetaContainer = emptyMetaContainer()) : DomainBNode() {
-        override fun copyMetas(newMetas: MetaContainer): UnpermutedSum =
+        override fun copy(metas: MetaContainer): UnpermutedSum =
             when (this) {
-                is UnpermutedProductVariant -> copy(metas = newMetas)
-                is UnpermutedRecordVariant -> copy(metas = newMetas)
+                is UnpermutedProductVariant -> copy(metas = metas)
+                is UnpermutedRecordVariant -> copy(metas = metas)
             }
     
         class UnpermutedProductVariant(
@@ -10475,11 +10425,11 @@ class DomainB private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): UnpermutedSum() {
         
-            override fun copyMetas(newMetas: MetaContainer): UnpermutedProductVariant =
+            override fun copy(metas: MetaContainer): UnpermutedProductVariant =
                 UnpermutedProductVariant(
                     foo = foo,
                     bar = bar,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): UnpermutedProductVariant =
                 UnpermutedProductVariant(
@@ -10532,11 +10482,11 @@ class DomainB private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): UnpermutedSum() {
         
-            override fun copyMetas(newMetas: MetaContainer): UnpermutedRecordVariant =
+            override fun copy(metas: MetaContainer): UnpermutedRecordVariant =
                 UnpermutedRecordVariant(
                     foo = foo,
                     bar = bar,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): UnpermutedRecordVariant =
                 UnpermutedRecordVariant(
@@ -10587,19 +10537,19 @@ class DomainB private constructor() {
     }
     
     sealed class SumB(override val metas: MetaContainer = emptyMetaContainer()) : DomainBNode() {
-        override fun copyMetas(newMetas: MetaContainer): SumB =
+        override fun copy(metas: MetaContainer): SumB =
             when (this) {
-                is WillBeUnchanged -> copy(metas = newMetas)
-                is WillBeReplaced -> copy(metas = newMetas)
+                is WillBeUnchanged -> copy(metas = metas)
+                is WillBeReplaced -> copy(metas = metas)
             }
     
         class WillBeUnchanged(
             override val metas: MetaContainer = emptyMetaContainer()
         ): SumB() {
         
-            override fun copyMetas(newMetas: MetaContainer): WillBeUnchanged =
+            override fun copy(metas: MetaContainer): WillBeUnchanged =
                 WillBeUnchanged(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): WillBeUnchanged =
                 WillBeUnchanged(
@@ -10612,11 +10562,6 @@ class DomainB private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                WillBeUnchanged(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -10634,10 +10579,10 @@ class DomainB private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): SumB() {
         
-            override fun copyMetas(newMetas: MetaContainer): WillBeReplaced =
+            override fun copy(metas: MetaContainer): WillBeReplaced =
                 WillBeReplaced(
                     something = something,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): WillBeReplaced =
                 WillBeReplaced(
@@ -10681,19 +10626,19 @@ class DomainB private constructor() {
     }
     
     sealed class NewSum(override val metas: MetaContainer = emptyMetaContainer()) : DomainBNode() {
-        override fun copyMetas(newMetas: MetaContainer): NewSum =
+        override fun copy(metas: MetaContainer): NewSum =
             when (this) {
-                is Eek -> copy(metas = newMetas)
-                is Whatever -> copy(metas = newMetas)
+                is Eek -> copy(metas = metas)
+                is Whatever -> copy(metas = metas)
             }
     
         class Eek(
             override val metas: MetaContainer = emptyMetaContainer()
         ): NewSum() {
         
-            override fun copyMetas(newMetas: MetaContainer): Eek =
+            override fun copy(metas: MetaContainer): Eek =
                 Eek(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Eek =
                 Eek(
@@ -10706,11 +10651,6 @@ class DomainB private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Eek(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false
@@ -10727,9 +10667,9 @@ class DomainB private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): NewSum() {
         
-            override fun copyMetas(newMetas: MetaContainer): Whatever =
+            override fun copy(metas: MetaContainer): Whatever =
                 Whatever(
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Whatever =
                 Whatever(
@@ -10742,11 +10682,6 @@ class DomainB private constructor() {
                 return elements
             }
         
-            fun copy(
-                metas: MetaContainer = this.metas
-            ) =
-                Whatever(
-                    metas)
         
             override fun equals(other: Any?): Boolean {
                 if (other == null) return false

--- a/pig-tests/src/org/partiql/pig/tests/generated/toy-lang.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/toy-lang.kt
@@ -437,7 +437,7 @@ class ToyLang private constructor() {
     
     /** Base class for all ToyLang types. */
     abstract class ToyLangNode : DomainNode {
-        abstract override fun copyMetas(newMetas: MetaContainer): ToyLangNode
+        abstract override fun copy(metas: MetaContainer): ToyLangNode
         override fun toString() = toIonElement().toString()
         abstract override fun withMeta(metaKey: String, metaValue: Any): ToyLangNode
         abstract override fun toIonElement(): SexpElement
@@ -450,19 +450,19 @@ class ToyLang private constructor() {
     /////////////////////////////////////////////////////////////////////////////
     
     sealed class Expr(override val metas: MetaContainer = emptyMetaContainer()) : ToyLangNode() {
-        override fun copyMetas(newMetas: MetaContainer): Expr =
+        override fun copy(metas: MetaContainer): Expr =
             when (this) {
-                is Lit -> copy(metas = newMetas)
-                is Variable -> copy(metas = newMetas)
-                is Not -> copy(metas = newMetas)
-                is Plus -> copy(metas = newMetas)
-                is Minus -> copy(metas = newMetas)
-                is Times -> copy(metas = newMetas)
-                is Divide -> copy(metas = newMetas)
-                is Modulo -> copy(metas = newMetas)
-                is Call -> copy(metas = newMetas)
-                is Let -> copy(metas = newMetas)
-                is Function -> copy(metas = newMetas)
+                is Lit -> copy(metas = metas)
+                is Variable -> copy(metas = metas)
+                is Not -> copy(metas = metas)
+                is Plus -> copy(metas = metas)
+                is Minus -> copy(metas = metas)
+                is Times -> copy(metas = metas)
+                is Divide -> copy(metas = metas)
+                is Modulo -> copy(metas = metas)
+                is Call -> copy(metas = metas)
+                is Let -> copy(metas = metas)
+                is Function -> copy(metas = metas)
             }
     
         class Lit(
@@ -470,10 +470,10 @@ class ToyLang private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Lit =
+            override fun copy(metas: MetaContainer): Lit =
                 Lit(
                     value = value,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Lit =
                 Lit(
@@ -519,10 +519,10 @@ class ToyLang private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Variable =
+            override fun copy(metas: MetaContainer): Variable =
                 Variable(
                     name = name,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Variable =
                 Variable(
@@ -568,10 +568,10 @@ class ToyLang private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Not =
+            override fun copy(metas: MetaContainer): Not =
                 Not(
                     expr = expr,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Not =
                 Not(
@@ -617,10 +617,10 @@ class ToyLang private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Plus =
+            override fun copy(metas: MetaContainer): Plus =
                 Plus(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Plus =
                 Plus(
@@ -666,10 +666,10 @@ class ToyLang private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Minus =
+            override fun copy(metas: MetaContainer): Minus =
                 Minus(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Minus =
                 Minus(
@@ -715,10 +715,10 @@ class ToyLang private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Times =
+            override fun copy(metas: MetaContainer): Times =
                 Times(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Times =
                 Times(
@@ -764,10 +764,10 @@ class ToyLang private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Divide =
+            override fun copy(metas: MetaContainer): Divide =
                 Divide(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Divide =
                 Divide(
@@ -813,10 +813,10 @@ class ToyLang private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Modulo =
+            override fun copy(metas: MetaContainer): Modulo =
                 Modulo(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Modulo =
                 Modulo(
@@ -863,11 +863,11 @@ class ToyLang private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Call =
+            override fun copy(metas: MetaContainer): Call =
                 Call(
                     name = name,
                     argument = argument,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Call =
                 Call(
@@ -921,12 +921,12 @@ class ToyLang private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Let =
+            override fun copy(metas: MetaContainer): Let =
                 Let(
                     name = name,
                     value = value,
                     body = body,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Let =
                 Let(
@@ -985,11 +985,11 @@ class ToyLang private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Function =
+            override fun copy(metas: MetaContainer): Function =
                 Function(
                     varName = varName,
                     body = body,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Function =
                 Function(
@@ -2108,7 +2108,7 @@ class ToyLangIndexed private constructor() {
     
     /** Base class for all ToyLangIndexed types. */
     abstract class ToyLangIndexedNode : DomainNode {
-        abstract override fun copyMetas(newMetas: MetaContainer): ToyLangIndexedNode
+        abstract override fun copy(metas: MetaContainer): ToyLangIndexedNode
         override fun toString() = toIonElement().toString()
         abstract override fun withMeta(metaKey: String, metaValue: Any): ToyLangIndexedNode
         abstract override fun toIonElement(): SexpElement
@@ -2121,19 +2121,19 @@ class ToyLangIndexed private constructor() {
     /////////////////////////////////////////////////////////////////////////////
     
     sealed class Expr(override val metas: MetaContainer = emptyMetaContainer()) : ToyLangIndexedNode() {
-        override fun copyMetas(newMetas: MetaContainer): Expr =
+        override fun copy(metas: MetaContainer): Expr =
             when (this) {
-                is Lit -> copy(metas = newMetas)
-                is Not -> copy(metas = newMetas)
-                is Plus -> copy(metas = newMetas)
-                is Minus -> copy(metas = newMetas)
-                is Times -> copy(metas = newMetas)
-                is Divide -> copy(metas = newMetas)
-                is Modulo -> copy(metas = newMetas)
-                is Call -> copy(metas = newMetas)
-                is Function -> copy(metas = newMetas)
-                is Variable -> copy(metas = newMetas)
-                is Let -> copy(metas = newMetas)
+                is Lit -> copy(metas = metas)
+                is Not -> copy(metas = metas)
+                is Plus -> copy(metas = metas)
+                is Minus -> copy(metas = metas)
+                is Times -> copy(metas = metas)
+                is Divide -> copy(metas = metas)
+                is Modulo -> copy(metas = metas)
+                is Call -> copy(metas = metas)
+                is Function -> copy(metas = metas)
+                is Variable -> copy(metas = metas)
+                is Let -> copy(metas = metas)
             }
     
         class Lit(
@@ -2141,10 +2141,10 @@ class ToyLangIndexed private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Lit =
+            override fun copy(metas: MetaContainer): Lit =
                 Lit(
                     value = value,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Lit =
                 Lit(
@@ -2190,10 +2190,10 @@ class ToyLangIndexed private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Not =
+            override fun copy(metas: MetaContainer): Not =
                 Not(
                     expr = expr,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Not =
                 Not(
@@ -2239,10 +2239,10 @@ class ToyLangIndexed private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Plus =
+            override fun copy(metas: MetaContainer): Plus =
                 Plus(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Plus =
                 Plus(
@@ -2288,10 +2288,10 @@ class ToyLangIndexed private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Minus =
+            override fun copy(metas: MetaContainer): Minus =
                 Minus(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Minus =
                 Minus(
@@ -2337,10 +2337,10 @@ class ToyLangIndexed private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Times =
+            override fun copy(metas: MetaContainer): Times =
                 Times(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Times =
                 Times(
@@ -2386,10 +2386,10 @@ class ToyLangIndexed private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Divide =
+            override fun copy(metas: MetaContainer): Divide =
                 Divide(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Divide =
                 Divide(
@@ -2435,10 +2435,10 @@ class ToyLangIndexed private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Modulo =
+            override fun copy(metas: MetaContainer): Modulo =
                 Modulo(
                     operands = operands,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Modulo =
                 Modulo(
@@ -2485,11 +2485,11 @@ class ToyLangIndexed private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Call =
+            override fun copy(metas: MetaContainer): Call =
                 Call(
                     name = name,
                     argument = argument,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Call =
                 Call(
@@ -2542,11 +2542,11 @@ class ToyLangIndexed private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Function =
+            override fun copy(metas: MetaContainer): Function =
                 Function(
                     varName = varName,
                     body = body,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Function =
                 Function(
@@ -2599,11 +2599,11 @@ class ToyLangIndexed private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Variable =
+            override fun copy(metas: MetaContainer): Variable =
                 Variable(
                     name = name,
                     index = index,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Variable =
                 Variable(
@@ -2658,13 +2658,13 @@ class ToyLangIndexed private constructor() {
             override val metas: MetaContainer = emptyMetaContainer()
         ): Expr() {
         
-            override fun copyMetas(newMetas: MetaContainer): Let =
+            override fun copy(metas: MetaContainer): Let =
                 Let(
                     name = name,
                     index = index,
                     value = value,
                     body = body,
-                    metas = newMetas)
+                    metas = metas)
         
             override fun withMeta(metaKey: String, metaValue: Any): Let =
                 Let(

--- a/pig-tests/test/org/partiql/pig/tests/CopyTests.kt
+++ b/pig-tests/test/org/partiql/pig/tests/CopyTests.kt
@@ -19,6 +19,7 @@ import com.amazon.ionelement.api.emptyMetaContainer
 import com.amazon.ionelement.api.metaContainerOf
 import org.junit.jupiter.api.Test
 import org.partiql.pig.runtime.LongPrimitive
+import org.partiql.pig.runtime.asPrimitive
 import org.partiql.pig.tests.generated.TestDomain
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -81,18 +82,18 @@ class CopyTests {
     }
 
     @Test
-    fun `copy only metas test`() {
-        val copiedNode = node.copy(metas = metaContainerOf(NUMBER_KEY to 0))
+    fun `copy metas - override with multiple parameters`() {
+        val copiedNode = node.copy(second = 2L.asPrimitive(), metas = metaContainerOf(NUMBER_KEY to 0))
         assertNotEquals(node.metas, copiedNode.metas)
         assertEquals(node.first, copiedNode.first)
-        assertEquals(node.second, copiedNode.second)
+        assertEquals(2L, copiedNode.second.value)
         assertEquals(node, copiedNode)
         assertNotSame(node, copiedNode)
     }
 
     @Test
-    fun `copyMetas test`() {
-        val copiedNode = node.copyMetas(metaContainerOf(NUMBER_KEY to 0))
+    fun `copy test - override with single metas parameter`() {
+        val copiedNode = node.copy(metaContainerOf(NUMBER_KEY to 0))
         assertNotEquals(node.metas, copiedNode.metas)
         assertEquals(node.first, copiedNode.first)
         assertEquals(node.second, copiedNode.second)

--- a/pig/resources/org/partiql/pig/templates/kotlin.ftl
+++ b/pig/resources/org/partiql/pig/templates/kotlin.ftl
@@ -38,12 +38,12 @@ class ${t.kotlinName}(
     override val metas: MetaContainer = emptyMetaContainer()
 ): ${t.superClass}() {
 
-    override fun copyMetas(newMetas: MetaContainer): ${t.kotlinName} =
+    override fun copy(metas: MetaContainer): ${t.kotlinName} =
         ${t.kotlinName}(
             [#list t.properties as p]
             ${p.kotlinName} = ${p.kotlinName},
             [/#list]
-            metas = newMetas)
+            metas = metas)
 
     override fun withMeta(metaKey: String, metaValue: Any): ${t.kotlinName} =
         ${t.kotlinName}(
@@ -87,10 +87,11 @@ class ${t.kotlinName}(
     }
 [/#if]
 
+    [#list t.properties]
     fun copy(
-    [#list t.properties as p]
+    [#items as p]
         ${p.kotlinName}: ${p.kotlinTypeName} = this.${p.kotlinName},
-    [/#list]
+    [/#items]
         metas: MetaContainer = this.metas
     ) =
         ${t.kotlinName}(
@@ -98,6 +99,7 @@ class ${t.kotlinName}(
             ${p.kotlinName},
             [/#list]
             metas)
+    [/#list]
 
     override fun equals(other: Any?): Boolean {
         if (other == null) return false
@@ -245,7 +247,7 @@ private object ${domain.kotlinName}Builder : Builder {
 
 /** Base class for all ${domain.kotlinName} types. */
 abstract class ${domain.kotlinName}Node : DomainNode {
-    abstract override fun copyMetas(newMetas: MetaContainer): ${domain.kotlinName}Node
+    abstract override fun copy(metas: MetaContainer): ${domain.kotlinName}Node
     override fun toString() = toIonElement().toString()
     abstract override fun withMeta(metaKey: String, metaValue: Any): ${domain.kotlinName}Node
     abstract override fun toIonElement(): SexpElement
@@ -267,10 +269,10 @@ abstract class ${domain.kotlinName}Node : DomainNode {
 [#list domain.sums as s]
 
 sealed class ${s.kotlinName}(override val metas: MetaContainer = emptyMetaContainer()) : ${s.superClass}() {
-    override fun copyMetas(newMetas: MetaContainer): ${s.kotlinName} =
+    override fun copy(metas: MetaContainer): ${s.kotlinName} =
         when (this) {
             [#list s.variants as v]
-            is ${v.kotlinName} -> copy(metas = newMetas)
+            is ${v.kotlinName} -> copy(metas = metas)
             [/#list]
         }
 


### PR DESCRIPTION
Issue #81.

The name "copyMetas" did not reflect what the function was actually
doing.  It does not copy the metas, but rather copies the node while
replacing the metas!  Hence, "copy" is a much better name.

Every generated class now gets up to two "copy" functions: one that
overrides the DomainNode.copy(MetaContainer) function and one that does
not override and is equivalent to the Kotlin data class copy function.
For user-defined types with no elements, the latter ends up with the
same signature as the former, so changes were also included to the
kotlin.ftl file to omit this function in the event that the type has
no elements.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
