### PR TITLE
Allow custom builder interfaces which provide metas

### DIFF
--- a/pig-tests/src/org/partiql/pig/tests/generated/partiql-basic.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/partiql-basic.kt
@@ -32,10 +32,10 @@ class PartiqlBasic private constructor() {
     interface Builder {
         fun newMetaContainer() = emptyMetaContainer()
     
-                    // Tuples
+        // Tuples 
         /**
-        * Creates an instance of [PartiqlBasic.ExprPair].
-        */
+         * Creates an instance of [PartiqlBasic.ExprPair].
+         */
         fun exprPair(
                     first: Expr,
                     second: Expr,
@@ -44,12 +44,13 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.ExprPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.GroupByItem].
-        */
+         * Creates an instance of [PartiqlBasic.GroupByItem].
+         */
         fun groupByItem(
                     value: Expr,
                     asAlias: String? = null,
@@ -58,15 +59,16 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.GroupByItem(
                 value = value,
                 asAlias = asAlias?.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.GroupByItem].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [PartiqlBasic.GroupByItem].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun groupByItem_(
                     value: Expr,
                     asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
@@ -75,23 +77,25 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.GroupByItem(
                 value = value,
                 asAlias = asAlias,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.GroupByList].
-        */
+         * Creates an instance of [PartiqlBasic.GroupByList].
+         */
         fun groupByList(
                     items: kotlin.collections.List<GroupByItem>,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupByList =
             PartiqlBasic.GroupByList(
                 items = items,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.GroupByList].
-        */
+         * Creates an instance of [PartiqlBasic.GroupByList].
+         */
         fun groupByList(
                     items0: GroupByItem,
                     vararg items: GroupByItem,
@@ -99,12 +103,13 @@ class PartiqlBasic private constructor() {
         ): PartiqlBasic.GroupByList =
             PartiqlBasic.GroupByList(
                 items = listOf(items0) + items.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.GroupBy].
-        */
+         * Creates an instance of [PartiqlBasic.GroupBy].
+         */
         fun groupBy(
                     items: GroupByList,
                     groupAsAlias: String? = null,
@@ -113,15 +118,16 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.GroupBy(
                 items = items,
                 groupAsAlias = groupAsAlias?.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.GroupBy].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [PartiqlBasic.GroupBy].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun groupBy_(
                     items: GroupByList,
                     groupAsAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
@@ -130,24 +136,26 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.GroupBy(
                 items = items,
                 groupAsAlias = groupAsAlias,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: Projection 
         /**
-        * Creates an instance of [PartiqlBasic.Projection.ProjectList].
-        */
+         * Creates an instance of [PartiqlBasic.Projection.ProjectList].
+         */
         fun projectList(
                     items: kotlin.collections.List<ProjectItem>,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Projection.ProjectList =
             PartiqlBasic.Projection.ProjectList(
                 items = items,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Projection.ProjectList].
-        */
+         * Creates an instance of [PartiqlBasic.Projection.ProjectList].
+         */
         fun projectList(
                     items0: ProjectItem,
                     vararg items: ProjectItem,
@@ -155,35 +163,38 @@ class PartiqlBasic private constructor() {
         ): PartiqlBasic.Projection.ProjectList =
             PartiqlBasic.Projection.ProjectList(
                 items = listOf(items0) + items.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Projection.ProjectValue].
-        */
+         * Creates an instance of [PartiqlBasic.Projection.ProjectValue].
+         */
         fun projectValue(
                     value: Expr,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Projection.ProjectValue =
             PartiqlBasic.Projection.ProjectValue(
                 value = value,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: ProjectItem 
         /**
-        * Creates an instance of [PartiqlBasic.ProjectItem.ProjectAll].
-        */
+         * Creates an instance of [PartiqlBasic.ProjectItem.ProjectAll].
+         */
         fun projectAll(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ProjectItem.ProjectAll =
             PartiqlBasic.ProjectItem.ProjectAll(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.ProjectItem.ProjectExpr].
-        */
+         * Creates an instance of [PartiqlBasic.ProjectItem.ProjectExpr].
+         */
         fun projectExpr(
                     value: Expr,
                     asAlias: String? = null,
@@ -192,15 +203,16 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.ProjectItem.ProjectExpr(
                 value = value,
                 asAlias = asAlias?.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.ProjectItem.ProjectExpr].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [PartiqlBasic.ProjectItem.ProjectExpr].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun projectExpr_(
                     value: Expr,
                     asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
@@ -209,54 +221,59 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.ProjectItem.ProjectExpr(
                 value = value,
                 asAlias = asAlias,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: JoinType 
         /**
-        * Creates an instance of [PartiqlBasic.JoinType.Inner].
-        */
+         * Creates an instance of [PartiqlBasic.JoinType.Inner].
+         */
         fun inner(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.JoinType.Inner =
             PartiqlBasic.JoinType.Inner(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.JoinType.Left].
-        */
+         * Creates an instance of [PartiqlBasic.JoinType.Left].
+         */
         fun left(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.JoinType.Left =
             PartiqlBasic.JoinType.Left(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.JoinType.Right].
-        */
+         * Creates an instance of [PartiqlBasic.JoinType.Right].
+         */
         fun right(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.JoinType.Right =
             PartiqlBasic.JoinType.Right(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.JoinType.Outer].
-        */
+         * Creates an instance of [PartiqlBasic.JoinType.Outer].
+         */
         fun outer(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.JoinType.Outer =
             PartiqlBasic.JoinType.Outer(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: FromSource 
         /**
-        * Creates an instance of [PartiqlBasic.FromSource.Scan].
-        */
+         * Creates an instance of [PartiqlBasic.FromSource.Scan].
+         */
         fun scan(
                     expr: Expr,
                     asAlias: String? = null,
@@ -269,15 +286,16 @@ class PartiqlBasic private constructor() {
                 asAlias = asAlias?.asPrimitive(),
                 atAlias = atAlias?.asPrimitive(),
                 byAlias = byAlias?.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.FromSource.Scan].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [PartiqlBasic.FromSource.Scan].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun scan_(
                     expr: Expr,
                     asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
@@ -290,12 +308,13 @@ class PartiqlBasic private constructor() {
                 asAlias = asAlias,
                 atAlias = atAlias,
                 byAlias = byAlias,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.FromSource.Join].
-        */
+         * Creates an instance of [PartiqlBasic.FromSource.Join].
+         */
         fun join(
                     type: JoinType,
                     left: FromSource,
@@ -308,121 +327,132 @@ class PartiqlBasic private constructor() {
                 left = left,
                 right = right,
                 predicate = predicate,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: CaseSensitivity 
         /**
-        * Creates an instance of [PartiqlBasic.CaseSensitivity.CaseSensitive].
-        */
+         * Creates an instance of [PartiqlBasic.CaseSensitivity.CaseSensitive].
+         */
         fun caseSensitive(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.CaseSensitivity.CaseSensitive =
             PartiqlBasic.CaseSensitivity.CaseSensitive(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.CaseSensitivity.CaseInsensitive].
-        */
+         * Creates an instance of [PartiqlBasic.CaseSensitivity.CaseInsensitive].
+         */
         fun caseInsensitive(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.CaseSensitivity.CaseInsensitive =
             PartiqlBasic.CaseSensitivity.CaseInsensitive(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: ScopeQualifier 
         /**
-        * Creates an instance of [PartiqlBasic.ScopeQualifier.Unqualified].
-        */
+         * Creates an instance of [PartiqlBasic.ScopeQualifier.Unqualified].
+         */
         fun unqualified(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ScopeQualifier.Unqualified =
             PartiqlBasic.ScopeQualifier.Unqualified(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.ScopeQualifier.Qualified].
-        */
+         * Creates an instance of [PartiqlBasic.ScopeQualifier.Qualified].
+         */
         fun qualified(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ScopeQualifier.Qualified =
             PartiqlBasic.ScopeQualifier.Qualified(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: SetQuantifier 
         /**
-        * Creates an instance of [PartiqlBasic.SetQuantifier.All].
-        */
+         * Creates an instance of [PartiqlBasic.SetQuantifier.All].
+         */
         fun all(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.SetQuantifier.All =
             PartiqlBasic.SetQuantifier.All(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.SetQuantifier.Distinct].
-        */
+         * Creates an instance of [PartiqlBasic.SetQuantifier.Distinct].
+         */
         fun distinct(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.SetQuantifier.Distinct =
             PartiqlBasic.SetQuantifier.Distinct(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: PathElement 
         /**
-        * Creates an instance of [PartiqlBasic.PathElement.PathExpr].
-        */
+         * Creates an instance of [PartiqlBasic.PathElement.PathExpr].
+         */
         fun pathExpr(
                     expr: Expr,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.PathElement.PathExpr =
             PartiqlBasic.PathElement.PathExpr(
                 expr = expr,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.PathElement.PathWildcard].
-        */
+         * Creates an instance of [PartiqlBasic.PathElement.PathWildcard].
+         */
         fun pathWildcard(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.PathElement.PathWildcard =
             PartiqlBasic.PathElement.PathWildcard(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.PathElement.PathUnpivot].
-        */
+         * Creates an instance of [PartiqlBasic.PathElement.PathUnpivot].
+         */
         fun pathUnpivot(
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.PathElement.PathUnpivot =
             PartiqlBasic.PathElement.PathUnpivot(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: Expr 
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Lit].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Lit].
+         */
         fun lit(
                     value: com.amazon.ionelement.api.IonElement,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Lit =
             PartiqlBasic.Expr.Lit(
                 value = value.asAnyElement(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Id].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Id].
+         */
         fun id(
                     name: String,
                     case: CaseSensitivity,
@@ -433,15 +463,16 @@ class PartiqlBasic private constructor() {
                 name = name.asPrimitive(),
                 case = case,
                 scopeQualifier = scopeQualifier,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Id].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Id].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun id_(
                     name: org.partiql.pig.runtime.SymbolPrimitive,
                     case: CaseSensitivity,
@@ -452,62 +483,67 @@ class PartiqlBasic private constructor() {
                 name = name,
                 case = case,
                 scopeQualifier = scopeQualifier,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Parameter].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Parameter].
+         */
         fun parameter(
                     index: Long,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Parameter =
             PartiqlBasic.Expr.Parameter(
                 index = index.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Parameter].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Parameter].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun parameter_(
                     index: org.partiql.pig.runtime.LongPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Parameter =
             PartiqlBasic.Expr.Parameter(
                 index = index,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Not].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Not].
+         */
         fun not(
                     expr: Expr,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Not =
             PartiqlBasic.Expr.Not(
                 expr = expr,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Plus].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Plus].
+         */
         fun plus(
                     operands: kotlin.collections.List<Expr>,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Plus =
             PartiqlBasic.Expr.Plus(
                 operands = operands,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Plus].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Plus].
+         */
         fun plus(
                     operands0: Expr,
                     operands1: Expr,
@@ -516,23 +552,25 @@ class PartiqlBasic private constructor() {
         ): PartiqlBasic.Expr.Plus =
             PartiqlBasic.Expr.Plus(
                 operands = listOf(operands0, operands1) + operands.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Minus].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Minus].
+         */
         fun minus(
                     operands: kotlin.collections.List<Expr>,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Minus =
             PartiqlBasic.Expr.Minus(
                 operands = operands,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Minus].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Minus].
+         */
         fun minus(
                     operands0: Expr,
                     operands1: Expr,
@@ -541,23 +579,25 @@ class PartiqlBasic private constructor() {
         ): PartiqlBasic.Expr.Minus =
             PartiqlBasic.Expr.Minus(
                 operands = listOf(operands0, operands1) + operands.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Times].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Times].
+         */
         fun times(
                     operands: kotlin.collections.List<Expr>,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Times =
             PartiqlBasic.Expr.Times(
                 operands = operands,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Times].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Times].
+         */
         fun times(
                     operands0: Expr,
                     operands1: Expr,
@@ -566,23 +606,25 @@ class PartiqlBasic private constructor() {
         ): PartiqlBasic.Expr.Times =
             PartiqlBasic.Expr.Times(
                 operands = listOf(operands0, operands1) + operands.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Divide].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Divide].
+         */
         fun divide(
                     operands: kotlin.collections.List<Expr>,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Divide =
             PartiqlBasic.Expr.Divide(
                 operands = operands,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Divide].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Divide].
+         */
         fun divide(
                     operands0: Expr,
                     operands1: Expr,
@@ -591,23 +633,25 @@ class PartiqlBasic private constructor() {
         ): PartiqlBasic.Expr.Divide =
             PartiqlBasic.Expr.Divide(
                 operands = listOf(operands0, operands1) + operands.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Modulo].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Modulo].
+         */
         fun modulo(
                     operands: kotlin.collections.List<Expr>,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Modulo =
             PartiqlBasic.Expr.Modulo(
                 operands = operands,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Modulo].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Modulo].
+         */
         fun modulo(
                     operands0: Expr,
                     operands1: Expr,
@@ -616,23 +660,25 @@ class PartiqlBasic private constructor() {
         ): PartiqlBasic.Expr.Modulo =
             PartiqlBasic.Expr.Modulo(
                 operands = listOf(operands0, operands1) + operands.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Concat].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Concat].
+         */
         fun concat(
                     operands: kotlin.collections.List<Expr>,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Concat =
             PartiqlBasic.Expr.Concat(
                 operands = operands,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Concat].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Concat].
+         */
         fun concat(
                     operands0: Expr,
                     operands1: Expr,
@@ -641,12 +687,13 @@ class PartiqlBasic private constructor() {
         ): PartiqlBasic.Expr.Concat =
             PartiqlBasic.Expr.Concat(
                 operands = listOf(operands0, operands1) + operands.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Like].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Like].
+         */
         fun like(
                     left: Expr,
                     right: Expr,
@@ -657,12 +704,13 @@ class PartiqlBasic private constructor() {
                 left = left,
                 right = right,
                 escape = escape,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Between].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Between].
+         */
         fun between(
                     value: Expr,
                     from: Expr,
@@ -673,12 +721,13 @@ class PartiqlBasic private constructor() {
                 value = value,
                 from = from,
                 to = to,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Path].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Path].
+         */
         fun path(
                     root: Expr,
                     elements: kotlin.collections.List<PathElement>,
@@ -687,11 +736,12 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.Expr.Path(
                 root = root,
                 elements = elements,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Path].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Path].
+         */
         fun path(
                     root: Expr,
                     elements0: PathElement,
@@ -701,12 +751,13 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.Expr.Path(
                 root = root,
                 elements = listOf(elements0) + elements.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Call].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Call].
+         */
         fun call(
                     name: String,
                     args: kotlin.collections.List<Expr>,
@@ -715,15 +766,16 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.Expr.Call(
                 name = name.asPrimitive(),
                 args = args,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Call].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Call].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun call_(
                     name: org.partiql.pig.runtime.SymbolPrimitive,
                     args: kotlin.collections.List<Expr>,
@@ -732,11 +784,12 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.Expr.Call(
                 name = name,
                 args = args,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Call].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Call].
+         */
         fun call(
                     name: String,
                     args0: Expr,
@@ -746,15 +799,16 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.Expr.Call(
                 name = name?.asPrimitive(),
                 args = listOf(args0) + args.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Call].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Call].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun call_(
                     name: org.partiql.pig.runtime.SymbolPrimitive,
                     args0: Expr,
@@ -764,12 +818,13 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.Expr.Call(
                 name = name,
                 args = listOf(args0) + args.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.CallAgg].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.CallAgg].
+         */
         fun callAgg(
                     name: String,
                     setQuantifier: SetQuantifier,
@@ -780,15 +835,16 @@ class PartiqlBasic private constructor() {
                 name = name.asPrimitive(),
                 setQuantifier = setQuantifier,
                 arg = arg,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.CallAgg].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [PartiqlBasic.Expr.CallAgg].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun callAgg_(
                     name: org.partiql.pig.runtime.SymbolPrimitive,
                     setQuantifier: SetQuantifier,
@@ -799,12 +855,13 @@ class PartiqlBasic private constructor() {
                 name = name,
                 setQuantifier = setQuantifier,
                 arg = arg,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
+         */
         fun simpleCase(
                     value: Expr,
                     branches: kotlin.collections.List<ExprPair>,
@@ -813,11 +870,12 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.Expr.SimpleCase(
                 value = value,
                 branches = branches,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
+         */
         fun simpleCase(
                     value: Expr,
                     branches0: ExprPair,
@@ -827,23 +885,25 @@ class PartiqlBasic private constructor() {
             PartiqlBasic.Expr.SimpleCase(
                 value = value,
                 branches = listOf(branches0) + branches.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
+         */
         fun searchedCase(
                     branches: kotlin.collections.List<ExprPair>,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.SearchedCase =
             PartiqlBasic.Expr.SearchedCase(
                 branches = branches,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
+         */
         fun searchedCase(
                     branches0: ExprPair,
                     vararg branches: ExprPair,
@@ -851,81 +911,88 @@ class PartiqlBasic private constructor() {
         ): PartiqlBasic.Expr.SearchedCase =
             PartiqlBasic.Expr.SearchedCase(
                 branches = listOf(branches0) + branches.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Struct].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Struct].
+         */
         fun struct(
                     fields: kotlin.collections.List<ExprPair> = emptyList(),
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Struct =
             PartiqlBasic.Expr.Struct(
                 fields = fields,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Struct].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Struct].
+         */
         fun struct(
                     vararg fields: ExprPair,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Struct =
             PartiqlBasic.Expr.Struct(
                 fields = fields.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Bag].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Bag].
+         */
         fun bag(
                     values: kotlin.collections.List<Expr> = emptyList(),
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Bag =
             PartiqlBasic.Expr.Bag(
                 values = values,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Bag].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Bag].
+         */
         fun bag(
                     vararg values: Expr,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Bag =
             PartiqlBasic.Expr.Bag(
                 values = values.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.List].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.List].
+         */
         fun list(
                     values: kotlin.collections.List<Expr> = emptyList(),
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.List =
             PartiqlBasic.Expr.List(
                 values = values,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.List].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.List].
+         */
         fun list(
                     vararg values: Expr,
                 metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.List =
             PartiqlBasic.Expr.List(
                 values = values.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [PartiqlBasic.Expr.Select].
-        */
+         * Creates an instance of [PartiqlBasic.Expr.Select].
+         */
         fun select(
                     setq: SetQuantifier? = null,
                     project: Projection,
@@ -944,7 +1011,8 @@ class PartiqlBasic private constructor() {
                 group = group,
                 having = having,
                 limit = limit,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */

--- a/pig-tests/src/org/partiql/pig/tests/generated/partiql-basic.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/partiql-basic.kt
@@ -37,9 +37,9 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.ExprPair].
          */
         fun exprPair(
-                    first: Expr,
-                    second: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Expr,
+            second: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ExprPair =
             PartiqlBasic.ExprPair(
                 first = first,
@@ -52,9 +52,9 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.GroupByItem].
          */
         fun groupByItem(
-                    value: Expr,
-                    asAlias: String? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            value: Expr,
+            asAlias: String? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupByItem =
             PartiqlBasic.GroupByItem(
                 value = value,
@@ -70,9 +70,9 @@ class PartiqlBasic private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun groupByItem_(
-                    value: Expr,
-                    asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            value: Expr,
+            asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupByItem =
             PartiqlBasic.GroupByItem(
                 value = value,
@@ -85,8 +85,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.GroupByList].
          */
         fun groupByList(
-                    items: kotlin.collections.List<GroupByItem>,
-                metas: MetaContainer = emptyMetaContainer()
+            items: kotlin.collections.List<GroupByItem>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupByList =
             PartiqlBasic.GroupByList(
                 items = items,
@@ -97,9 +97,9 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.GroupByList].
          */
         fun groupByList(
-                    items0: GroupByItem,
-                    vararg items: GroupByItem,
-                metas: MetaContainer = emptyMetaContainer()
+            items0: GroupByItem,
+            vararg items: GroupByItem,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupByList =
             PartiqlBasic.GroupByList(
                 items = listOf(items0) + items.toList(),
@@ -111,9 +111,9 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.GroupBy].
          */
         fun groupBy(
-                    items: GroupByList,
-                    groupAsAlias: String? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            items: GroupByList,
+            groupAsAlias: String? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupBy =
             PartiqlBasic.GroupBy(
                 items = items,
@@ -129,9 +129,9 @@ class PartiqlBasic private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun groupBy_(
-                    items: GroupByList,
-                    groupAsAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            items: GroupByList,
+            groupAsAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupBy =
             PartiqlBasic.GroupBy(
                 items = items,
@@ -145,8 +145,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Projection.ProjectList].
          */
         fun projectList(
-                    items: kotlin.collections.List<ProjectItem>,
-                metas: MetaContainer = emptyMetaContainer()
+            items: kotlin.collections.List<ProjectItem>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Projection.ProjectList =
             PartiqlBasic.Projection.ProjectList(
                 items = items,
@@ -157,9 +157,9 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Projection.ProjectList].
          */
         fun projectList(
-                    items0: ProjectItem,
-                    vararg items: ProjectItem,
-                metas: MetaContainer = emptyMetaContainer()
+            items0: ProjectItem,
+            vararg items: ProjectItem,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Projection.ProjectList =
             PartiqlBasic.Projection.ProjectList(
                 items = listOf(items0) + items.toList(),
@@ -171,8 +171,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Projection.ProjectValue].
          */
         fun projectValue(
-                    value: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            value: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Projection.ProjectValue =
             PartiqlBasic.Projection.ProjectValue(
                 value = value,
@@ -185,7 +185,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.ProjectItem.ProjectAll].
          */
         fun projectAll(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ProjectItem.ProjectAll =
             PartiqlBasic.ProjectItem.ProjectAll(
                 metas = newMetaContainer() + metas
@@ -196,9 +196,9 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.ProjectItem.ProjectExpr].
          */
         fun projectExpr(
-                    value: Expr,
-                    asAlias: String? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            value: Expr,
+            asAlias: String? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ProjectItem.ProjectExpr =
             PartiqlBasic.ProjectItem.ProjectExpr(
                 value = value,
@@ -214,9 +214,9 @@ class PartiqlBasic private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun projectExpr_(
-                    value: Expr,
-                    asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            value: Expr,
+            asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ProjectItem.ProjectExpr =
             PartiqlBasic.ProjectItem.ProjectExpr(
                 value = value,
@@ -230,7 +230,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.JoinType.Inner].
          */
         fun inner(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.JoinType.Inner =
             PartiqlBasic.JoinType.Inner(
                 metas = newMetaContainer() + metas
@@ -241,7 +241,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.JoinType.Left].
          */
         fun left(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.JoinType.Left =
             PartiqlBasic.JoinType.Left(
                 metas = newMetaContainer() + metas
@@ -252,7 +252,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.JoinType.Right].
          */
         fun right(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.JoinType.Right =
             PartiqlBasic.JoinType.Right(
                 metas = newMetaContainer() + metas
@@ -263,7 +263,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.JoinType.Outer].
          */
         fun outer(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.JoinType.Outer =
             PartiqlBasic.JoinType.Outer(
                 metas = newMetaContainer() + metas
@@ -275,11 +275,11 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.FromSource.Scan].
          */
         fun scan(
-                    expr: Expr,
-                    asAlias: String? = null,
-                    atAlias: String? = null,
-                    byAlias: String? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            expr: Expr,
+            asAlias: String? = null,
+            atAlias: String? = null,
+            byAlias: String? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.FromSource.Scan =
             PartiqlBasic.FromSource.Scan(
                 expr = expr,
@@ -297,11 +297,11 @@ class PartiqlBasic private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun scan_(
-                    expr: Expr,
-                    asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
-                    atAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
-                    byAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            expr: Expr,
+            asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
+            atAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
+            byAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.FromSource.Scan =
             PartiqlBasic.FromSource.Scan(
                 expr = expr,
@@ -316,11 +316,11 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.FromSource.Join].
          */
         fun join(
-                    type: JoinType,
-                    left: FromSource,
-                    right: FromSource,
-                    predicate: Expr? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            type: JoinType,
+            left: FromSource,
+            right: FromSource,
+            predicate: Expr? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.FromSource.Join =
             PartiqlBasic.FromSource.Join(
                 type = type,
@@ -336,7 +336,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.CaseSensitivity.CaseSensitive].
          */
         fun caseSensitive(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.CaseSensitivity.CaseSensitive =
             PartiqlBasic.CaseSensitivity.CaseSensitive(
                 metas = newMetaContainer() + metas
@@ -347,7 +347,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.CaseSensitivity.CaseInsensitive].
          */
         fun caseInsensitive(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.CaseSensitivity.CaseInsensitive =
             PartiqlBasic.CaseSensitivity.CaseInsensitive(
                 metas = newMetaContainer() + metas
@@ -359,7 +359,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.ScopeQualifier.Unqualified].
          */
         fun unqualified(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ScopeQualifier.Unqualified =
             PartiqlBasic.ScopeQualifier.Unqualified(
                 metas = newMetaContainer() + metas
@@ -370,7 +370,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.ScopeQualifier.Qualified].
          */
         fun qualified(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ScopeQualifier.Qualified =
             PartiqlBasic.ScopeQualifier.Qualified(
                 metas = newMetaContainer() + metas
@@ -382,7 +382,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.SetQuantifier.All].
          */
         fun all(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.SetQuantifier.All =
             PartiqlBasic.SetQuantifier.All(
                 metas = newMetaContainer() + metas
@@ -393,7 +393,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.SetQuantifier.Distinct].
          */
         fun distinct(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.SetQuantifier.Distinct =
             PartiqlBasic.SetQuantifier.Distinct(
                 metas = newMetaContainer() + metas
@@ -405,8 +405,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.PathElement.PathExpr].
          */
         fun pathExpr(
-                    expr: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            expr: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.PathElement.PathExpr =
             PartiqlBasic.PathElement.PathExpr(
                 expr = expr,
@@ -418,7 +418,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.PathElement.PathWildcard].
          */
         fun pathWildcard(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.PathElement.PathWildcard =
             PartiqlBasic.PathElement.PathWildcard(
                 metas = newMetaContainer() + metas
@@ -429,7 +429,7 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.PathElement.PathUnpivot].
          */
         fun pathUnpivot(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.PathElement.PathUnpivot =
             PartiqlBasic.PathElement.PathUnpivot(
                 metas = newMetaContainer() + metas
@@ -441,8 +441,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Lit].
          */
         fun lit(
-                    value: com.amazon.ionelement.api.IonElement,
-                metas: MetaContainer = emptyMetaContainer()
+            value: com.amazon.ionelement.api.IonElement,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Lit =
             PartiqlBasic.Expr.Lit(
                 value = value.asAnyElement(),
@@ -454,10 +454,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Id].
          */
         fun id(
-                    name: String,
-                    case: CaseSensitivity,
-                    scopeQualifier: ScopeQualifier,
-                metas: MetaContainer = emptyMetaContainer()
+            name: String,
+            case: CaseSensitivity,
+            scopeQualifier: ScopeQualifier,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Id =
             PartiqlBasic.Expr.Id(
                 name = name.asPrimitive(),
@@ -474,10 +474,10 @@ class PartiqlBasic private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun id_(
-                    name: org.partiql.pig.runtime.SymbolPrimitive,
-                    case: CaseSensitivity,
-                    scopeQualifier: ScopeQualifier,
-                metas: MetaContainer = emptyMetaContainer()
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            case: CaseSensitivity,
+            scopeQualifier: ScopeQualifier,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Id =
             PartiqlBasic.Expr.Id(
                 name = name,
@@ -491,8 +491,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Parameter].
          */
         fun parameter(
-                    index: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            index: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Parameter =
             PartiqlBasic.Expr.Parameter(
                 index = index.asPrimitive(),
@@ -507,8 +507,8 @@ class PartiqlBasic private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun parameter_(
-                    index: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            index: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Parameter =
             PartiqlBasic.Expr.Parameter(
                 index = index,
@@ -520,8 +520,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Not].
          */
         fun not(
-                    expr: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            expr: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Not =
             PartiqlBasic.Expr.Not(
                 expr = expr,
@@ -533,8 +533,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Plus].
          */
         fun plus(
-                    operands: kotlin.collections.List<Expr>,
-                metas: MetaContainer = emptyMetaContainer()
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Plus =
             PartiqlBasic.Expr.Plus(
                 operands = operands,
@@ -545,10 +545,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Plus].
          */
         fun plus(
-                    operands0: Expr,
-                    operands1: Expr,
-                    vararg operands: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Plus =
             PartiqlBasic.Expr.Plus(
                 operands = listOf(operands0, operands1) + operands.toList(),
@@ -560,8 +560,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Minus].
          */
         fun minus(
-                    operands: kotlin.collections.List<Expr>,
-                metas: MetaContainer = emptyMetaContainer()
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Minus =
             PartiqlBasic.Expr.Minus(
                 operands = operands,
@@ -572,10 +572,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Minus].
          */
         fun minus(
-                    operands0: Expr,
-                    operands1: Expr,
-                    vararg operands: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Minus =
             PartiqlBasic.Expr.Minus(
                 operands = listOf(operands0, operands1) + operands.toList(),
@@ -587,8 +587,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Times].
          */
         fun times(
-                    operands: kotlin.collections.List<Expr>,
-                metas: MetaContainer = emptyMetaContainer()
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Times =
             PartiqlBasic.Expr.Times(
                 operands = operands,
@@ -599,10 +599,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Times].
          */
         fun times(
-                    operands0: Expr,
-                    operands1: Expr,
-                    vararg operands: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Times =
             PartiqlBasic.Expr.Times(
                 operands = listOf(operands0, operands1) + operands.toList(),
@@ -614,8 +614,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Divide].
          */
         fun divide(
-                    operands: kotlin.collections.List<Expr>,
-                metas: MetaContainer = emptyMetaContainer()
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Divide =
             PartiqlBasic.Expr.Divide(
                 operands = operands,
@@ -626,10 +626,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Divide].
          */
         fun divide(
-                    operands0: Expr,
-                    operands1: Expr,
-                    vararg operands: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Divide =
             PartiqlBasic.Expr.Divide(
                 operands = listOf(operands0, operands1) + operands.toList(),
@@ -641,8 +641,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Modulo].
          */
         fun modulo(
-                    operands: kotlin.collections.List<Expr>,
-                metas: MetaContainer = emptyMetaContainer()
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Modulo =
             PartiqlBasic.Expr.Modulo(
                 operands = operands,
@@ -653,10 +653,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Modulo].
          */
         fun modulo(
-                    operands0: Expr,
-                    operands1: Expr,
-                    vararg operands: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Modulo =
             PartiqlBasic.Expr.Modulo(
                 operands = listOf(operands0, operands1) + operands.toList(),
@@ -668,8 +668,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Concat].
          */
         fun concat(
-                    operands: kotlin.collections.List<Expr>,
-                metas: MetaContainer = emptyMetaContainer()
+            operands: kotlin.collections.List<Expr>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Concat =
             PartiqlBasic.Expr.Concat(
                 operands = operands,
@@ -680,10 +680,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Concat].
          */
         fun concat(
-                    operands0: Expr,
-                    operands1: Expr,
-                    vararg operands: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            operands0: Expr,
+            operands1: Expr,
+            vararg operands: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Concat =
             PartiqlBasic.Expr.Concat(
                 operands = listOf(operands0, operands1) + operands.toList(),
@@ -695,10 +695,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Like].
          */
         fun like(
-                    left: Expr,
-                    right: Expr,
-                    escape: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            left: Expr,
+            right: Expr,
+            escape: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Like =
             PartiqlBasic.Expr.Like(
                 left = left,
@@ -712,10 +712,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Between].
          */
         fun between(
-                    value: Expr,
-                    from: Expr,
-                    to: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            value: Expr,
+            from: Expr,
+            to: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Between =
             PartiqlBasic.Expr.Between(
                 value = value,
@@ -729,9 +729,9 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Path].
          */
         fun path(
-                    root: Expr,
-                    elements: kotlin.collections.List<PathElement>,
-                metas: MetaContainer = emptyMetaContainer()
+            root: Expr,
+            elements: kotlin.collections.List<PathElement>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Path =
             PartiqlBasic.Expr.Path(
                 root = root,
@@ -743,10 +743,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Path].
          */
         fun path(
-                    root: Expr,
-                    elements0: PathElement,
-                    vararg elements: PathElement,
-                metas: MetaContainer = emptyMetaContainer()
+            root: Expr,
+            elements0: PathElement,
+            vararg elements: PathElement,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Path =
             PartiqlBasic.Expr.Path(
                 root = root,
@@ -759,9 +759,9 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Call].
          */
         fun call(
-                    name: String,
-                    args: kotlin.collections.List<Expr>,
-                metas: MetaContainer = emptyMetaContainer()
+            name: String,
+            args: kotlin.collections.List<Expr>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
                 name = name.asPrimitive(),
@@ -777,9 +777,9 @@ class PartiqlBasic private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun call_(
-                    name: org.partiql.pig.runtime.SymbolPrimitive,
-                    args: kotlin.collections.List<Expr>,
-                metas: MetaContainer = emptyMetaContainer()
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            args: kotlin.collections.List<Expr>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
                 name = name,
@@ -791,10 +791,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Call].
          */
         fun call(
-                    name: String,
-                    args0: Expr,
-                    vararg args: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            name: String,
+            args0: Expr,
+            vararg args: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
                 name = name?.asPrimitive(),
@@ -810,10 +810,10 @@ class PartiqlBasic private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun call_(
-                    name: org.partiql.pig.runtime.SymbolPrimitive,
-                    args0: Expr,
-                    vararg args: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            args0: Expr,
+            vararg args: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
                 name = name,
@@ -826,10 +826,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.CallAgg].
          */
         fun callAgg(
-                    name: String,
-                    setQuantifier: SetQuantifier,
-                    arg: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            name: String,
+            setQuantifier: SetQuantifier,
+            arg: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.CallAgg =
             PartiqlBasic.Expr.CallAgg(
                 name = name.asPrimitive(),
@@ -846,10 +846,10 @@ class PartiqlBasic private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun callAgg_(
-                    name: org.partiql.pig.runtime.SymbolPrimitive,
-                    setQuantifier: SetQuantifier,
-                    arg: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            setQuantifier: SetQuantifier,
+            arg: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.CallAgg =
             PartiqlBasic.Expr.CallAgg(
                 name = name,
@@ -863,9 +863,9 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
          */
         fun simpleCase(
-                    value: Expr,
-                    branches: kotlin.collections.List<ExprPair>,
-                metas: MetaContainer = emptyMetaContainer()
+            value: Expr,
+            branches: kotlin.collections.List<ExprPair>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.SimpleCase =
             PartiqlBasic.Expr.SimpleCase(
                 value = value,
@@ -877,10 +877,10 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
          */
         fun simpleCase(
-                    value: Expr,
-                    branches0: ExprPair,
-                    vararg branches: ExprPair,
-                metas: MetaContainer = emptyMetaContainer()
+            value: Expr,
+            branches0: ExprPair,
+            vararg branches: ExprPair,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.SimpleCase =
             PartiqlBasic.Expr.SimpleCase(
                 value = value,
@@ -893,8 +893,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
          */
         fun searchedCase(
-                    branches: kotlin.collections.List<ExprPair>,
-                metas: MetaContainer = emptyMetaContainer()
+            branches: kotlin.collections.List<ExprPair>,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.SearchedCase =
             PartiqlBasic.Expr.SearchedCase(
                 branches = branches,
@@ -905,9 +905,9 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
          */
         fun searchedCase(
-                    branches0: ExprPair,
-                    vararg branches: ExprPair,
-                metas: MetaContainer = emptyMetaContainer()
+            branches0: ExprPair,
+            vararg branches: ExprPair,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.SearchedCase =
             PartiqlBasic.Expr.SearchedCase(
                 branches = listOf(branches0) + branches.toList(),
@@ -919,8 +919,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Struct].
          */
         fun struct(
-                    fields: kotlin.collections.List<ExprPair> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            fields: kotlin.collections.List<ExprPair> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Struct =
             PartiqlBasic.Expr.Struct(
                 fields = fields,
@@ -931,8 +931,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Struct].
          */
         fun struct(
-                    vararg fields: ExprPair,
-                metas: MetaContainer = emptyMetaContainer()
+            vararg fields: ExprPair,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Struct =
             PartiqlBasic.Expr.Struct(
                 fields = fields.toList(),
@@ -944,8 +944,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Bag].
          */
         fun bag(
-                    values: kotlin.collections.List<Expr> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            values: kotlin.collections.List<Expr> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Bag =
             PartiqlBasic.Expr.Bag(
                 values = values,
@@ -956,8 +956,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Bag].
          */
         fun bag(
-                    vararg values: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            vararg values: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Bag =
             PartiqlBasic.Expr.Bag(
                 values = values.toList(),
@@ -969,8 +969,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.List].
          */
         fun list(
-                    values: kotlin.collections.List<Expr> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            values: kotlin.collections.List<Expr> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.List =
             PartiqlBasic.Expr.List(
                 values = values,
@@ -981,8 +981,8 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.List].
          */
         fun list(
-                    vararg values: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            vararg values: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.List =
             PartiqlBasic.Expr.List(
                 values = values.toList(),
@@ -994,14 +994,14 @@ class PartiqlBasic private constructor() {
          * Creates an instance of [PartiqlBasic.Expr.Select].
          */
         fun select(
-                    setq: SetQuantifier? = null,
-                    project: Projection,
-                    from: FromSource,
-                    where: Expr? = null,
-                    group: GroupBy? = null,
-                    having: Expr? = null,
-                    limit: Expr? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            setq: SetQuantifier? = null,
+            project: Projection,
+            from: FromSource,
+            where: Expr? = null,
+            group: GroupBy? = null,
+            having: Expr? = null,
+            limit: Expr? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Select =
             PartiqlBasic.Expr.Select(
                 setq = setq,

--- a/pig-tests/src/org/partiql/pig/tests/generated/partiql-basic.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/partiql-basic.kt
@@ -30,676 +30,902 @@ class PartiqlBasic private constructor() {
     }
     
     interface Builder {
-                // Tuples
+        fun newMetaContainer() = emptyMetaContainer()
+    
+                    // Tuples
         /**
-         * Creates an instance of [PartiqlBasic.ExprPair].
-         */
+        * Creates an instance of [PartiqlBasic.ExprPair].
+        */
         fun exprPair(
             first: Expr,
             second: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.ExprPair
+        ): PartiqlBasic.ExprPair =
+            PartiqlBasic.ExprPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.GroupByItem].
-         */
+        * Creates an instance of [PartiqlBasic.GroupByItem].
+        */
         fun groupByItem(
             value: Expr,
             asAlias: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.GroupByItem
+        ): PartiqlBasic.GroupByItem =
+            PartiqlBasic.GroupByItem(
+                value = value,
+                asAlias = asAlias?.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.GroupByItem].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [PartiqlBasic.GroupByItem].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun groupByItem_(
             value: Expr,
             asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.GroupByItem
+        ): PartiqlBasic.GroupByItem =
+            PartiqlBasic.GroupByItem(
+                value = value,
+                asAlias = asAlias,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.GroupByList].
-         */
+        * Creates an instance of [PartiqlBasic.GroupByList].
+        */
         fun groupByList(
             items: kotlin.collections.List<GroupByItem>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.GroupByList
+        ): PartiqlBasic.GroupByList =
+            PartiqlBasic.GroupByList(
+                items = items,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.GroupByList].
-         */
+        * Creates an instance of [PartiqlBasic.GroupByList].
+        */
         fun groupByList(
             items0: GroupByItem,
             vararg items: GroupByItem,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.GroupByList
+        ): PartiqlBasic.GroupByList =
+            PartiqlBasic.GroupByList(
+                items = listOf(items0) + items.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.GroupBy].
-         */
+        * Creates an instance of [PartiqlBasic.GroupBy].
+        */
         fun groupBy(
             items: GroupByList,
             groupAsAlias: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.GroupBy
+        ): PartiqlBasic.GroupBy =
+            PartiqlBasic.GroupBy(
+                items = items,
+                groupAsAlias = groupAsAlias?.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.GroupBy].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [PartiqlBasic.GroupBy].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun groupBy_(
             items: GroupByList,
             groupAsAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.GroupBy
+        ): PartiqlBasic.GroupBy =
+            PartiqlBasic.GroupBy(
+                items = items,
+                groupAsAlias = groupAsAlias,
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: Projection 
         /**
-         * Creates an instance of [PartiqlBasic.Projection.ProjectList].
-         */
+        * Creates an instance of [PartiqlBasic.Projection.ProjectList].
+        */
         fun projectList(
             items: kotlin.collections.List<ProjectItem>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Projection.ProjectList
+        ): PartiqlBasic.Projection.ProjectList =
+            PartiqlBasic.Projection.ProjectList(
+                items = items,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Projection.ProjectList].
-         */
+        * Creates an instance of [PartiqlBasic.Projection.ProjectList].
+        */
         fun projectList(
             items0: ProjectItem,
             vararg items: ProjectItem,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Projection.ProjectList
+        ): PartiqlBasic.Projection.ProjectList =
+            PartiqlBasic.Projection.ProjectList(
+                items = listOf(items0) + items.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Projection.ProjectValue].
-         */
+        * Creates an instance of [PartiqlBasic.Projection.ProjectValue].
+        */
         fun projectValue(
             value: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Projection.ProjectValue
+        ): PartiqlBasic.Projection.ProjectValue =
+            PartiqlBasic.Projection.ProjectValue(
+                value = value,
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: ProjectItem 
         /**
-         * Creates an instance of [PartiqlBasic.ProjectItem.ProjectAll].
-         */
+        * Creates an instance of [PartiqlBasic.ProjectItem.ProjectAll].
+        */
         fun projectAll(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.ProjectItem.ProjectAll
+        ): PartiqlBasic.ProjectItem.ProjectAll =
+            PartiqlBasic.ProjectItem.ProjectAll(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.ProjectItem.ProjectExpr].
-         */
+        * Creates an instance of [PartiqlBasic.ProjectItem.ProjectExpr].
+        */
         fun projectExpr(
             value: Expr,
             asAlias: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.ProjectItem.ProjectExpr
+        ): PartiqlBasic.ProjectItem.ProjectExpr =
+            PartiqlBasic.ProjectItem.ProjectExpr(
+                value = value,
+                asAlias = asAlias?.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.ProjectItem.ProjectExpr].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [PartiqlBasic.ProjectItem.ProjectExpr].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun projectExpr_(
             value: Expr,
             asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.ProjectItem.ProjectExpr
+        ): PartiqlBasic.ProjectItem.ProjectExpr =
+            PartiqlBasic.ProjectItem.ProjectExpr(
+                value = value,
+                asAlias = asAlias,
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: JoinType 
         /**
-         * Creates an instance of [PartiqlBasic.JoinType.Inner].
-         */
+        * Creates an instance of [PartiqlBasic.JoinType.Inner].
+        */
         fun inner(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.JoinType.Inner
+        ): PartiqlBasic.JoinType.Inner =
+            PartiqlBasic.JoinType.Inner(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.JoinType.Left].
-         */
+        * Creates an instance of [PartiqlBasic.JoinType.Left].
+        */
         fun left(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.JoinType.Left
+        ): PartiqlBasic.JoinType.Left =
+            PartiqlBasic.JoinType.Left(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.JoinType.Right].
-         */
+        * Creates an instance of [PartiqlBasic.JoinType.Right].
+        */
         fun right(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.JoinType.Right
+        ): PartiqlBasic.JoinType.Right =
+            PartiqlBasic.JoinType.Right(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.JoinType.Outer].
-         */
+        * Creates an instance of [PartiqlBasic.JoinType.Outer].
+        */
         fun outer(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.JoinType.Outer
+        ): PartiqlBasic.JoinType.Outer =
+            PartiqlBasic.JoinType.Outer(
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: FromSource 
         /**
-         * Creates an instance of [PartiqlBasic.FromSource.Scan].
-         */
+        * Creates an instance of [PartiqlBasic.FromSource.Scan].
+        */
         fun scan(
             expr: Expr,
             asAlias: String? = null,
             atAlias: String? = null,
             byAlias: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.FromSource.Scan
+        ): PartiqlBasic.FromSource.Scan =
+            PartiqlBasic.FromSource.Scan(
+                expr = expr,
+                asAlias = asAlias?.asPrimitive(),
+                atAlias = atAlias?.asPrimitive(),
+                byAlias = byAlias?.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.FromSource.Scan].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [PartiqlBasic.FromSource.Scan].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun scan_(
             expr: Expr,
             asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
             atAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
             byAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.FromSource.Scan
+        ): PartiqlBasic.FromSource.Scan =
+            PartiqlBasic.FromSource.Scan(
+                expr = expr,
+                asAlias = asAlias,
+                atAlias = atAlias,
+                byAlias = byAlias,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.FromSource.Join].
-         */
+        * Creates an instance of [PartiqlBasic.FromSource.Join].
+        */
         fun join(
             type: JoinType,
             left: FromSource,
             right: FromSource,
             predicate: Expr? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.FromSource.Join
+        ): PartiqlBasic.FromSource.Join =
+            PartiqlBasic.FromSource.Join(
+                type = type,
+                left = left,
+                right = right,
+                predicate = predicate,
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: CaseSensitivity 
         /**
-         * Creates an instance of [PartiqlBasic.CaseSensitivity.CaseSensitive].
-         */
+        * Creates an instance of [PartiqlBasic.CaseSensitivity.CaseSensitive].
+        */
         fun caseSensitive(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.CaseSensitivity.CaseSensitive
+        ): PartiqlBasic.CaseSensitivity.CaseSensitive =
+            PartiqlBasic.CaseSensitivity.CaseSensitive(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.CaseSensitivity.CaseInsensitive].
-         */
+        * Creates an instance of [PartiqlBasic.CaseSensitivity.CaseInsensitive].
+        */
         fun caseInsensitive(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.CaseSensitivity.CaseInsensitive
+        ): PartiqlBasic.CaseSensitivity.CaseInsensitive =
+            PartiqlBasic.CaseSensitivity.CaseInsensitive(
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: ScopeQualifier 
         /**
-         * Creates an instance of [PartiqlBasic.ScopeQualifier.Unqualified].
-         */
+        * Creates an instance of [PartiqlBasic.ScopeQualifier.Unqualified].
+        */
         fun unqualified(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.ScopeQualifier.Unqualified
+        ): PartiqlBasic.ScopeQualifier.Unqualified =
+            PartiqlBasic.ScopeQualifier.Unqualified(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.ScopeQualifier.Qualified].
-         */
+        * Creates an instance of [PartiqlBasic.ScopeQualifier.Qualified].
+        */
         fun qualified(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.ScopeQualifier.Qualified
+        ): PartiqlBasic.ScopeQualifier.Qualified =
+            PartiqlBasic.ScopeQualifier.Qualified(
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: SetQuantifier 
         /**
-         * Creates an instance of [PartiqlBasic.SetQuantifier.All].
-         */
+        * Creates an instance of [PartiqlBasic.SetQuantifier.All].
+        */
         fun all(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.SetQuantifier.All
+        ): PartiqlBasic.SetQuantifier.All =
+            PartiqlBasic.SetQuantifier.All(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.SetQuantifier.Distinct].
-         */
+        * Creates an instance of [PartiqlBasic.SetQuantifier.Distinct].
+        */
         fun distinct(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.SetQuantifier.Distinct
+        ): PartiqlBasic.SetQuantifier.Distinct =
+            PartiqlBasic.SetQuantifier.Distinct(
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: PathElement 
         /**
-         * Creates an instance of [PartiqlBasic.PathElement.PathExpr].
-         */
+        * Creates an instance of [PartiqlBasic.PathElement.PathExpr].
+        */
         fun pathExpr(
             expr: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.PathElement.PathExpr
+        ): PartiqlBasic.PathElement.PathExpr =
+            PartiqlBasic.PathElement.PathExpr(
+                expr = expr,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.PathElement.PathWildcard].
-         */
+        * Creates an instance of [PartiqlBasic.PathElement.PathWildcard].
+        */
         fun pathWildcard(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.PathElement.PathWildcard
+        ): PartiqlBasic.PathElement.PathWildcard =
+            PartiqlBasic.PathElement.PathWildcard(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.PathElement.PathUnpivot].
-         */
+        * Creates an instance of [PartiqlBasic.PathElement.PathUnpivot].
+        */
         fun pathUnpivot(
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.PathElement.PathUnpivot
+        ): PartiqlBasic.PathElement.PathUnpivot =
+            PartiqlBasic.PathElement.PathUnpivot(
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: Expr 
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Lit].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Lit].
+        */
         fun lit(
             value: com.amazon.ionelement.api.IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Lit
+        ): PartiqlBasic.Expr.Lit =
+            PartiqlBasic.Expr.Lit(
+                value = value.asAnyElement(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Id].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Id].
+        */
         fun id(
             name: String,
             case: CaseSensitivity,
             scopeQualifier: ScopeQualifier,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Id
+        ): PartiqlBasic.Expr.Id =
+            PartiqlBasic.Expr.Id(
+                name = name.asPrimitive(),
+                case = case,
+                scopeQualifier = scopeQualifier,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Id].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Id].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun id_(
             name: org.partiql.pig.runtime.SymbolPrimitive,
             case: CaseSensitivity,
             scopeQualifier: ScopeQualifier,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Id
+        ): PartiqlBasic.Expr.Id =
+            PartiqlBasic.Expr.Id(
+                name = name,
+                case = case,
+                scopeQualifier = scopeQualifier,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Parameter].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Parameter].
+        */
         fun parameter(
             index: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Parameter
+        ): PartiqlBasic.Expr.Parameter =
+            PartiqlBasic.Expr.Parameter(
+                index = index.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Parameter].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Parameter].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun parameter_(
             index: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Parameter
+        ): PartiqlBasic.Expr.Parameter =
+            PartiqlBasic.Expr.Parameter(
+                index = index,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Not].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Not].
+        */
         fun not(
             expr: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Not
+        ): PartiqlBasic.Expr.Not =
+            PartiqlBasic.Expr.Not(
+                expr = expr,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Plus].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Plus].
+        */
         fun plus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Plus
+        ): PartiqlBasic.Expr.Plus =
+            PartiqlBasic.Expr.Plus(
+                operands = operands,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Plus].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Plus].
+        */
         fun plus(
             operands0: Expr,
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Plus
+        ): PartiqlBasic.Expr.Plus =
+            PartiqlBasic.Expr.Plus(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Minus].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Minus].
+        */
         fun minus(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Minus
+        ): PartiqlBasic.Expr.Minus =
+            PartiqlBasic.Expr.Minus(
+                operands = operands,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Minus].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Minus].
+        */
         fun minus(
             operands0: Expr,
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Minus
+        ): PartiqlBasic.Expr.Minus =
+            PartiqlBasic.Expr.Minus(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Times].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Times].
+        */
         fun times(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Times
+        ): PartiqlBasic.Expr.Times =
+            PartiqlBasic.Expr.Times(
+                operands = operands,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Times].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Times].
+        */
         fun times(
             operands0: Expr,
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Times
+        ): PartiqlBasic.Expr.Times =
+            PartiqlBasic.Expr.Times(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Divide].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Divide].
+        */
         fun divide(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Divide
+        ): PartiqlBasic.Expr.Divide =
+            PartiqlBasic.Expr.Divide(
+                operands = operands,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Divide].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Divide].
+        */
         fun divide(
             operands0: Expr,
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Divide
+        ): PartiqlBasic.Expr.Divide =
+            PartiqlBasic.Expr.Divide(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Modulo].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Modulo].
+        */
         fun modulo(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Modulo
+        ): PartiqlBasic.Expr.Modulo =
+            PartiqlBasic.Expr.Modulo(
+                operands = operands,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Modulo].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Modulo].
+        */
         fun modulo(
             operands0: Expr,
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Modulo
+        ): PartiqlBasic.Expr.Modulo =
+            PartiqlBasic.Expr.Modulo(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Concat].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Concat].
+        */
         fun concat(
             operands: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Concat
+        ): PartiqlBasic.Expr.Concat =
+            PartiqlBasic.Expr.Concat(
+                operands = operands,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Concat].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Concat].
+        */
         fun concat(
             operands0: Expr,
             operands1: Expr,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Concat
+        ): PartiqlBasic.Expr.Concat =
+            PartiqlBasic.Expr.Concat(
+                operands = listOf(operands0, operands1) + operands.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Like].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Like].
+        */
         fun like(
             left: Expr,
             right: Expr,
             escape: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Like
+        ): PartiqlBasic.Expr.Like =
+            PartiqlBasic.Expr.Like(
+                left = left,
+                right = right,
+                escape = escape,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Between].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Between].
+        */
         fun between(
             value: Expr,
             from: Expr,
             to: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Between
+        ): PartiqlBasic.Expr.Between =
+            PartiqlBasic.Expr.Between(
+                value = value,
+                from = from,
+                to = to,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Path].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Path].
+        */
         fun path(
             root: Expr,
             elements: kotlin.collections.List<PathElement>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Path
+        ): PartiqlBasic.Expr.Path =
+            PartiqlBasic.Expr.Path(
+                root = root,
+                elements = elements,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Path].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Path].
+        */
         fun path(
             root: Expr,
             elements0: PathElement,
             vararg elements: PathElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Path
+        ): PartiqlBasic.Expr.Path =
+            PartiqlBasic.Expr.Path(
+                root = root,
+                elements = listOf(elements0) + elements.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Call].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Call].
+        */
         fun call(
             name: String,
             args: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Call
+        ): PartiqlBasic.Expr.Call =
+            PartiqlBasic.Expr.Call(
+                name = name.asPrimitive(),
+                args = args,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Call].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Call].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun call_(
             name: org.partiql.pig.runtime.SymbolPrimitive,
             args: kotlin.collections.List<Expr>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Call
+        ): PartiqlBasic.Expr.Call =
+            PartiqlBasic.Expr.Call(
+                name = name,
+                args = args,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Call].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Call].
+        */
         fun call(
             name: String,
             args0: Expr,
             vararg args: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Call
+        ): PartiqlBasic.Expr.Call =
+            PartiqlBasic.Expr.Call(
+                name = name?.asPrimitive(),
+                args = listOf(args0) + args.toList(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Call].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Call].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun call_(
             name: org.partiql.pig.runtime.SymbolPrimitive,
             args0: Expr,
             vararg args: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Call
+        ): PartiqlBasic.Expr.Call =
+            PartiqlBasic.Expr.Call(
+                name = name,
+                args = listOf(args0) + args.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.CallAgg].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.CallAgg].
+        */
         fun callAgg(
             name: String,
             setQuantifier: SetQuantifier,
             arg: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.CallAgg
+        ): PartiqlBasic.Expr.CallAgg =
+            PartiqlBasic.Expr.CallAgg(
+                name = name.asPrimitive(),
+                setQuantifier = setQuantifier,
+                arg = arg,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.CallAgg].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [PartiqlBasic.Expr.CallAgg].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun callAgg_(
             name: org.partiql.pig.runtime.SymbolPrimitive,
             setQuantifier: SetQuantifier,
             arg: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.CallAgg
+        ): PartiqlBasic.Expr.CallAgg =
+            PartiqlBasic.Expr.CallAgg(
+                name = name,
+                setQuantifier = setQuantifier,
+                arg = arg,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
+        */
         fun simpleCase(
             value: Expr,
             branches: kotlin.collections.List<ExprPair>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.SimpleCase
+        ): PartiqlBasic.Expr.SimpleCase =
+            PartiqlBasic.Expr.SimpleCase(
+                value = value,
+                branches = branches,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
+        */
         fun simpleCase(
             value: Expr,
             branches0: ExprPair,
             vararg branches: ExprPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.SimpleCase
+        ): PartiqlBasic.Expr.SimpleCase =
+            PartiqlBasic.Expr.SimpleCase(
+                value = value,
+                branches = listOf(branches0) + branches.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
+        */
         fun searchedCase(
             branches: kotlin.collections.List<ExprPair>,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.SearchedCase
+        ): PartiqlBasic.Expr.SearchedCase =
+            PartiqlBasic.Expr.SearchedCase(
+                branches = branches,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
+        */
         fun searchedCase(
             branches0: ExprPair,
             vararg branches: ExprPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.SearchedCase
+        ): PartiqlBasic.Expr.SearchedCase =
+            PartiqlBasic.Expr.SearchedCase(
+                branches = listOf(branches0) + branches.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Struct].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Struct].
+        */
         fun struct(
             fields: kotlin.collections.List<ExprPair> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Struct
+        ): PartiqlBasic.Expr.Struct =
+            PartiqlBasic.Expr.Struct(
+                fields = fields,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Struct].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Struct].
+        */
         fun struct(
             vararg fields: ExprPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Struct
+        ): PartiqlBasic.Expr.Struct =
+            PartiqlBasic.Expr.Struct(
+                fields = fields.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Bag].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Bag].
+        */
         fun bag(
             values: kotlin.collections.List<Expr> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Bag
+        ): PartiqlBasic.Expr.Bag =
+            PartiqlBasic.Expr.Bag(
+                values = values,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Bag].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Bag].
+        */
         fun bag(
             vararg values: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Bag
+        ): PartiqlBasic.Expr.Bag =
+            PartiqlBasic.Expr.Bag(
+                values = values.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.List].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.List].
+        */
         fun list(
             values: kotlin.collections.List<Expr> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.List
+        ): PartiqlBasic.Expr.List =
+            PartiqlBasic.Expr.List(
+                values = values,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.List].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.List].
+        */
         fun list(
             vararg values: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.List
+        ): PartiqlBasic.Expr.List =
+            PartiqlBasic.Expr.List(
+                values = values.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [PartiqlBasic.Expr.Select].
-         */
+        * Creates an instance of [PartiqlBasic.Expr.Select].
+        */
         fun select(
             setq: SetQuantifier? = null,
             project: Projection,
@@ -709,673 +935,6 @@ class PartiqlBasic private constructor() {
             having: Expr? = null,
             limit: Expr? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): PartiqlBasic.Expr.Select
-    }
-    
-    private object PartiqlBasicBuilder : Builder {
-                // Tuples
-        override fun exprPair(
-            first: Expr,
-            second: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.ExprPair =
-            PartiqlBasic.ExprPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun groupByItem(
-            value: Expr,
-            asAlias: String?,
-            metas: MetaContainer
-        ): PartiqlBasic.GroupByItem =
-            PartiqlBasic.GroupByItem(
-                value = value,
-                asAlias = asAlias?.asPrimitive(),
-                metas = metas)
-        
-        override fun groupByItem_(
-            value: Expr,
-            asAlias: org.partiql.pig.runtime.SymbolPrimitive?,
-            metas: MetaContainer
-        ): PartiqlBasic.GroupByItem =
-            PartiqlBasic.GroupByItem(
-                value = value,
-                asAlias = asAlias,
-                metas = metas)
-        
-        
-        override fun groupByList(
-            items: kotlin.collections.List<GroupByItem>,
-            metas: MetaContainer
-        ): PartiqlBasic.GroupByList =
-            PartiqlBasic.GroupByList(
-                items = items,
-                metas = metas)
-        
-        override fun groupByList(
-            items0: GroupByItem,
-            vararg items: GroupByItem,
-            metas: MetaContainer
-        ): PartiqlBasic.GroupByList =
-            PartiqlBasic.GroupByList(
-                items = listOf(items0) + items.toList(),
-                metas = metas)
-        
-        
-        override fun groupBy(
-            items: GroupByList,
-            groupAsAlias: String?,
-            metas: MetaContainer
-        ): PartiqlBasic.GroupBy =
-            PartiqlBasic.GroupBy(
-                items = items,
-                groupAsAlias = groupAsAlias?.asPrimitive(),
-                metas = metas)
-        
-        override fun groupBy_(
-            items: GroupByList,
-            groupAsAlias: org.partiql.pig.runtime.SymbolPrimitive?,
-            metas: MetaContainer
-        ): PartiqlBasic.GroupBy =
-            PartiqlBasic.GroupBy(
-                items = items,
-                groupAsAlias = groupAsAlias,
-                metas = metas)
-        
-        
-        // Variants for Sum: Projection 
-        override fun projectList(
-            items: kotlin.collections.List<ProjectItem>,
-            metas: MetaContainer
-        ): PartiqlBasic.Projection.ProjectList =
-            PartiqlBasic.Projection.ProjectList(
-                items = items,
-                metas = metas)
-        
-        override fun projectList(
-            items0: ProjectItem,
-            vararg items: ProjectItem,
-            metas: MetaContainer
-        ): PartiqlBasic.Projection.ProjectList =
-            PartiqlBasic.Projection.ProjectList(
-                items = listOf(items0) + items.toList(),
-                metas = metas)
-        
-        
-        override fun projectValue(
-            value: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Projection.ProjectValue =
-            PartiqlBasic.Projection.ProjectValue(
-                value = value,
-                metas = metas)
-        
-        
-        // Variants for Sum: ProjectItem 
-        override fun projectAll(
-            metas: MetaContainer
-        ): PartiqlBasic.ProjectItem.ProjectAll =
-            PartiqlBasic.ProjectItem.ProjectAll(
-                metas = metas)
-        
-        
-        override fun projectExpr(
-            value: Expr,
-            asAlias: String?,
-            metas: MetaContainer
-        ): PartiqlBasic.ProjectItem.ProjectExpr =
-            PartiqlBasic.ProjectItem.ProjectExpr(
-                value = value,
-                asAlias = asAlias?.asPrimitive(),
-                metas = metas)
-        
-        override fun projectExpr_(
-            value: Expr,
-            asAlias: org.partiql.pig.runtime.SymbolPrimitive?,
-            metas: MetaContainer
-        ): PartiqlBasic.ProjectItem.ProjectExpr =
-            PartiqlBasic.ProjectItem.ProjectExpr(
-                value = value,
-                asAlias = asAlias,
-                metas = metas)
-        
-        
-        // Variants for Sum: JoinType 
-        override fun inner(
-            metas: MetaContainer
-        ): PartiqlBasic.JoinType.Inner =
-            PartiqlBasic.JoinType.Inner(
-                metas = metas)
-        
-        
-        override fun left(
-            metas: MetaContainer
-        ): PartiqlBasic.JoinType.Left =
-            PartiqlBasic.JoinType.Left(
-                metas = metas)
-        
-        
-        override fun right(
-            metas: MetaContainer
-        ): PartiqlBasic.JoinType.Right =
-            PartiqlBasic.JoinType.Right(
-                metas = metas)
-        
-        
-        override fun outer(
-            metas: MetaContainer
-        ): PartiqlBasic.JoinType.Outer =
-            PartiqlBasic.JoinType.Outer(
-                metas = metas)
-        
-        
-        // Variants for Sum: FromSource 
-        override fun scan(
-            expr: Expr,
-            asAlias: String?,
-            atAlias: String?,
-            byAlias: String?,
-            metas: MetaContainer
-        ): PartiqlBasic.FromSource.Scan =
-            PartiqlBasic.FromSource.Scan(
-                expr = expr,
-                asAlias = asAlias?.asPrimitive(),
-                atAlias = atAlias?.asPrimitive(),
-                byAlias = byAlias?.asPrimitive(),
-                metas = metas)
-        
-        override fun scan_(
-            expr: Expr,
-            asAlias: org.partiql.pig.runtime.SymbolPrimitive?,
-            atAlias: org.partiql.pig.runtime.SymbolPrimitive?,
-            byAlias: org.partiql.pig.runtime.SymbolPrimitive?,
-            metas: MetaContainer
-        ): PartiqlBasic.FromSource.Scan =
-            PartiqlBasic.FromSource.Scan(
-                expr = expr,
-                asAlias = asAlias,
-                atAlias = atAlias,
-                byAlias = byAlias,
-                metas = metas)
-        
-        
-        override fun join(
-            type: JoinType,
-            left: FromSource,
-            right: FromSource,
-            predicate: Expr?,
-            metas: MetaContainer
-        ): PartiqlBasic.FromSource.Join =
-            PartiqlBasic.FromSource.Join(
-                type = type,
-                left = left,
-                right = right,
-                predicate = predicate,
-                metas = metas)
-        
-        
-        // Variants for Sum: CaseSensitivity 
-        override fun caseSensitive(
-            metas: MetaContainer
-        ): PartiqlBasic.CaseSensitivity.CaseSensitive =
-            PartiqlBasic.CaseSensitivity.CaseSensitive(
-                metas = metas)
-        
-        
-        override fun caseInsensitive(
-            metas: MetaContainer
-        ): PartiqlBasic.CaseSensitivity.CaseInsensitive =
-            PartiqlBasic.CaseSensitivity.CaseInsensitive(
-                metas = metas)
-        
-        
-        // Variants for Sum: ScopeQualifier 
-        override fun unqualified(
-            metas: MetaContainer
-        ): PartiqlBasic.ScopeQualifier.Unqualified =
-            PartiqlBasic.ScopeQualifier.Unqualified(
-                metas = metas)
-        
-        
-        override fun qualified(
-            metas: MetaContainer
-        ): PartiqlBasic.ScopeQualifier.Qualified =
-            PartiqlBasic.ScopeQualifier.Qualified(
-                metas = metas)
-        
-        
-        // Variants for Sum: SetQuantifier 
-        override fun all(
-            metas: MetaContainer
-        ): PartiqlBasic.SetQuantifier.All =
-            PartiqlBasic.SetQuantifier.All(
-                metas = metas)
-        
-        
-        override fun distinct(
-            metas: MetaContainer
-        ): PartiqlBasic.SetQuantifier.Distinct =
-            PartiqlBasic.SetQuantifier.Distinct(
-                metas = metas)
-        
-        
-        // Variants for Sum: PathElement 
-        override fun pathExpr(
-            expr: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.PathElement.PathExpr =
-            PartiqlBasic.PathElement.PathExpr(
-                expr = expr,
-                metas = metas)
-        
-        
-        override fun pathWildcard(
-            metas: MetaContainer
-        ): PartiqlBasic.PathElement.PathWildcard =
-            PartiqlBasic.PathElement.PathWildcard(
-                metas = metas)
-        
-        
-        override fun pathUnpivot(
-            metas: MetaContainer
-        ): PartiqlBasic.PathElement.PathUnpivot =
-            PartiqlBasic.PathElement.PathUnpivot(
-                metas = metas)
-        
-        
-        // Variants for Sum: Expr 
-        override fun lit(
-            value: com.amazon.ionelement.api.IonElement,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Lit =
-            PartiqlBasic.Expr.Lit(
-                value = value.asAnyElement(),
-                metas = metas)
-        
-        
-        override fun id(
-            name: String,
-            case: CaseSensitivity,
-            scopeQualifier: ScopeQualifier,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Id =
-            PartiqlBasic.Expr.Id(
-                name = name.asPrimitive(),
-                case = case,
-                scopeQualifier = scopeQualifier,
-                metas = metas)
-        
-        override fun id_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            case: CaseSensitivity,
-            scopeQualifier: ScopeQualifier,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Id =
-            PartiqlBasic.Expr.Id(
-                name = name,
-                case = case,
-                scopeQualifier = scopeQualifier,
-                metas = metas)
-        
-        
-        override fun parameter(
-            index: Long,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Parameter =
-            PartiqlBasic.Expr.Parameter(
-                index = index.asPrimitive(),
-                metas = metas)
-        
-        override fun parameter_(
-            index: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Parameter =
-            PartiqlBasic.Expr.Parameter(
-                index = index,
-                metas = metas)
-        
-        
-        override fun not(
-            expr: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Not =
-            PartiqlBasic.Expr.Not(
-                expr = expr,
-                metas = metas)
-        
-        
-        override fun plus(
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Plus =
-            PartiqlBasic.Expr.Plus(
-                operands = operands,
-                metas = metas)
-        
-        override fun plus(
-            operands0: Expr,
-            operands1: Expr,
-            vararg operands: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Plus =
-            PartiqlBasic.Expr.Plus(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
-        
-        
-        override fun minus(
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Minus =
-            PartiqlBasic.Expr.Minus(
-                operands = operands,
-                metas = metas)
-        
-        override fun minus(
-            operands0: Expr,
-            operands1: Expr,
-            vararg operands: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Minus =
-            PartiqlBasic.Expr.Minus(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
-        
-        
-        override fun times(
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Times =
-            PartiqlBasic.Expr.Times(
-                operands = operands,
-                metas = metas)
-        
-        override fun times(
-            operands0: Expr,
-            operands1: Expr,
-            vararg operands: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Times =
-            PartiqlBasic.Expr.Times(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
-        
-        
-        override fun divide(
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Divide =
-            PartiqlBasic.Expr.Divide(
-                operands = operands,
-                metas = metas)
-        
-        override fun divide(
-            operands0: Expr,
-            operands1: Expr,
-            vararg operands: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Divide =
-            PartiqlBasic.Expr.Divide(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
-        
-        
-        override fun modulo(
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Modulo =
-            PartiqlBasic.Expr.Modulo(
-                operands = operands,
-                metas = metas)
-        
-        override fun modulo(
-            operands0: Expr,
-            operands1: Expr,
-            vararg operands: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Modulo =
-            PartiqlBasic.Expr.Modulo(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
-        
-        
-        override fun concat(
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Concat =
-            PartiqlBasic.Expr.Concat(
-                operands = operands,
-                metas = metas)
-        
-        override fun concat(
-            operands0: Expr,
-            operands1: Expr,
-            vararg operands: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Concat =
-            PartiqlBasic.Expr.Concat(
-                operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas)
-        
-        
-        override fun like(
-            left: Expr,
-            right: Expr,
-            escape: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Like =
-            PartiqlBasic.Expr.Like(
-                left = left,
-                right = right,
-                escape = escape,
-                metas = metas)
-        
-        
-        override fun between(
-            value: Expr,
-            from: Expr,
-            to: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Between =
-            PartiqlBasic.Expr.Between(
-                value = value,
-                from = from,
-                to = to,
-                metas = metas)
-        
-        
-        override fun path(
-            root: Expr,
-            elements: kotlin.collections.List<PathElement>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Path =
-            PartiqlBasic.Expr.Path(
-                root = root,
-                elements = elements,
-                metas = metas)
-        
-        override fun path(
-            root: Expr,
-            elements0: PathElement,
-            vararg elements: PathElement,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Path =
-            PartiqlBasic.Expr.Path(
-                root = root,
-                elements = listOf(elements0) + elements.toList(),
-                metas = metas)
-        
-        
-        override fun call(
-            name: String,
-            args: kotlin.collections.List<Expr>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Call =
-            PartiqlBasic.Expr.Call(
-                name = name.asPrimitive(),
-                args = args,
-                metas = metas)
-        
-        override fun call_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            args: kotlin.collections.List<Expr>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Call =
-            PartiqlBasic.Expr.Call(
-                name = name,
-                args = args,
-                metas = metas)
-        
-        override fun call(
-            name: String,
-            args0: Expr,
-            vararg args: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Call =
-            PartiqlBasic.Expr.Call(
-                name = name?.asPrimitive(),
-                args = listOf(args0) + args.toList(),
-                metas = metas)
-        
-        override fun call_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            args0: Expr,
-            vararg args: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Call =
-            PartiqlBasic.Expr.Call(
-                name = name,
-                args = listOf(args0) + args.toList(),
-                metas = metas)
-        
-        
-        override fun callAgg(
-            name: String,
-            setQuantifier: SetQuantifier,
-            arg: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.CallAgg =
-            PartiqlBasic.Expr.CallAgg(
-                name = name.asPrimitive(),
-                setQuantifier = setQuantifier,
-                arg = arg,
-                metas = metas)
-        
-        override fun callAgg_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            setQuantifier: SetQuantifier,
-            arg: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.CallAgg =
-            PartiqlBasic.Expr.CallAgg(
-                name = name,
-                setQuantifier = setQuantifier,
-                arg = arg,
-                metas = metas)
-        
-        
-        override fun simpleCase(
-            value: Expr,
-            branches: kotlin.collections.List<ExprPair>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.SimpleCase =
-            PartiqlBasic.Expr.SimpleCase(
-                value = value,
-                branches = branches,
-                metas = metas)
-        
-        override fun simpleCase(
-            value: Expr,
-            branches0: ExprPair,
-            vararg branches: ExprPair,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.SimpleCase =
-            PartiqlBasic.Expr.SimpleCase(
-                value = value,
-                branches = listOf(branches0) + branches.toList(),
-                metas = metas)
-        
-        
-        override fun searchedCase(
-            branches: kotlin.collections.List<ExprPair>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.SearchedCase =
-            PartiqlBasic.Expr.SearchedCase(
-                branches = branches,
-                metas = metas)
-        
-        override fun searchedCase(
-            branches0: ExprPair,
-            vararg branches: ExprPair,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.SearchedCase =
-            PartiqlBasic.Expr.SearchedCase(
-                branches = listOf(branches0) + branches.toList(),
-                metas = metas)
-        
-        
-        override fun struct(
-            fields: kotlin.collections.List<ExprPair>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Struct =
-            PartiqlBasic.Expr.Struct(
-                fields = fields,
-                metas = metas)
-        
-        override fun struct(
-            vararg fields: ExprPair,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Struct =
-            PartiqlBasic.Expr.Struct(
-                fields = fields.toList(),
-                metas = metas)
-        
-        
-        override fun bag(
-            values: kotlin.collections.List<Expr>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Bag =
-            PartiqlBasic.Expr.Bag(
-                values = values,
-                metas = metas)
-        
-        override fun bag(
-            vararg values: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.Bag =
-            PartiqlBasic.Expr.Bag(
-                values = values.toList(),
-                metas = metas)
-        
-        
-        override fun list(
-            values: kotlin.collections.List<Expr>,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.List =
-            PartiqlBasic.Expr.List(
-                values = values,
-                metas = metas)
-        
-        override fun list(
-            vararg values: Expr,
-            metas: MetaContainer
-        ): PartiqlBasic.Expr.List =
-            PartiqlBasic.Expr.List(
-                values = values.toList(),
-                metas = metas)
-        
-        
-        override fun select(
-            setq: SetQuantifier?,
-            project: Projection,
-            from: FromSource,
-            where: Expr?,
-            group: GroupBy?,
-            having: Expr?,
-            limit: Expr?,
-            metas: MetaContainer
         ): PartiqlBasic.Expr.Select =
             PartiqlBasic.Expr.Select(
                 setq = setq,
@@ -1385,8 +944,11 @@ class PartiqlBasic private constructor() {
                 group = group,
                 having = having,
                 limit = limit,
-                metas = metas)
+                metas = metas + newMetaContainer())
     }
+    
+    /** Default implementation of [Builder] that uses all default method implementations. */
+    private object PartiqlBasicBuilder : Builder
     
     /** Base class for all PartiqlBasic types. */
     abstract class PartiqlBasicNode : DomainNode {

--- a/pig-tests/src/org/partiql/pig/tests/generated/partiql-basic.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/partiql-basic.kt
@@ -37,28 +37,28 @@ class PartiqlBasic private constructor() {
         * Creates an instance of [PartiqlBasic.ExprPair].
         */
         fun exprPair(
-            first: Expr,
-            second: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Expr,
+                    second: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ExprPair =
             PartiqlBasic.ExprPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.GroupByItem].
         */
         fun groupByItem(
-            value: Expr,
-            asAlias: String? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: Expr,
+                    asAlias: String? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupByItem =
             PartiqlBasic.GroupByItem(
                 value = value,
                 asAlias = asAlias?.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.GroupByItem].
@@ -68,52 +68,52 @@ class PartiqlBasic private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun groupByItem_(
-            value: Expr,
-            asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: Expr,
+                    asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupByItem =
             PartiqlBasic.GroupByItem(
                 value = value,
                 asAlias = asAlias,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.GroupByList].
         */
         fun groupByList(
-            items: kotlin.collections.List<GroupByItem>,
-            metas: MetaContainer = emptyMetaContainer()
+                    items: kotlin.collections.List<GroupByItem>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupByList =
             PartiqlBasic.GroupByList(
                 items = items,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.GroupByList].
         */
         fun groupByList(
-            items0: GroupByItem,
-            vararg items: GroupByItem,
-            metas: MetaContainer = emptyMetaContainer()
+                    items0: GroupByItem,
+                    vararg items: GroupByItem,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupByList =
             PartiqlBasic.GroupByList(
                 items = listOf(items0) + items.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.GroupBy].
         */
         fun groupBy(
-            items: GroupByList,
-            groupAsAlias: String? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    items: GroupByList,
+                    groupAsAlias: String? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupBy =
             PartiqlBasic.GroupBy(
                 items = items,
                 groupAsAlias = groupAsAlias?.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.GroupBy].
@@ -123,14 +123,14 @@ class PartiqlBasic private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun groupBy_(
-            items: GroupByList,
-            groupAsAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    items: GroupByList,
+                    groupAsAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.GroupBy =
             PartiqlBasic.GroupBy(
                 items = items,
                 groupAsAlias = groupAsAlias,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: Projection 
@@ -138,36 +138,36 @@ class PartiqlBasic private constructor() {
         * Creates an instance of [PartiqlBasic.Projection.ProjectList].
         */
         fun projectList(
-            items: kotlin.collections.List<ProjectItem>,
-            metas: MetaContainer = emptyMetaContainer()
+                    items: kotlin.collections.List<ProjectItem>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Projection.ProjectList =
             PartiqlBasic.Projection.ProjectList(
                 items = items,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Projection.ProjectList].
         */
         fun projectList(
-            items0: ProjectItem,
-            vararg items: ProjectItem,
-            metas: MetaContainer = emptyMetaContainer()
+                    items0: ProjectItem,
+                    vararg items: ProjectItem,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Projection.ProjectList =
             PartiqlBasic.Projection.ProjectList(
                 items = listOf(items0) + items.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Projection.ProjectValue].
         */
         fun projectValue(
-            value: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Projection.ProjectValue =
             PartiqlBasic.Projection.ProjectValue(
                 value = value,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: ProjectItem 
@@ -175,24 +175,24 @@ class PartiqlBasic private constructor() {
         * Creates an instance of [PartiqlBasic.ProjectItem.ProjectAll].
         */
         fun projectAll(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ProjectItem.ProjectAll =
             PartiqlBasic.ProjectItem.ProjectAll(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.ProjectItem.ProjectExpr].
         */
         fun projectExpr(
-            value: Expr,
-            asAlias: String? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: Expr,
+                    asAlias: String? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ProjectItem.ProjectExpr =
             PartiqlBasic.ProjectItem.ProjectExpr(
                 value = value,
                 asAlias = asAlias?.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.ProjectItem.ProjectExpr].
@@ -202,14 +202,14 @@ class PartiqlBasic private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun projectExpr_(
-            value: Expr,
-            asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: Expr,
+                    asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ProjectItem.ProjectExpr =
             PartiqlBasic.ProjectItem.ProjectExpr(
                 value = value,
                 asAlias = asAlias,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: JoinType 
@@ -217,40 +217,40 @@ class PartiqlBasic private constructor() {
         * Creates an instance of [PartiqlBasic.JoinType.Inner].
         */
         fun inner(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.JoinType.Inner =
             PartiqlBasic.JoinType.Inner(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.JoinType.Left].
         */
         fun left(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.JoinType.Left =
             PartiqlBasic.JoinType.Left(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.JoinType.Right].
         */
         fun right(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.JoinType.Right =
             PartiqlBasic.JoinType.Right(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.JoinType.Outer].
         */
         fun outer(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.JoinType.Outer =
             PartiqlBasic.JoinType.Outer(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: FromSource 
@@ -258,18 +258,18 @@ class PartiqlBasic private constructor() {
         * Creates an instance of [PartiqlBasic.FromSource.Scan].
         */
         fun scan(
-            expr: Expr,
-            asAlias: String? = null,
-            atAlias: String? = null,
-            byAlias: String? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    expr: Expr,
+                    asAlias: String? = null,
+                    atAlias: String? = null,
+                    byAlias: String? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.FromSource.Scan =
             PartiqlBasic.FromSource.Scan(
                 expr = expr,
                 asAlias = asAlias?.asPrimitive(),
                 atAlias = atAlias?.asPrimitive(),
                 byAlias = byAlias?.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.FromSource.Scan].
@@ -279,36 +279,36 @@ class PartiqlBasic private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun scan_(
-            expr: Expr,
-            asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
-            atAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
-            byAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    expr: Expr,
+                    asAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
+                    atAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
+                    byAlias: org.partiql.pig.runtime.SymbolPrimitive? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.FromSource.Scan =
             PartiqlBasic.FromSource.Scan(
                 expr = expr,
                 asAlias = asAlias,
                 atAlias = atAlias,
                 byAlias = byAlias,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.FromSource.Join].
         */
         fun join(
-            type: JoinType,
-            left: FromSource,
-            right: FromSource,
-            predicate: Expr? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    type: JoinType,
+                    left: FromSource,
+                    right: FromSource,
+                    predicate: Expr? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.FromSource.Join =
             PartiqlBasic.FromSource.Join(
                 type = type,
                 left = left,
                 right = right,
                 predicate = predicate,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: CaseSensitivity 
@@ -316,20 +316,20 @@ class PartiqlBasic private constructor() {
         * Creates an instance of [PartiqlBasic.CaseSensitivity.CaseSensitive].
         */
         fun caseSensitive(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.CaseSensitivity.CaseSensitive =
             PartiqlBasic.CaseSensitivity.CaseSensitive(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.CaseSensitivity.CaseInsensitive].
         */
         fun caseInsensitive(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.CaseSensitivity.CaseInsensitive =
             PartiqlBasic.CaseSensitivity.CaseInsensitive(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: ScopeQualifier 
@@ -337,20 +337,20 @@ class PartiqlBasic private constructor() {
         * Creates an instance of [PartiqlBasic.ScopeQualifier.Unqualified].
         */
         fun unqualified(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ScopeQualifier.Unqualified =
             PartiqlBasic.ScopeQualifier.Unqualified(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.ScopeQualifier.Qualified].
         */
         fun qualified(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.ScopeQualifier.Qualified =
             PartiqlBasic.ScopeQualifier.Qualified(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: SetQuantifier 
@@ -358,20 +358,20 @@ class PartiqlBasic private constructor() {
         * Creates an instance of [PartiqlBasic.SetQuantifier.All].
         */
         fun all(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.SetQuantifier.All =
             PartiqlBasic.SetQuantifier.All(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.SetQuantifier.Distinct].
         */
         fun distinct(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.SetQuantifier.Distinct =
             PartiqlBasic.SetQuantifier.Distinct(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: PathElement 
@@ -379,32 +379,32 @@ class PartiqlBasic private constructor() {
         * Creates an instance of [PartiqlBasic.PathElement.PathExpr].
         */
         fun pathExpr(
-            expr: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    expr: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.PathElement.PathExpr =
             PartiqlBasic.PathElement.PathExpr(
                 expr = expr,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.PathElement.PathWildcard].
         */
         fun pathWildcard(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.PathElement.PathWildcard =
             PartiqlBasic.PathElement.PathWildcard(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.PathElement.PathUnpivot].
         */
         fun pathUnpivot(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.PathElement.PathUnpivot =
             PartiqlBasic.PathElement.PathUnpivot(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: Expr 
@@ -412,28 +412,28 @@ class PartiqlBasic private constructor() {
         * Creates an instance of [PartiqlBasic.Expr.Lit].
         */
         fun lit(
-            value: com.amazon.ionelement.api.IonElement,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: com.amazon.ionelement.api.IonElement,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Lit =
             PartiqlBasic.Expr.Lit(
                 value = value.asAnyElement(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Id].
         */
         fun id(
-            name: String,
-            case: CaseSensitivity,
-            scopeQualifier: ScopeQualifier,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: String,
+                    case: CaseSensitivity,
+                    scopeQualifier: ScopeQualifier,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Id =
             PartiqlBasic.Expr.Id(
                 name = name.asPrimitive(),
                 case = case,
                 scopeQualifier = scopeQualifier,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Id].
@@ -443,28 +443,28 @@ class PartiqlBasic private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun id_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            case: CaseSensitivity,
-            scopeQualifier: ScopeQualifier,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: org.partiql.pig.runtime.SymbolPrimitive,
+                    case: CaseSensitivity,
+                    scopeQualifier: ScopeQualifier,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Id =
             PartiqlBasic.Expr.Id(
                 name = name,
                 case = case,
                 scopeQualifier = scopeQualifier,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Parameter].
         */
         fun parameter(
-            index: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    index: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Parameter =
             PartiqlBasic.Expr.Parameter(
                 index = index.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Parameter].
@@ -474,248 +474,248 @@ class PartiqlBasic private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun parameter_(
-            index: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    index: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Parameter =
             PartiqlBasic.Expr.Parameter(
                 index = index,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Not].
         */
         fun not(
-            expr: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    expr: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Not =
             PartiqlBasic.Expr.Not(
                 expr = expr,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Plus].
         */
         fun plus(
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer = emptyMetaContainer()
+                    operands: kotlin.collections.List<Expr>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Plus =
             PartiqlBasic.Expr.Plus(
                 operands = operands,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Plus].
         */
         fun plus(
-            operands0: Expr,
-            operands1: Expr,
-            vararg operands: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    operands0: Expr,
+                    operands1: Expr,
+                    vararg operands: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Plus =
             PartiqlBasic.Expr.Plus(
                 operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Minus].
         */
         fun minus(
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer = emptyMetaContainer()
+                    operands: kotlin.collections.List<Expr>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Minus =
             PartiqlBasic.Expr.Minus(
                 operands = operands,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Minus].
         */
         fun minus(
-            operands0: Expr,
-            operands1: Expr,
-            vararg operands: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    operands0: Expr,
+                    operands1: Expr,
+                    vararg operands: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Minus =
             PartiqlBasic.Expr.Minus(
                 operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Times].
         */
         fun times(
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer = emptyMetaContainer()
+                    operands: kotlin.collections.List<Expr>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Times =
             PartiqlBasic.Expr.Times(
                 operands = operands,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Times].
         */
         fun times(
-            operands0: Expr,
-            operands1: Expr,
-            vararg operands: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    operands0: Expr,
+                    operands1: Expr,
+                    vararg operands: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Times =
             PartiqlBasic.Expr.Times(
                 operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Divide].
         */
         fun divide(
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer = emptyMetaContainer()
+                    operands: kotlin.collections.List<Expr>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Divide =
             PartiqlBasic.Expr.Divide(
                 operands = operands,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Divide].
         */
         fun divide(
-            operands0: Expr,
-            operands1: Expr,
-            vararg operands: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    operands0: Expr,
+                    operands1: Expr,
+                    vararg operands: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Divide =
             PartiqlBasic.Expr.Divide(
                 operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Modulo].
         */
         fun modulo(
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer = emptyMetaContainer()
+                    operands: kotlin.collections.List<Expr>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Modulo =
             PartiqlBasic.Expr.Modulo(
                 operands = operands,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Modulo].
         */
         fun modulo(
-            operands0: Expr,
-            operands1: Expr,
-            vararg operands: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    operands0: Expr,
+                    operands1: Expr,
+                    vararg operands: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Modulo =
             PartiqlBasic.Expr.Modulo(
                 operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Concat].
         */
         fun concat(
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer = emptyMetaContainer()
+                    operands: kotlin.collections.List<Expr>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Concat =
             PartiqlBasic.Expr.Concat(
                 operands = operands,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Concat].
         */
         fun concat(
-            operands0: Expr,
-            operands1: Expr,
-            vararg operands: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    operands0: Expr,
+                    operands1: Expr,
+                    vararg operands: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Concat =
             PartiqlBasic.Expr.Concat(
                 operands = listOf(operands0, operands1) + operands.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Like].
         */
         fun like(
-            left: Expr,
-            right: Expr,
-            escape: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    left: Expr,
+                    right: Expr,
+                    escape: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Like =
             PartiqlBasic.Expr.Like(
                 left = left,
                 right = right,
                 escape = escape,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Between].
         */
         fun between(
-            value: Expr,
-            from: Expr,
-            to: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: Expr,
+                    from: Expr,
+                    to: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Between =
             PartiqlBasic.Expr.Between(
                 value = value,
                 from = from,
                 to = to,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Path].
         */
         fun path(
-            root: Expr,
-            elements: kotlin.collections.List<PathElement>,
-            metas: MetaContainer = emptyMetaContainer()
+                    root: Expr,
+                    elements: kotlin.collections.List<PathElement>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Path =
             PartiqlBasic.Expr.Path(
                 root = root,
                 elements = elements,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Path].
         */
         fun path(
-            root: Expr,
-            elements0: PathElement,
-            vararg elements: PathElement,
-            metas: MetaContainer = emptyMetaContainer()
+                    root: Expr,
+                    elements0: PathElement,
+                    vararg elements: PathElement,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Path =
             PartiqlBasic.Expr.Path(
                 root = root,
                 elements = listOf(elements0) + elements.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Call].
         */
         fun call(
-            name: String,
-            args: kotlin.collections.List<Expr>,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: String,
+                    args: kotlin.collections.List<Expr>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
                 name = name.asPrimitive(),
                 args = args,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Call].
@@ -725,28 +725,28 @@ class PartiqlBasic private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun call_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            args: kotlin.collections.List<Expr>,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: org.partiql.pig.runtime.SymbolPrimitive,
+                    args: kotlin.collections.List<Expr>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
                 name = name,
                 args = args,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Call].
         */
         fun call(
-            name: String,
-            args0: Expr,
-            vararg args: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: String,
+                    args0: Expr,
+                    vararg args: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
                 name = name?.asPrimitive(),
                 args = listOf(args0) + args.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Call].
@@ -756,31 +756,31 @@ class PartiqlBasic private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun call_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            args0: Expr,
-            vararg args: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: org.partiql.pig.runtime.SymbolPrimitive,
+                    args0: Expr,
+                    vararg args: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
                 name = name,
                 args = listOf(args0) + args.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.CallAgg].
         */
         fun callAgg(
-            name: String,
-            setQuantifier: SetQuantifier,
-            arg: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: String,
+                    setQuantifier: SetQuantifier,
+                    arg: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.CallAgg =
             PartiqlBasic.Expr.CallAgg(
                 name = name.asPrimitive(),
                 setQuantifier = setQuantifier,
                 arg = arg,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.CallAgg].
@@ -790,151 +790,151 @@ class PartiqlBasic private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun callAgg_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            setQuantifier: SetQuantifier,
-            arg: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: org.partiql.pig.runtime.SymbolPrimitive,
+                    setQuantifier: SetQuantifier,
+                    arg: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.CallAgg =
             PartiqlBasic.Expr.CallAgg(
                 name = name,
                 setQuantifier = setQuantifier,
                 arg = arg,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
         */
         fun simpleCase(
-            value: Expr,
-            branches: kotlin.collections.List<ExprPair>,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: Expr,
+                    branches: kotlin.collections.List<ExprPair>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.SimpleCase =
             PartiqlBasic.Expr.SimpleCase(
                 value = value,
                 branches = branches,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.SimpleCase].
         */
         fun simpleCase(
-            value: Expr,
-            branches0: ExprPair,
-            vararg branches: ExprPair,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: Expr,
+                    branches0: ExprPair,
+                    vararg branches: ExprPair,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.SimpleCase =
             PartiqlBasic.Expr.SimpleCase(
                 value = value,
                 branches = listOf(branches0) + branches.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
         */
         fun searchedCase(
-            branches: kotlin.collections.List<ExprPair>,
-            metas: MetaContainer = emptyMetaContainer()
+                    branches: kotlin.collections.List<ExprPair>,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.SearchedCase =
             PartiqlBasic.Expr.SearchedCase(
                 branches = branches,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.SearchedCase].
         */
         fun searchedCase(
-            branches0: ExprPair,
-            vararg branches: ExprPair,
-            metas: MetaContainer = emptyMetaContainer()
+                    branches0: ExprPair,
+                    vararg branches: ExprPair,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.SearchedCase =
             PartiqlBasic.Expr.SearchedCase(
                 branches = listOf(branches0) + branches.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Struct].
         */
         fun struct(
-            fields: kotlin.collections.List<ExprPair> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    fields: kotlin.collections.List<ExprPair> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Struct =
             PartiqlBasic.Expr.Struct(
                 fields = fields,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Struct].
         */
         fun struct(
-            vararg fields: ExprPair,
-            metas: MetaContainer = emptyMetaContainer()
+                    vararg fields: ExprPair,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Struct =
             PartiqlBasic.Expr.Struct(
                 fields = fields.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Bag].
         */
         fun bag(
-            values: kotlin.collections.List<Expr> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    values: kotlin.collections.List<Expr> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Bag =
             PartiqlBasic.Expr.Bag(
                 values = values,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Bag].
         */
         fun bag(
-            vararg values: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    vararg values: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Bag =
             PartiqlBasic.Expr.Bag(
                 values = values.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.List].
         */
         fun list(
-            values: kotlin.collections.List<Expr> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    values: kotlin.collections.List<Expr> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.List =
             PartiqlBasic.Expr.List(
                 values = values,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.List].
         */
         fun list(
-            vararg values: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    vararg values: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.List =
             PartiqlBasic.Expr.List(
                 values = values.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [PartiqlBasic.Expr.Select].
         */
         fun select(
-            setq: SetQuantifier? = null,
-            project: Projection,
-            from: FromSource,
-            where: Expr? = null,
-            group: GroupBy? = null,
-            having: Expr? = null,
-            limit: Expr? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    setq: SetQuantifier? = null,
+                    project: Projection,
+                    from: FromSource,
+                    where: Expr? = null,
+                    group: GroupBy? = null,
+                    having: Expr? = null,
+                    limit: Expr? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Select =
             PartiqlBasic.Expr.Select(
                 setq = setq,
@@ -944,7 +944,7 @@ class PartiqlBasic private constructor() {
                 group = group,
                 having = having,
                 limit = limit,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */

--- a/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
@@ -32,10 +32,10 @@ class TestDomain private constructor() {
     interface Builder {
         fun newMetaContainer() = emptyMetaContainer()
     
-                    // Tuples
+        // Tuples 
         /**
-        * Creates an instance of [TestDomain.BoolPair].
-        */
+         * Creates an instance of [TestDomain.BoolPair].
+         */
         fun boolPair(
                     first: Boolean,
                     second: Boolean,
@@ -44,15 +44,16 @@ class TestDomain private constructor() {
             TestDomain.BoolPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.BoolPair].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.BoolPair].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun boolPair_(
                     first: org.partiql.pig.runtime.BoolPrimitive,
                     second: org.partiql.pig.runtime.BoolPrimitive,
@@ -61,12 +62,13 @@ class TestDomain private constructor() {
             TestDomain.BoolPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.IntPair].
-        */
+         * Creates an instance of [TestDomain.IntPair].
+         */
         fun intPair(
                     first: Long,
                     second: Long,
@@ -75,15 +77,16 @@ class TestDomain private constructor() {
             TestDomain.IntPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.IntPair].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.IntPair].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun intPair_(
                     first: org.partiql.pig.runtime.LongPrimitive,
                     second: org.partiql.pig.runtime.LongPrimitive,
@@ -92,12 +95,13 @@ class TestDomain private constructor() {
             TestDomain.IntPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.SymbolPair].
-        */
+         * Creates an instance of [TestDomain.SymbolPair].
+         */
         fun symbolPair(
                     first: String,
                     second: String,
@@ -106,15 +110,16 @@ class TestDomain private constructor() {
             TestDomain.SymbolPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.SymbolPair].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.SymbolPair].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun symbolPair_(
                     first: org.partiql.pig.runtime.SymbolPrimitive,
                     second: org.partiql.pig.runtime.SymbolPrimitive,
@@ -123,12 +128,13 @@ class TestDomain private constructor() {
             TestDomain.SymbolPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.IonPair].
-        */
+         * Creates an instance of [TestDomain.IonPair].
+         */
         fun ionPair(
                     first: com.amazon.ionelement.api.IonElement,
                     second: com.amazon.ionelement.api.IonElement,
@@ -137,12 +143,13 @@ class TestDomain private constructor() {
             TestDomain.IonPair(
                 first = first.asAnyElement(),
                 second = second.asAnyElement(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.IntSymbolPair].
-        */
+         * Creates an instance of [TestDomain.IntSymbolPair].
+         */
         fun intSymbolPair(
                     first: Long,
                     second: String,
@@ -151,15 +158,16 @@ class TestDomain private constructor() {
             TestDomain.IntSymbolPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.IntSymbolPair].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.IntSymbolPair].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun intSymbolPair_(
                     first: org.partiql.pig.runtime.LongPrimitive,
                     second: org.partiql.pig.runtime.SymbolPrimitive,
@@ -168,12 +176,13 @@ class TestDomain private constructor() {
             TestDomain.IntSymbolPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.SymbolIntPair].
-        */
+         * Creates an instance of [TestDomain.SymbolIntPair].
+         */
         fun symbolIntPair(
                     first: String,
                     second: Long,
@@ -182,15 +191,16 @@ class TestDomain private constructor() {
             TestDomain.SymbolIntPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.SymbolIntPair].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.SymbolIntPair].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun symbolIntPair_(
                     first: org.partiql.pig.runtime.SymbolPrimitive,
                     second: org.partiql.pig.runtime.LongPrimitive,
@@ -199,12 +209,13 @@ class TestDomain private constructor() {
             TestDomain.SymbolIntPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.IonIntPair].
-        */
+         * Creates an instance of [TestDomain.IonIntPair].
+         */
         fun ionIntPair(
                     first: com.amazon.ionelement.api.IonElement,
                     second: Long,
@@ -213,15 +224,16 @@ class TestDomain private constructor() {
             TestDomain.IonIntPair(
                 first = first.asAnyElement(),
                 second = second.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.IonIntPair].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.IonIntPair].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun ionIntPair_(
                     first: com.amazon.ionelement.api.IonElement,
                     second: org.partiql.pig.runtime.LongPrimitive,
@@ -230,12 +242,13 @@ class TestDomain private constructor() {
             TestDomain.IonIntPair(
                 first = first.asAnyElement(),
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.IonSymbolPair].
-        */
+         * Creates an instance of [TestDomain.IonSymbolPair].
+         */
         fun ionSymbolPair(
                     first: com.amazon.ionelement.api.IonElement,
                     second: com.amazon.ionelement.api.IonElement,
@@ -244,12 +257,13 @@ class TestDomain private constructor() {
             TestDomain.IonSymbolPair(
                 first = first.asAnyElement(),
                 second = second.asAnyElement(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.IntPairPair].
-        */
+         * Creates an instance of [TestDomain.IntPairPair].
+         */
         fun intPairPair(
                     first: IntPair,
                     second: IntPair,
@@ -258,12 +272,13 @@ class TestDomain private constructor() {
             TestDomain.IntPairPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.SymbolPairPair].
-        */
+         * Creates an instance of [TestDomain.SymbolPairPair].
+         */
         fun symbolPairPair(
                     first: SymbolPair,
                     second: SymbolPair,
@@ -272,12 +287,13 @@ class TestDomain private constructor() {
             TestDomain.SymbolPairPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.IonPairPair].
-        */
+         * Creates an instance of [TestDomain.IonPairPair].
+         */
         fun ionPairPair(
                     first: IonPair,
                     second: IonPair,
@@ -286,12 +302,13 @@ class TestDomain private constructor() {
             TestDomain.IonPairPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.RecursivePair].
-        */
+         * Creates an instance of [TestDomain.RecursivePair].
+         */
         fun recursivePair(
                     first: Long,
                     second: RecursivePair? = null,
@@ -300,15 +317,16 @@ class TestDomain private constructor() {
             TestDomain.RecursivePair(
                 first = first.asPrimitive(),
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.RecursivePair].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.RecursivePair].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun recursivePair_(
                     first: org.partiql.pig.runtime.LongPrimitive,
                     second: RecursivePair? = null,
@@ -317,12 +335,13 @@ class TestDomain private constructor() {
             TestDomain.RecursivePair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.AnswerPair].
-        */
+         * Creates an instance of [TestDomain.AnswerPair].
+         */
         fun answerPair(
                     first: Answer,
                     second: Answer,
@@ -331,12 +350,13 @@ class TestDomain private constructor() {
             TestDomain.AnswerPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.AnswerIntPair].
-        */
+         * Creates an instance of [TestDomain.AnswerIntPair].
+         */
         fun answerIntPair(
                     first: Answer,
                     second: Long,
@@ -345,15 +365,16 @@ class TestDomain private constructor() {
             TestDomain.AnswerIntPair(
                 first = first,
                 second = second.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.AnswerIntPair].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.AnswerIntPair].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun answerIntPair_(
                     first: Answer,
                     second: org.partiql.pig.runtime.LongPrimitive,
@@ -362,12 +383,13 @@ class TestDomain private constructor() {
             TestDomain.AnswerIntPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.IntAnswerPair].
-        */
+         * Creates an instance of [TestDomain.IntAnswerPair].
+         */
         fun intAnswerPair(
                     first: Long,
                     second: Answer,
@@ -376,15 +398,16 @@ class TestDomain private constructor() {
             TestDomain.IntAnswerPair(
                 first = first.asPrimitive(),
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.IntAnswerPair].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.IntAnswerPair].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun intAnswerPair_(
                     first: org.partiql.pig.runtime.LongPrimitive,
                     second: Answer,
@@ -393,12 +416,13 @@ class TestDomain private constructor() {
             TestDomain.IntAnswerPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.SymbolAnswerPair].
-        */
+         * Creates an instance of [TestDomain.SymbolAnswerPair].
+         */
         fun symbolAnswerPair(
                     first: String,
                     second: Answer,
@@ -407,15 +431,16 @@ class TestDomain private constructor() {
             TestDomain.SymbolAnswerPair(
                 first = first.asPrimitive(),
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.SymbolAnswerPair].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.SymbolAnswerPair].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun symbolAnswerPair_(
                     first: org.partiql.pig.runtime.SymbolPrimitive,
                     second: Answer,
@@ -424,12 +449,13 @@ class TestDomain private constructor() {
             TestDomain.SymbolAnswerPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.AnswerSymbolPair].
-        */
+         * Creates an instance of [TestDomain.AnswerSymbolPair].
+         */
         fun answerSymbolPair(
                     first: Answer,
                     second: String,
@@ -438,15 +464,16 @@ class TestDomain private constructor() {
             TestDomain.AnswerSymbolPair(
                 first = first,
                 second = second.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.AnswerSymbolPair].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.AnswerSymbolPair].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun answerSymbolPair_(
                     first: Answer,
                     second: org.partiql.pig.runtime.SymbolPrimitive,
@@ -455,91 +482,98 @@ class TestDomain private constructor() {
             TestDomain.AnswerSymbolPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.VariadicMin0].
-        */
+         * Creates an instance of [TestDomain.VariadicMin0].
+         */
         fun variadicMin0(
                     ints: kotlin.collections.List<Long> = emptyList(),
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.VariadicMin0].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.VariadicMin0].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun variadicMin0_(
                     ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.VariadicMin0].
-        */
+         * Creates an instance of [TestDomain.VariadicMin0].
+         */
         fun variadicMin0(
                     vararg ints: Long,
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.VariadicMin0].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.VariadicMin0].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun variadicMin0_(
                     vararg ints: org.partiql.pig.runtime.LongPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.VariadicMin1].
-        */
+         * Creates an instance of [TestDomain.VariadicMin1].
+         */
         fun variadicMin1(
                     ints: kotlin.collections.List<Long>,
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = ints.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.VariadicMin1].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.VariadicMin1].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun variadicMin1_(
                     ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = ints,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.VariadicMin1].
-        */
+         * Creates an instance of [TestDomain.VariadicMin1].
+         */
         fun variadicMin1(
                     ints0: Long,
                     vararg ints: Long,
@@ -547,15 +581,16 @@ class TestDomain private constructor() {
         ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = listOfPrimitives(ints0) + ints.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.VariadicMin1].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.VariadicMin1].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun variadicMin1_(
                     ints0: org.partiql.pig.runtime.LongPrimitive,
                     vararg ints: org.partiql.pig.runtime.LongPrimitive,
@@ -563,12 +598,13 @@ class TestDomain private constructor() {
         ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = listOfPrimitives(ints0) + ints.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.ElementVariadic].
-        */
+         * Creates an instance of [TestDomain.ElementVariadic].
+         */
         fun elementVariadic(
                     name: String,
                     ints: kotlin.collections.List<Long> = emptyList(),
@@ -577,15 +613,16 @@ class TestDomain private constructor() {
             TestDomain.ElementVariadic(
                 name = name.asPrimitive(),
                 ints = ints.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.ElementVariadic].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.ElementVariadic].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun elementVariadic_(
                     name: org.partiql.pig.runtime.SymbolPrimitive,
                     ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
@@ -594,11 +631,12 @@ class TestDomain private constructor() {
             TestDomain.ElementVariadic(
                 name = name,
                 ints = ints,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.ElementVariadic].
-        */
+         * Creates an instance of [TestDomain.ElementVariadic].
+         */
         fun elementVariadic(
                     name: String,
                     vararg ints: Long,
@@ -607,15 +645,16 @@ class TestDomain private constructor() {
             TestDomain.ElementVariadic(
                 name = name?.asPrimitive(),
                 ints = ints.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.ElementVariadic].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.ElementVariadic].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun elementVariadic_(
                     name: org.partiql.pig.runtime.SymbolPrimitive,
                     vararg ints: org.partiql.pig.runtime.LongPrimitive,
@@ -624,39 +663,42 @@ class TestDomain private constructor() {
             TestDomain.ElementVariadic(
                 name = name,
                 ints = ints.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.Optional1].
-        */
+         * Creates an instance of [TestDomain.Optional1].
+         */
         fun optional1(
                     value: Long? = null,
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Optional1 =
             TestDomain.Optional1(
                 value = value?.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.Optional1].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.Optional1].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun optional1_(
                     value: org.partiql.pig.runtime.LongPrimitive? = null,
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Optional1 =
             TestDomain.Optional1(
                 value = value,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.Optional2].
-        */
+         * Creates an instance of [TestDomain.Optional2].
+         */
         fun optional2(
                     first: Long? = null,
                     second: Long? = null,
@@ -665,15 +707,16 @@ class TestDomain private constructor() {
             TestDomain.Optional2(
                 first = first?.asPrimitive(),
                 second = second?.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.Optional2].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.Optional2].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun optional2_(
                     first: org.partiql.pig.runtime.LongPrimitive? = null,
                     second: org.partiql.pig.runtime.LongPrimitive? = null,
@@ -682,12 +725,13 @@ class TestDomain private constructor() {
             TestDomain.Optional2(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.DomainLevelRecord].
-        */
+         * Creates an instance of [TestDomain.DomainLevelRecord].
+         */
         fun domainLevelRecord(
                     someField: Long,
                     anotherField: String,
@@ -698,15 +742,16 @@ class TestDomain private constructor() {
                 someField = someField.asPrimitive(),
                 anotherField = anotherField.asPrimitive(),
                 optionalField = optionalField?.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.DomainLevelRecord].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.DomainLevelRecord].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun domainLevelRecord_(
                     someField: org.partiql.pig.runtime.LongPrimitive,
                     anotherField: org.partiql.pig.runtime.SymbolPrimitive,
@@ -717,12 +762,13 @@ class TestDomain private constructor() {
                 someField = someField,
                 anotherField = anotherField,
                 optionalField = optionalField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.ProductWithRecord].
-        */
+         * Creates an instance of [TestDomain.ProductWithRecord].
+         */
         fun productWithRecord(
                     value: Long,
                     dlr: DomainLevelRecord,
@@ -731,15 +777,16 @@ class TestDomain private constructor() {
             TestDomain.ProductWithRecord(
                 value = value.asPrimitive(),
                 dlr = dlr,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.ProductWithRecord].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.ProductWithRecord].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun productWithRecord_(
                     value: org.partiql.pig.runtime.LongPrimitive,
                     dlr: DomainLevelRecord,
@@ -748,12 +795,13 @@ class TestDomain private constructor() {
             TestDomain.ProductWithRecord(
                 value = value,
                 dlr = dlr,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.TestSumTriplet].
-        */
+         * Creates an instance of [TestDomain.TestSumTriplet].
+         */
         fun testSumTriplet(
                     a: TestSum,
                     b: TestSum,
@@ -764,12 +812,13 @@ class TestDomain private constructor() {
                 a = a,
                 b = b,
                 c = c,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.EntityPair].
-        */
+         * Creates an instance of [TestDomain.EntityPair].
+         */
         fun entityPair(
                     first: Entity,
                     second: Entity,
@@ -778,34 +827,37 @@ class TestDomain private constructor() {
             TestDomain.EntityPair(
                 first = first,
                 second = second,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: Answer 
         /**
-        * Creates an instance of [TestDomain.Answer.No].
-        */
+         * Creates an instance of [TestDomain.Answer.No].
+         */
         fun no(
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Answer.No =
             TestDomain.Answer.No(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.Answer.Yes].
-        */
+         * Creates an instance of [TestDomain.Answer.Yes].
+         */
         fun yes(
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Answer.Yes =
             TestDomain.Answer.Yes(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: SumWithRecord 
         /**
-        * Creates an instance of [TestDomain.SumWithRecord.VariantWithRecord].
-        */
+         * Creates an instance of [TestDomain.SumWithRecord.VariantWithRecord].
+         */
         fun variantWithRecord(
                     value: Long,
                     dlr: DomainLevelRecord,
@@ -814,15 +866,16 @@ class TestDomain private constructor() {
             TestDomain.SumWithRecord.VariantWithRecord(
                 value = value.asPrimitive(),
                 dlr = dlr,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.SumWithRecord.VariantWithRecord].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.SumWithRecord.VariantWithRecord].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun variantWithRecord_(
                     value: org.partiql.pig.runtime.LongPrimitive,
                     dlr: DomainLevelRecord,
@@ -831,40 +884,43 @@ class TestDomain private constructor() {
             TestDomain.SumWithRecord.VariantWithRecord(
                 value = value,
                 dlr = dlr,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: TestSum 
         /**
-        * Creates an instance of [TestDomain.TestSum.One].
-        */
+         * Creates an instance of [TestDomain.TestSum.One].
+         */
         fun one(
                     a: Long,
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.One =
             TestDomain.TestSum.One(
                 a = a.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.TestSum.One].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.TestSum.One].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun one_(
                     a: org.partiql.pig.runtime.LongPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.One =
             TestDomain.TestSum.One(
                 a = a,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.TestSum.Two].
-        */
+         * Creates an instance of [TestDomain.TestSum.Two].
+         */
         fun two(
                     a: Long,
                     b: Long,
@@ -873,15 +929,16 @@ class TestDomain private constructor() {
             TestDomain.TestSum.Two(
                 a = a.asPrimitive(),
                 b = b.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.TestSum.Two].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.TestSum.Two].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun two_(
                     a: org.partiql.pig.runtime.LongPrimitive,
                     b: org.partiql.pig.runtime.LongPrimitive,
@@ -890,12 +947,13 @@ class TestDomain private constructor() {
             TestDomain.TestSum.Two(
                 a = a,
                 b = b,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.TestSum.Three].
-        */
+         * Creates an instance of [TestDomain.TestSum.Three].
+         */
         fun three(
                     a: Long,
                     b: Long,
@@ -906,15 +964,16 @@ class TestDomain private constructor() {
                 a = a.asPrimitive(),
                 b = b.asPrimitive(),
                 c = c.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.TestSum.Three].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.TestSum.Three].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun three_(
                     a: org.partiql.pig.runtime.LongPrimitive,
                     b: org.partiql.pig.runtime.LongPrimitive,
@@ -925,50 +984,54 @@ class TestDomain private constructor() {
                 a = a,
                 b = b,
                 c = c,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: Entity 
         /**
-        * Creates an instance of [TestDomain.Entity.Slug].
-        */
+         * Creates an instance of [TestDomain.Entity.Slug].
+         */
         fun slug(
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Slug =
             TestDomain.Entity.Slug(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.Entity.Android].
-        */
+         * Creates an instance of [TestDomain.Entity.Android].
+         */
         fun android(
                     id: Long,
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Android =
             TestDomain.Entity.Android(
                 id = id.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.Entity.Android].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.Entity.Android].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun android_(
                     id: org.partiql.pig.runtime.LongPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Android =
             TestDomain.Entity.Android(
                 id = id,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [TestDomain.Entity.Human].
-        */
+         * Creates an instance of [TestDomain.Entity.Human].
+         */
         fun human(
                     firstName: String,
                     middleNames: kotlin.collections.List<String> = emptyList(),
@@ -983,15 +1046,16 @@ class TestDomain private constructor() {
                 lastName = lastName.asPrimitive(),
                 title = title?.asPrimitive(),
                 parent = parent,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [TestDomain.Entity.Human].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [TestDomain.Entity.Human].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun human_(
                     firstName: org.partiql.pig.runtime.SymbolPrimitive,
                     middleNames: kotlin.collections.List<org.partiql.pig.runtime.SymbolPrimitive> = emptyList(),
@@ -1006,7 +1070,8 @@ class TestDomain private constructor() {
                 lastName = lastName,
                 title = title,
                 parent = parent,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */
@@ -5093,47 +5158,50 @@ class MultiWordDomain private constructor() {
     interface Builder {
         fun newMetaContainer() = emptyMetaContainer()
     
-                    // Tuples
+        // Tuples 
         /**
-        * Creates an instance of [MultiWordDomain.AaaAaa].
-        */
+         * Creates an instance of [MultiWordDomain.AaaAaa].
+         */
         fun aaaAaa(
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAaa =
             MultiWordDomain.AaaAaa(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [MultiWordDomain.AaaAab].
-        */
+         * Creates an instance of [MultiWordDomain.AaaAab].
+         */
         fun aaaAab(
                     dField: Long? = null,
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAab =
             MultiWordDomain.AaaAab(
                 dField = dField?.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AaaAab].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AaaAab].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aaaAab_(
                     dField: org.partiql.pig.runtime.LongPrimitive? = null,
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAab =
             MultiWordDomain.AaaAab(
                 dField = dField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [MultiWordDomain.AaaAac].
-        */
+         * Creates an instance of [MultiWordDomain.AaaAac].
+         */
         fun aaaAac(
                     dField: Long? = null,
                     eField: String? = null,
@@ -5142,15 +5210,16 @@ class MultiWordDomain private constructor() {
             MultiWordDomain.AaaAac(
                 dField = dField?.asPrimitive(),
                 eField = eField?.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AaaAac].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AaaAac].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aaaAac_(
                     dField: org.partiql.pig.runtime.LongPrimitive? = null,
                     eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
@@ -5159,91 +5228,98 @@ class MultiWordDomain private constructor() {
             MultiWordDomain.AaaAac(
                 dField = dField,
                 eField = eField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [MultiWordDomain.AaaAad].
-        */
+         * Creates an instance of [MultiWordDomain.AaaAad].
+         */
         fun aaaAad(
                     dField: kotlin.collections.List<Long> = emptyList(),
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AaaAad].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AaaAad].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aaaAad_(
                     dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AaaAad].
-        */
+         * Creates an instance of [MultiWordDomain.AaaAad].
+         */
         fun aaaAad(
                     vararg dField: Long,
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AaaAad].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AaaAad].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aaaAad_(
                     vararg dField: org.partiql.pig.runtime.LongPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [MultiWordDomain.AaaAae].
-        */
+         * Creates an instance of [MultiWordDomain.AaaAae].
+         */
         fun aaaAae(
                     dField: kotlin.collections.List<Long>,
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = dField.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AaaAae].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AaaAae].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aaaAae_(
                     dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = dField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AaaAae].
-        */
+         * Creates an instance of [MultiWordDomain.AaaAae].
+         */
         fun aaaAae(
                     dField0: Long,
                     dField1: Long,
@@ -5252,15 +5328,16 @@ class MultiWordDomain private constructor() {
         ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AaaAae].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AaaAae].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aaaAae_(
                     dField0: org.partiql.pig.runtime.LongPrimitive,
                     dField1: org.partiql.pig.runtime.LongPrimitive,
@@ -5269,12 +5346,13 @@ class MultiWordDomain private constructor() {
         ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = listOfPrimitives(dField0, dField1) + dField.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAaa].
-        */
+         * Creates an instance of [MultiWordDomain.AabAaa].
+         */
         fun aabAaa(
                     bField: Long,
                     cField: String,
@@ -5283,15 +5361,16 @@ class MultiWordDomain private constructor() {
             MultiWordDomain.AabAaa(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAaa].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AabAaa].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aabAaa_(
                     bField: org.partiql.pig.runtime.LongPrimitive,
                     cField: org.partiql.pig.runtime.SymbolPrimitive,
@@ -5300,12 +5379,13 @@ class MultiWordDomain private constructor() {
             MultiWordDomain.AabAaa(
                 bField = bField,
                 cField = cField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAab].
-        */
+         * Creates an instance of [MultiWordDomain.AabAab].
+         */
         fun aabAab(
                     bField: Long,
                     cField: String,
@@ -5316,15 +5396,16 @@ class MultiWordDomain private constructor() {
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
                 dField = dField?.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAab].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AabAab].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aabAab_(
                     bField: org.partiql.pig.runtime.LongPrimitive,
                     cField: org.partiql.pig.runtime.SymbolPrimitive,
@@ -5335,12 +5416,13 @@ class MultiWordDomain private constructor() {
                 bField = bField,
                 cField = cField,
                 dField = dField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAac].
-        */
+         * Creates an instance of [MultiWordDomain.AabAac].
+         */
         fun aabAac(
                     bField: Long,
                     cField: String,
@@ -5353,15 +5435,16 @@ class MultiWordDomain private constructor() {
                 cField = cField.asPrimitive(),
                 dField = dField?.asPrimitive(),
                 eField = eField?.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAac].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AabAac].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aabAac_(
                     bField: org.partiql.pig.runtime.LongPrimitive,
                     cField: org.partiql.pig.runtime.SymbolPrimitive,
@@ -5374,12 +5457,13 @@ class MultiWordDomain private constructor() {
                 cField = cField,
                 dField = dField,
                 eField = eField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAad].
-        */
+         * Creates an instance of [MultiWordDomain.AabAad].
+         */
         fun aabAad(
                     bField: Long,
                     cField: String,
@@ -5390,15 +5474,16 @@ class MultiWordDomain private constructor() {
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
                 dField = dField.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAad].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AabAad].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aabAad_(
                     bField: org.partiql.pig.runtime.LongPrimitive,
                     cField: org.partiql.pig.runtime.SymbolPrimitive,
@@ -5409,11 +5494,12 @@ class MultiWordDomain private constructor() {
                 bField = bField,
                 cField = cField,
                 dField = dField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAad].
-        */
+         * Creates an instance of [MultiWordDomain.AabAad].
+         */
         fun aabAad(
                     bField: Long,
                     cField: String,
@@ -5424,15 +5510,16 @@ class MultiWordDomain private constructor() {
                 bField = bField?.asPrimitive(),
                 cField = cField?.asPrimitive(),
                 dField = dField.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAad].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AabAad].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aabAad_(
                     bField: org.partiql.pig.runtime.LongPrimitive,
                     cField: org.partiql.pig.runtime.SymbolPrimitive,
@@ -5443,12 +5530,13 @@ class MultiWordDomain private constructor() {
                 bField = bField,
                 cField = cField,
                 dField = dField.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAae].
-        */
+         * Creates an instance of [MultiWordDomain.AabAae].
+         */
         fun aabAae(
                     bField: Long,
                     cField: String,
@@ -5459,15 +5547,16 @@ class MultiWordDomain private constructor() {
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
                 dField = dField.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAae].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AabAae].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aabAae_(
                     bField: org.partiql.pig.runtime.LongPrimitive,
                     cField: org.partiql.pig.runtime.SymbolPrimitive,
@@ -5478,11 +5567,12 @@ class MultiWordDomain private constructor() {
                 bField = bField,
                 cField = cField,
                 dField = dField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAae].
-        */
+         * Creates an instance of [MultiWordDomain.AabAae].
+         */
         fun aabAae(
                     bField: Long,
                     cField: String,
@@ -5495,15 +5585,16 @@ class MultiWordDomain private constructor() {
                 bField = bField?.asPrimitive(),
                 cField = cField?.asPrimitive(),
                 dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.AabAae].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.AabAae].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun aabAae_(
                     bField: org.partiql.pig.runtime.LongPrimitive,
                     cField: org.partiql.pig.runtime.SymbolPrimitive,
@@ -5516,12 +5607,13 @@ class MultiWordDomain private constructor() {
                 bField = bField,
                 cField = cField,
                 dField = listOfPrimitives(dField0, dField1) + dField.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [MultiWordDomain.Rrr].
-        */
+         * Creates an instance of [MultiWordDomain.Rrr].
+         */
         fun rrr(
                     aField: Long,
                     bbbField: Long,
@@ -5530,15 +5622,16 @@ class MultiWordDomain private constructor() {
             MultiWordDomain.Rrr(
                 aField = aField.asPrimitive(),
                 bbbField = bbbField.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.Rrr].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.Rrr].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun rrr_(
                     aField: org.partiql.pig.runtime.LongPrimitive,
                     bbbField: org.partiql.pig.runtime.LongPrimitive,
@@ -5547,62 +5640,67 @@ class MultiWordDomain private constructor() {
             MultiWordDomain.Rrr(
                 aField = aField,
                 bbbField = bbbField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: SssTtt 
         /**
-        * Creates an instance of [MultiWordDomain.SssTtt.Lll].
-        */
+         * Creates an instance of [MultiWordDomain.SssTtt.Lll].
+         */
         fun lll(
                     uField: Long,
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Lll =
             MultiWordDomain.SssTtt.Lll(
                 uField = uField.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.SssTtt.Lll].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.SssTtt.Lll].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun lll_(
                     uField: org.partiql.pig.runtime.LongPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Lll =
             MultiWordDomain.SssTtt.Lll(
                 uField = uField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [MultiWordDomain.SssTtt.Mmm].
-        */
+         * Creates an instance of [MultiWordDomain.SssTtt.Mmm].
+         */
         fun mmm(
                     vField: String,
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Mmm =
             MultiWordDomain.SssTtt.Mmm(
                 vField = vField.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [MultiWordDomain.SssTtt.Mmm].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [MultiWordDomain.SssTtt.Mmm].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun mmm_(
                     vField: org.partiql.pig.runtime.SymbolPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Mmm =
             MultiWordDomain.SssTtt.Mmm(
                 vField = vField,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */
@@ -7156,118 +7254,126 @@ class DomainA private constructor() {
     interface Builder {
         fun newMetaContainer() = emptyMetaContainer()
     
-                    // Tuples
+        // Tuples 
         /**
-        * Creates an instance of [DomainA.ProductToRemove].
-        */
+         * Creates an instance of [DomainA.ProductToRemove].
+         */
         fun productToRemove(
                     whatever: String,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.ProductToRemove =
             DomainA.ProductToRemove(
                 whatever = whatever.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainA.ProductToRemove].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainA.ProductToRemove].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun productToRemove_(
                     whatever: org.partiql.pig.runtime.SymbolPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.ProductToRemove =
             DomainA.ProductToRemove(
                 whatever = whatever,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainA.RecordToRemove].
-        */
+         * Creates an instance of [DomainA.RecordToRemove].
+         */
         fun recordToRemove(
                     irrelevant: Long,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.RecordToRemove =
             DomainA.RecordToRemove(
                 irrelevant = irrelevant.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainA.RecordToRemove].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainA.RecordToRemove].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun recordToRemove_(
                     irrelevant: org.partiql.pig.runtime.LongPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.RecordToRemove =
             DomainA.RecordToRemove(
                 irrelevant = irrelevant,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainA.ProductA].
-        */
+         * Creates an instance of [DomainA.ProductA].
+         */
         fun productA(
                     one: Long,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.ProductA =
             DomainA.ProductA(
                 one = one.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainA.ProductA].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainA.ProductA].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun productA_(
                     one: org.partiql.pig.runtime.LongPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.ProductA =
             DomainA.ProductA(
                 one = one,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainA.RecordA].
-        */
+         * Creates an instance of [DomainA.RecordA].
+         */
         fun recordA(
                     one: Long,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.RecordA =
             DomainA.RecordA(
                 one = one.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainA.RecordA].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainA.RecordA].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun recordA_(
                     one: org.partiql.pig.runtime.LongPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.RecordA =
             DomainA.RecordA(
                 one = one,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainA.UnpermutedProduct].
-        */
+         * Creates an instance of [DomainA.UnpermutedProduct].
+         */
         fun unpermutedProduct(
                     foo: String,
                     bar: Long,
@@ -7276,15 +7382,16 @@ class DomainA private constructor() {
             DomainA.UnpermutedProduct(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainA.UnpermutedProduct].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainA.UnpermutedProduct].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun unpermutedProduct_(
                     foo: org.partiql.pig.runtime.SymbolPrimitive,
                     bar: org.partiql.pig.runtime.LongPrimitive,
@@ -7293,12 +7400,13 @@ class DomainA private constructor() {
             DomainA.UnpermutedProduct(
                 foo = foo,
                 bar = bar,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainA.UnpermutedRecord].
-        */
+         * Creates an instance of [DomainA.UnpermutedRecord].
+         */
         fun unpermutedRecord(
                     foo: String,
                     bar: Long,
@@ -7307,15 +7415,16 @@ class DomainA private constructor() {
             DomainA.UnpermutedRecord(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainA.UnpermutedRecord].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainA.UnpermutedRecord].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun unpermutedRecord_(
                     foo: org.partiql.pig.runtime.SymbolPrimitive,
                     bar: org.partiql.pig.runtime.LongPrimitive,
@@ -7324,103 +7433,112 @@ class DomainA private constructor() {
             DomainA.UnpermutedRecord(
                 foo = foo,
                 bar = bar,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: SumToRemove 
         /**
-        * Creates an instance of [DomainA.SumToRemove.Doesnt].
-        */
+         * Creates an instance of [DomainA.SumToRemove.Doesnt].
+         */
         fun doesnt(
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumToRemove.Doesnt =
             DomainA.SumToRemove.Doesnt(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainA.SumToRemove.Matter].
-        */
+         * Creates an instance of [DomainA.SumToRemove.Matter].
+         */
         fun matter(
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumToRemove.Matter =
             DomainA.SumToRemove.Matter(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: SumA 
         /**
-        * Creates an instance of [DomainA.SumA.Who].
-        */
+         * Creates an instance of [DomainA.SumA.Who].
+         */
         fun who(
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumA.Who =
             DomainA.SumA.Who(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainA.SumA.Cares].
-        */
+         * Creates an instance of [DomainA.SumA.Cares].
+         */
         fun cares(
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumA.Cares =
             DomainA.SumA.Cares(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: SumB 
         /**
-        * Creates an instance of [DomainA.SumB.WillBeUnchanged].
-        */
+         * Creates an instance of [DomainA.SumB.WillBeUnchanged].
+         */
         fun willBeUnchanged(
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumB.WillBeUnchanged =
             DomainA.SumB.WillBeUnchanged(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainA.SumB.WillBeRemoved].
-        */
+         * Creates an instance of [DomainA.SumB.WillBeRemoved].
+         */
         fun willBeRemoved(
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumB.WillBeRemoved =
             DomainA.SumB.WillBeRemoved(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainA.SumB.WillBeReplaced].
-        */
+         * Creates an instance of [DomainA.SumB.WillBeReplaced].
+         */
         fun willBeReplaced(
                     something: Long,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumB.WillBeReplaced =
             DomainA.SumB.WillBeReplaced(
                 something = something.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainA.SumB.WillBeReplaced].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainA.SumB.WillBeReplaced].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun willBeReplaced_(
                     something: org.partiql.pig.runtime.LongPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumB.WillBeReplaced =
             DomainA.SumB.WillBeReplaced(
                 something = something,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: UnpermutedSum 
         /**
-        * Creates an instance of [DomainA.UnpermutedSum.UnpermutedProductVariant].
-        */
+         * Creates an instance of [DomainA.UnpermutedSum.UnpermutedProductVariant].
+         */
         fun unpermutedProductVariant(
                     foo: String,
                     bar: Long,
@@ -7429,15 +7547,16 @@ class DomainA private constructor() {
             DomainA.UnpermutedSum.UnpermutedProductVariant(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainA.UnpermutedSum.UnpermutedProductVariant].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainA.UnpermutedSum.UnpermutedProductVariant].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun unpermutedProductVariant_(
                     foo: org.partiql.pig.runtime.SymbolPrimitive,
                     bar: org.partiql.pig.runtime.LongPrimitive,
@@ -7446,12 +7565,13 @@ class DomainA private constructor() {
             DomainA.UnpermutedSum.UnpermutedProductVariant(
                 foo = foo,
                 bar = bar,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainA.UnpermutedSum.UnpermutedRecordVariant].
-        */
+         * Creates an instance of [DomainA.UnpermutedSum.UnpermutedRecordVariant].
+         */
         fun unpermutedRecordVariant(
                     foo: String,
                     bar: Long,
@@ -7460,15 +7580,16 @@ class DomainA private constructor() {
             DomainA.UnpermutedSum.UnpermutedRecordVariant(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainA.UnpermutedSum.UnpermutedRecordVariant].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainA.UnpermutedSum.UnpermutedRecordVariant].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun unpermutedRecordVariant_(
                     foo: org.partiql.pig.runtime.SymbolPrimitive,
                     bar: org.partiql.pig.runtime.LongPrimitive,
@@ -7477,7 +7598,8 @@ class DomainA private constructor() {
             DomainA.UnpermutedSum.UnpermutedRecordVariant(
                 foo = foo,
                 bar = bar,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */
@@ -9140,10 +9262,10 @@ class DomainB private constructor() {
     interface Builder {
         fun newMetaContainer() = emptyMetaContainer()
     
-                    // Tuples
+        // Tuples 
         /**
-        * Creates an instance of [DomainB.UnpermutedProduct].
-        */
+         * Creates an instance of [DomainB.UnpermutedProduct].
+         */
         fun unpermutedProduct(
                     foo: String,
                     bar: Long,
@@ -9152,15 +9274,16 @@ class DomainB private constructor() {
             DomainB.UnpermutedProduct(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainB.UnpermutedProduct].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainB.UnpermutedProduct].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun unpermutedProduct_(
                     foo: org.partiql.pig.runtime.SymbolPrimitive,
                     bar: org.partiql.pig.runtime.LongPrimitive,
@@ -9169,12 +9292,13 @@ class DomainB private constructor() {
             DomainB.UnpermutedProduct(
                 foo = foo,
                 bar = bar,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainB.UnpermutedRecord].
-        */
+         * Creates an instance of [DomainB.UnpermutedRecord].
+         */
         fun unpermutedRecord(
                     foo: String,
                     bar: Long,
@@ -9183,15 +9307,16 @@ class DomainB private constructor() {
             DomainB.UnpermutedRecord(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainB.UnpermutedRecord].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainB.UnpermutedRecord].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun unpermutedRecord_(
                     foo: org.partiql.pig.runtime.SymbolPrimitive,
                     bar: org.partiql.pig.runtime.LongPrimitive,
@@ -9200,121 +9325,130 @@ class DomainB private constructor() {
             DomainB.UnpermutedRecord(
                 foo = foo,
                 bar = bar,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainB.ProductA].
-        */
+         * Creates an instance of [DomainB.ProductA].
+         */
         fun productA(
                     one: String,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.ProductA =
             DomainB.ProductA(
                 one = one.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainB.ProductA].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainB.ProductA].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun productA_(
                     one: org.partiql.pig.runtime.SymbolPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.ProductA =
             DomainB.ProductA(
                 one = one,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainB.RecordA].
-        */
+         * Creates an instance of [DomainB.RecordA].
+         */
         fun recordA(
                     one: String,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.RecordA =
             DomainB.RecordA(
                 one = one.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainB.RecordA].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainB.RecordA].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun recordA_(
                     one: org.partiql.pig.runtime.SymbolPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.RecordA =
             DomainB.RecordA(
                 one = one,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainB.NewProduct].
-        */
+         * Creates an instance of [DomainB.NewProduct].
+         */
         fun newProduct(
                     foo: Long,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewProduct =
             DomainB.NewProduct(
                 foo = foo.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainB.NewProduct].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainB.NewProduct].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun newProduct_(
                     foo: org.partiql.pig.runtime.LongPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewProduct =
             DomainB.NewProduct(
                 foo = foo,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainB.NewRecord].
-        */
+         * Creates an instance of [DomainB.NewRecord].
+         */
         fun newRecord(
                     foo: Long,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewRecord =
             DomainB.NewRecord(
                 foo = foo.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainB.NewRecord].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainB.NewRecord].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun newRecord_(
                     foo: org.partiql.pig.runtime.LongPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewRecord =
             DomainB.NewRecord(
                 foo = foo,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: UnpermutedSum 
         /**
-        * Creates an instance of [DomainB.UnpermutedSum.UnpermutedProductVariant].
-        */
+         * Creates an instance of [DomainB.UnpermutedSum.UnpermutedProductVariant].
+         */
         fun unpermutedProductVariant(
                     foo: String,
                     bar: Long,
@@ -9323,15 +9457,16 @@ class DomainB private constructor() {
             DomainB.UnpermutedSum.UnpermutedProductVariant(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainB.UnpermutedSum.UnpermutedProductVariant].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainB.UnpermutedSum.UnpermutedProductVariant].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun unpermutedProductVariant_(
                     foo: org.partiql.pig.runtime.SymbolPrimitive,
                     bar: org.partiql.pig.runtime.LongPrimitive,
@@ -9340,12 +9475,13 @@ class DomainB private constructor() {
             DomainB.UnpermutedSum.UnpermutedProductVariant(
                 foo = foo,
                 bar = bar,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainB.UnpermutedSum.UnpermutedRecordVariant].
-        */
+         * Creates an instance of [DomainB.UnpermutedSum.UnpermutedRecordVariant].
+         */
         fun unpermutedRecordVariant(
                     foo: String,
                     bar: Long,
@@ -9354,15 +9490,16 @@ class DomainB private constructor() {
             DomainB.UnpermutedSum.UnpermutedRecordVariant(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainB.UnpermutedSum.UnpermutedRecordVariant].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainB.UnpermutedSum.UnpermutedRecordVariant].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun unpermutedRecordVariant_(
                     foo: org.partiql.pig.runtime.SymbolPrimitive,
                     bar: org.partiql.pig.runtime.LongPrimitive,
@@ -9371,66 +9508,72 @@ class DomainB private constructor() {
             DomainB.UnpermutedSum.UnpermutedRecordVariant(
                 foo = foo,
                 bar = bar,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: SumB 
         /**
-        * Creates an instance of [DomainB.SumB.WillBeUnchanged].
-        */
+         * Creates an instance of [DomainB.SumB.WillBeUnchanged].
+         */
         fun willBeUnchanged(
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.SumB.WillBeUnchanged =
             DomainB.SumB.WillBeUnchanged(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainB.SumB.WillBeReplaced].
-        */
+         * Creates an instance of [DomainB.SumB.WillBeReplaced].
+         */
         fun willBeReplaced(
                     something: String,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.SumB.WillBeReplaced =
             DomainB.SumB.WillBeReplaced(
                 something = something.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [DomainB.SumB.WillBeReplaced].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [DomainB.SumB.WillBeReplaced].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun willBeReplaced_(
                     something: org.partiql.pig.runtime.SymbolPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.SumB.WillBeReplaced =
             DomainB.SumB.WillBeReplaced(
                 something = something,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: NewSum 
         /**
-        * Creates an instance of [DomainB.NewSum.Eek].
-        */
+         * Creates an instance of [DomainB.NewSum.Eek].
+         */
         fun eek(
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewSum.Eek =
             DomainB.NewSum.Eek(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [DomainB.NewSum.Whatever].
-        */
+         * Creates an instance of [DomainB.NewSum.Whatever].
+         */
         fun whatever(
                 metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewSum.Whatever =
             DomainB.NewSum.Whatever(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */

--- a/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
@@ -37,9 +37,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.BoolPair].
          */
         fun boolPair(
-                    first: Boolean,
-                    second: Boolean,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Boolean,
+            second: Boolean,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.BoolPair =
             TestDomain.BoolPair(
                 first = first.asPrimitive(),
@@ -55,9 +55,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun boolPair_(
-                    first: org.partiql.pig.runtime.BoolPrimitive,
-                    second: org.partiql.pig.runtime.BoolPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            first: org.partiql.pig.runtime.BoolPrimitive,
+            second: org.partiql.pig.runtime.BoolPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.BoolPair =
             TestDomain.BoolPair(
                 first = first,
@@ -70,9 +70,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.IntPair].
          */
         fun intPair(
-                    first: Long,
-                    second: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Long,
+            second: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntPair =
             TestDomain.IntPair(
                 first = first.asPrimitive(),
@@ -88,9 +88,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun intPair_(
-                    first: org.partiql.pig.runtime.LongPrimitive,
-                    second: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            first: org.partiql.pig.runtime.LongPrimitive,
+            second: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntPair =
             TestDomain.IntPair(
                 first = first,
@@ -103,9 +103,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.SymbolPair].
          */
         fun symbolPair(
-                    first: String,
-                    second: String,
-                metas: MetaContainer = emptyMetaContainer()
+            first: String,
+            second: String,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolPair =
             TestDomain.SymbolPair(
                 first = first.asPrimitive(),
@@ -121,9 +121,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun symbolPair_(
-                    first: org.partiql.pig.runtime.SymbolPrimitive,
-                    second: org.partiql.pig.runtime.SymbolPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            first: org.partiql.pig.runtime.SymbolPrimitive,
+            second: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolPair =
             TestDomain.SymbolPair(
                 first = first,
@@ -136,9 +136,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.IonPair].
          */
         fun ionPair(
-                    first: com.amazon.ionelement.api.IonElement,
-                    second: com.amazon.ionelement.api.IonElement,
-                metas: MetaContainer = emptyMetaContainer()
+            first: com.amazon.ionelement.api.IonElement,
+            second: com.amazon.ionelement.api.IonElement,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IonPair =
             TestDomain.IonPair(
                 first = first.asAnyElement(),
@@ -151,9 +151,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.IntSymbolPair].
          */
         fun intSymbolPair(
-                    first: Long,
-                    second: String,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Long,
+            second: String,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntSymbolPair =
             TestDomain.IntSymbolPair(
                 first = first.asPrimitive(),
@@ -169,9 +169,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun intSymbolPair_(
-                    first: org.partiql.pig.runtime.LongPrimitive,
-                    second: org.partiql.pig.runtime.SymbolPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            first: org.partiql.pig.runtime.LongPrimitive,
+            second: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntSymbolPair =
             TestDomain.IntSymbolPair(
                 first = first,
@@ -184,9 +184,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.SymbolIntPair].
          */
         fun symbolIntPair(
-                    first: String,
-                    second: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            first: String,
+            second: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolIntPair =
             TestDomain.SymbolIntPair(
                 first = first.asPrimitive(),
@@ -202,9 +202,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun symbolIntPair_(
-                    first: org.partiql.pig.runtime.SymbolPrimitive,
-                    second: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            first: org.partiql.pig.runtime.SymbolPrimitive,
+            second: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolIntPair =
             TestDomain.SymbolIntPair(
                 first = first,
@@ -217,9 +217,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.IonIntPair].
          */
         fun ionIntPair(
-                    first: com.amazon.ionelement.api.IonElement,
-                    second: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            first: com.amazon.ionelement.api.IonElement,
+            second: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IonIntPair =
             TestDomain.IonIntPair(
                 first = first.asAnyElement(),
@@ -235,9 +235,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun ionIntPair_(
-                    first: com.amazon.ionelement.api.IonElement,
-                    second: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            first: com.amazon.ionelement.api.IonElement,
+            second: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IonIntPair =
             TestDomain.IonIntPair(
                 first = first.asAnyElement(),
@@ -250,9 +250,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.IonSymbolPair].
          */
         fun ionSymbolPair(
-                    first: com.amazon.ionelement.api.IonElement,
-                    second: com.amazon.ionelement.api.IonElement,
-                metas: MetaContainer = emptyMetaContainer()
+            first: com.amazon.ionelement.api.IonElement,
+            second: com.amazon.ionelement.api.IonElement,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IonSymbolPair =
             TestDomain.IonSymbolPair(
                 first = first.asAnyElement(),
@@ -265,9 +265,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.IntPairPair].
          */
         fun intPairPair(
-                    first: IntPair,
-                    second: IntPair,
-                metas: MetaContainer = emptyMetaContainer()
+            first: IntPair,
+            second: IntPair,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntPairPair =
             TestDomain.IntPairPair(
                 first = first,
@@ -280,9 +280,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.SymbolPairPair].
          */
         fun symbolPairPair(
-                    first: SymbolPair,
-                    second: SymbolPair,
-                metas: MetaContainer = emptyMetaContainer()
+            first: SymbolPair,
+            second: SymbolPair,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolPairPair =
             TestDomain.SymbolPairPair(
                 first = first,
@@ -295,9 +295,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.IonPairPair].
          */
         fun ionPairPair(
-                    first: IonPair,
-                    second: IonPair,
-                metas: MetaContainer = emptyMetaContainer()
+            first: IonPair,
+            second: IonPair,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IonPairPair =
             TestDomain.IonPairPair(
                 first = first,
@@ -310,9 +310,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.RecursivePair].
          */
         fun recursivePair(
-                    first: Long,
-                    second: RecursivePair? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Long,
+            second: RecursivePair? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.RecursivePair =
             TestDomain.RecursivePair(
                 first = first.asPrimitive(),
@@ -328,9 +328,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun recursivePair_(
-                    first: org.partiql.pig.runtime.LongPrimitive,
-                    second: RecursivePair? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            first: org.partiql.pig.runtime.LongPrimitive,
+            second: RecursivePair? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.RecursivePair =
             TestDomain.RecursivePair(
                 first = first,
@@ -343,9 +343,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.AnswerPair].
          */
         fun answerPair(
-                    first: Answer,
-                    second: Answer,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Answer,
+            second: Answer,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.AnswerPair =
             TestDomain.AnswerPair(
                 first = first,
@@ -358,9 +358,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.AnswerIntPair].
          */
         fun answerIntPair(
-                    first: Answer,
-                    second: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Answer,
+            second: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.AnswerIntPair =
             TestDomain.AnswerIntPair(
                 first = first,
@@ -376,9 +376,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun answerIntPair_(
-                    first: Answer,
-                    second: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Answer,
+            second: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.AnswerIntPair =
             TestDomain.AnswerIntPair(
                 first = first,
@@ -391,9 +391,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.IntAnswerPair].
          */
         fun intAnswerPair(
-                    first: Long,
-                    second: Answer,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Long,
+            second: Answer,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntAnswerPair =
             TestDomain.IntAnswerPair(
                 first = first.asPrimitive(),
@@ -409,9 +409,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun intAnswerPair_(
-                    first: org.partiql.pig.runtime.LongPrimitive,
-                    second: Answer,
-                metas: MetaContainer = emptyMetaContainer()
+            first: org.partiql.pig.runtime.LongPrimitive,
+            second: Answer,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntAnswerPair =
             TestDomain.IntAnswerPair(
                 first = first,
@@ -424,9 +424,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.SymbolAnswerPair].
          */
         fun symbolAnswerPair(
-                    first: String,
-                    second: Answer,
-                metas: MetaContainer = emptyMetaContainer()
+            first: String,
+            second: Answer,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolAnswerPair =
             TestDomain.SymbolAnswerPair(
                 first = first.asPrimitive(),
@@ -442,9 +442,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun symbolAnswerPair_(
-                    first: org.partiql.pig.runtime.SymbolPrimitive,
-                    second: Answer,
-                metas: MetaContainer = emptyMetaContainer()
+            first: org.partiql.pig.runtime.SymbolPrimitive,
+            second: Answer,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolAnswerPair =
             TestDomain.SymbolAnswerPair(
                 first = first,
@@ -457,9 +457,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.AnswerSymbolPair].
          */
         fun answerSymbolPair(
-                    first: Answer,
-                    second: String,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Answer,
+            second: String,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.AnswerSymbolPair =
             TestDomain.AnswerSymbolPair(
                 first = first,
@@ -475,9 +475,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun answerSymbolPair_(
-                    first: Answer,
-                    second: org.partiql.pig.runtime.SymbolPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Answer,
+            second: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.AnswerSymbolPair =
             TestDomain.AnswerSymbolPair(
                 first = first,
@@ -490,8 +490,8 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.VariadicMin0].
          */
         fun variadicMin0(
-                    ints: kotlin.collections.List<Long> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            ints: kotlin.collections.List<Long> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints.map { it.asPrimitive() },
@@ -506,8 +506,8 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun variadicMin0_(
-                    ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints,
@@ -518,8 +518,8 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.VariadicMin0].
          */
         fun variadicMin0(
-                    vararg ints: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            vararg ints: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints.map { it.asPrimitive() },
@@ -534,8 +534,8 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun variadicMin0_(
-                    vararg ints: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            vararg ints: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints.toList(),
@@ -547,8 +547,8 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.VariadicMin1].
          */
         fun variadicMin1(
-                    ints: kotlin.collections.List<Long>,
-                metas: MetaContainer = emptyMetaContainer()
+            ints: kotlin.collections.List<Long>,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = ints.map { it.asPrimitive() },
@@ -563,8 +563,8 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun variadicMin1_(
-                    ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-                metas: MetaContainer = emptyMetaContainer()
+            ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = ints,
@@ -575,9 +575,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.VariadicMin1].
          */
         fun variadicMin1(
-                    ints0: Long,
-                    vararg ints: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            ints0: Long,
+            vararg ints: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = listOfPrimitives(ints0) + ints.map { it.asPrimitive() },
@@ -592,9 +592,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun variadicMin1_(
-                    ints0: org.partiql.pig.runtime.LongPrimitive,
-                    vararg ints: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            ints0: org.partiql.pig.runtime.LongPrimitive,
+            vararg ints: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = listOfPrimitives(ints0) + ints.toList(),
@@ -606,9 +606,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.ElementVariadic].
          */
         fun elementVariadic(
-                    name: String,
-                    ints: kotlin.collections.List<Long> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            name: String,
+            ints: kotlin.collections.List<Long> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
                 name = name.asPrimitive(),
@@ -624,9 +624,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun elementVariadic_(
-                    name: org.partiql.pig.runtime.SymbolPrimitive,
-                    ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
                 name = name,
@@ -638,9 +638,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.ElementVariadic].
          */
         fun elementVariadic(
-                    name: String,
-                    vararg ints: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            name: String,
+            vararg ints: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
                 name = name?.asPrimitive(),
@@ -656,9 +656,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun elementVariadic_(
-                    name: org.partiql.pig.runtime.SymbolPrimitive,
-                    vararg ints: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            vararg ints: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
                 name = name,
@@ -671,8 +671,8 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.Optional1].
          */
         fun optional1(
-                    value: Long? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            value: Long? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Optional1 =
             TestDomain.Optional1(
                 value = value?.asPrimitive(),
@@ -687,8 +687,8 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun optional1_(
-                    value: org.partiql.pig.runtime.LongPrimitive? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            value: org.partiql.pig.runtime.LongPrimitive? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Optional1 =
             TestDomain.Optional1(
                 value = value,
@@ -700,9 +700,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.Optional2].
          */
         fun optional2(
-                    first: Long? = null,
-                    second: Long? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Long? = null,
+            second: Long? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Optional2 =
             TestDomain.Optional2(
                 first = first?.asPrimitive(),
@@ -718,9 +718,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun optional2_(
-                    first: org.partiql.pig.runtime.LongPrimitive? = null,
-                    second: org.partiql.pig.runtime.LongPrimitive? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            first: org.partiql.pig.runtime.LongPrimitive? = null,
+            second: org.partiql.pig.runtime.LongPrimitive? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Optional2 =
             TestDomain.Optional2(
                 first = first,
@@ -733,10 +733,10 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.DomainLevelRecord].
          */
         fun domainLevelRecord(
-                    someField: Long,
-                    anotherField: String,
-                    optionalField: Long? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            someField: Long,
+            anotherField: String,
+            optionalField: Long? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.DomainLevelRecord =
             TestDomain.DomainLevelRecord(
                 someField = someField.asPrimitive(),
@@ -753,10 +753,10 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun domainLevelRecord_(
-                    someField: org.partiql.pig.runtime.LongPrimitive,
-                    anotherField: org.partiql.pig.runtime.SymbolPrimitive,
-                    optionalField: org.partiql.pig.runtime.LongPrimitive? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            someField: org.partiql.pig.runtime.LongPrimitive,
+            anotherField: org.partiql.pig.runtime.SymbolPrimitive,
+            optionalField: org.partiql.pig.runtime.LongPrimitive? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.DomainLevelRecord =
             TestDomain.DomainLevelRecord(
                 someField = someField,
@@ -770,9 +770,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.ProductWithRecord].
          */
         fun productWithRecord(
-                    value: Long,
-                    dlr: DomainLevelRecord,
-                metas: MetaContainer = emptyMetaContainer()
+            value: Long,
+            dlr: DomainLevelRecord,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ProductWithRecord =
             TestDomain.ProductWithRecord(
                 value = value.asPrimitive(),
@@ -788,9 +788,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun productWithRecord_(
-                    value: org.partiql.pig.runtime.LongPrimitive,
-                    dlr: DomainLevelRecord,
-                metas: MetaContainer = emptyMetaContainer()
+            value: org.partiql.pig.runtime.LongPrimitive,
+            dlr: DomainLevelRecord,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ProductWithRecord =
             TestDomain.ProductWithRecord(
                 value = value,
@@ -803,10 +803,10 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.TestSumTriplet].
          */
         fun testSumTriplet(
-                    a: TestSum,
-                    b: TestSum,
-                    c: TestSum,
-                metas: MetaContainer = emptyMetaContainer()
+            a: TestSum,
+            b: TestSum,
+            c: TestSum,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSumTriplet =
             TestDomain.TestSumTriplet(
                 a = a,
@@ -820,9 +820,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.EntityPair].
          */
         fun entityPair(
-                    first: Entity,
-                    second: Entity,
-                metas: MetaContainer = emptyMetaContainer()
+            first: Entity,
+            second: Entity,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.EntityPair =
             TestDomain.EntityPair(
                 first = first,
@@ -836,7 +836,7 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.Answer.No].
          */
         fun no(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Answer.No =
             TestDomain.Answer.No(
                 metas = newMetaContainer() + metas
@@ -847,7 +847,7 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.Answer.Yes].
          */
         fun yes(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Answer.Yes =
             TestDomain.Answer.Yes(
                 metas = newMetaContainer() + metas
@@ -859,9 +859,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.SumWithRecord.VariantWithRecord].
          */
         fun variantWithRecord(
-                    value: Long,
-                    dlr: DomainLevelRecord,
-                metas: MetaContainer = emptyMetaContainer()
+            value: Long,
+            dlr: DomainLevelRecord,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SumWithRecord.VariantWithRecord =
             TestDomain.SumWithRecord.VariantWithRecord(
                 value = value.asPrimitive(),
@@ -877,9 +877,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun variantWithRecord_(
-                    value: org.partiql.pig.runtime.LongPrimitive,
-                    dlr: DomainLevelRecord,
-                metas: MetaContainer = emptyMetaContainer()
+            value: org.partiql.pig.runtime.LongPrimitive,
+            dlr: DomainLevelRecord,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SumWithRecord.VariantWithRecord =
             TestDomain.SumWithRecord.VariantWithRecord(
                 value = value,
@@ -893,8 +893,8 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.TestSum.One].
          */
         fun one(
-                    a: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            a: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.One =
             TestDomain.TestSum.One(
                 a = a.asPrimitive(),
@@ -909,8 +909,8 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun one_(
-                    a: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            a: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.One =
             TestDomain.TestSum.One(
                 a = a,
@@ -922,9 +922,9 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.TestSum.Two].
          */
         fun two(
-                    a: Long,
-                    b: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            a: Long,
+            b: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.Two =
             TestDomain.TestSum.Two(
                 a = a.asPrimitive(),
@@ -940,9 +940,9 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun two_(
-                    a: org.partiql.pig.runtime.LongPrimitive,
-                    b: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            a: org.partiql.pig.runtime.LongPrimitive,
+            b: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.Two =
             TestDomain.TestSum.Two(
                 a = a,
@@ -955,10 +955,10 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.TestSum.Three].
          */
         fun three(
-                    a: Long,
-                    b: Long,
-                    c: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            a: Long,
+            b: Long,
+            c: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.Three =
             TestDomain.TestSum.Three(
                 a = a.asPrimitive(),
@@ -975,10 +975,10 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun three_(
-                    a: org.partiql.pig.runtime.LongPrimitive,
-                    b: org.partiql.pig.runtime.LongPrimitive,
-                    c: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            a: org.partiql.pig.runtime.LongPrimitive,
+            b: org.partiql.pig.runtime.LongPrimitive,
+            c: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.Three =
             TestDomain.TestSum.Three(
                 a = a,
@@ -993,7 +993,7 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.Entity.Slug].
          */
         fun slug(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Slug =
             TestDomain.Entity.Slug(
                 metas = newMetaContainer() + metas
@@ -1004,8 +1004,8 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.Entity.Android].
          */
         fun android(
-                    id: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            id: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Android =
             TestDomain.Entity.Android(
                 id = id.asPrimitive(),
@@ -1020,8 +1020,8 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun android_(
-                    id: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            id: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Android =
             TestDomain.Entity.Android(
                 id = id,
@@ -1033,12 +1033,12 @@ class TestDomain private constructor() {
          * Creates an instance of [TestDomain.Entity.Human].
          */
         fun human(
-                    firstName: String,
-                    middleNames: kotlin.collections.List<String> = emptyList(),
-                    lastName: String,
-                    title: String? = null,
-                    parent: Entity? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            firstName: String,
+            middleNames: kotlin.collections.List<String> = emptyList(),
+            lastName: String,
+            title: String? = null,
+            parent: Entity? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Human =
             TestDomain.Entity.Human(
                 firstName = firstName.asPrimitive(),
@@ -1057,12 +1057,12 @@ class TestDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun human_(
-                    firstName: org.partiql.pig.runtime.SymbolPrimitive,
-                    middleNames: kotlin.collections.List<org.partiql.pig.runtime.SymbolPrimitive> = emptyList(),
-                    lastName: org.partiql.pig.runtime.SymbolPrimitive,
-                    title: org.partiql.pig.runtime.SymbolPrimitive? = null,
-                    parent: Entity? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            firstName: org.partiql.pig.runtime.SymbolPrimitive,
+            middleNames: kotlin.collections.List<org.partiql.pig.runtime.SymbolPrimitive> = emptyList(),
+            lastName: org.partiql.pig.runtime.SymbolPrimitive,
+            title: org.partiql.pig.runtime.SymbolPrimitive? = null,
+            parent: Entity? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Human =
             TestDomain.Entity.Human(
                 firstName = firstName,
@@ -5163,7 +5163,7 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AaaAaa].
          */
         fun aaaAaa(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAaa =
             MultiWordDomain.AaaAaa(
                 metas = newMetaContainer() + metas
@@ -5174,8 +5174,8 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AaaAab].
          */
         fun aaaAab(
-                    dField: Long? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            dField: Long? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAab =
             MultiWordDomain.AaaAab(
                 dField = dField?.asPrimitive(),
@@ -5190,8 +5190,8 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aaaAab_(
-                    dField: org.partiql.pig.runtime.LongPrimitive? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            dField: org.partiql.pig.runtime.LongPrimitive? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAab =
             MultiWordDomain.AaaAab(
                 dField = dField,
@@ -5203,9 +5203,9 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AaaAac].
          */
         fun aaaAac(
-                    dField: Long? = null,
-                    eField: String? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            dField: Long? = null,
+            eField: String? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAac =
             MultiWordDomain.AaaAac(
                 dField = dField?.asPrimitive(),
@@ -5221,9 +5221,9 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aaaAac_(
-                    dField: org.partiql.pig.runtime.LongPrimitive? = null,
-                    eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            dField: org.partiql.pig.runtime.LongPrimitive? = null,
+            eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAac =
             MultiWordDomain.AaaAac(
                 dField = dField,
@@ -5236,8 +5236,8 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AaaAad].
          */
         fun aaaAad(
-                    dField: kotlin.collections.List<Long> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            dField: kotlin.collections.List<Long> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField.map { it.asPrimitive() },
@@ -5252,8 +5252,8 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aaaAad_(
-                    dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField,
@@ -5264,8 +5264,8 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AaaAad].
          */
         fun aaaAad(
-                    vararg dField: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            vararg dField: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField.map { it.asPrimitive() },
@@ -5280,8 +5280,8 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aaaAad_(
-                    vararg dField: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            vararg dField: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField.toList(),
@@ -5293,8 +5293,8 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AaaAae].
          */
         fun aaaAae(
-                    dField: kotlin.collections.List<Long>,
-                metas: MetaContainer = emptyMetaContainer()
+            dField: kotlin.collections.List<Long>,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = dField.map { it.asPrimitive() },
@@ -5309,8 +5309,8 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aaaAae_(
-                    dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-                metas: MetaContainer = emptyMetaContainer()
+            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = dField,
@@ -5321,10 +5321,10 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AaaAae].
          */
         fun aaaAae(
-                    dField0: Long,
-                    dField1: Long,
-                    vararg dField: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            dField0: Long,
+            dField1: Long,
+            vararg dField: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
@@ -5339,10 +5339,10 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aaaAae_(
-                    dField0: org.partiql.pig.runtime.LongPrimitive,
-                    dField1: org.partiql.pig.runtime.LongPrimitive,
-                    vararg dField: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            dField0: org.partiql.pig.runtime.LongPrimitive,
+            dField1: org.partiql.pig.runtime.LongPrimitive,
+            vararg dField: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = listOfPrimitives(dField0, dField1) + dField.toList(),
@@ -5354,9 +5354,9 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AabAaa].
          */
         fun aabAaa(
-                    bField: Long,
-                    cField: String,
-                metas: MetaContainer = emptyMetaContainer()
+            bField: Long,
+            cField: String,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAaa =
             MultiWordDomain.AabAaa(
                 bField = bField.asPrimitive(),
@@ -5372,9 +5372,9 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aabAaa_(
-                    bField: org.partiql.pig.runtime.LongPrimitive,
-                    cField: org.partiql.pig.runtime.SymbolPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAaa =
             MultiWordDomain.AabAaa(
                 bField = bField,
@@ -5387,10 +5387,10 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AabAab].
          */
         fun aabAab(
-                    bField: Long,
-                    cField: String,
-                    dField: Long? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            bField: Long,
+            cField: String,
+            dField: Long? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAab =
             MultiWordDomain.AabAab(
                 bField = bField.asPrimitive(),
@@ -5407,10 +5407,10 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aabAab_(
-                    bField: org.partiql.pig.runtime.LongPrimitive,
-                    cField: org.partiql.pig.runtime.SymbolPrimitive,
-                    dField: org.partiql.pig.runtime.LongPrimitive? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            dField: org.partiql.pig.runtime.LongPrimitive? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAab =
             MultiWordDomain.AabAab(
                 bField = bField,
@@ -5424,11 +5424,11 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AabAac].
          */
         fun aabAac(
-                    bField: Long,
-                    cField: String,
-                    dField: Long? = null,
-                    eField: String? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            bField: Long,
+            cField: String,
+            dField: Long? = null,
+            eField: String? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAac =
             MultiWordDomain.AabAac(
                 bField = bField.asPrimitive(),
@@ -5446,11 +5446,11 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aabAac_(
-                    bField: org.partiql.pig.runtime.LongPrimitive,
-                    cField: org.partiql.pig.runtime.SymbolPrimitive,
-                    dField: org.partiql.pig.runtime.LongPrimitive? = null,
-                    eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
-                metas: MetaContainer = emptyMetaContainer()
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            dField: org.partiql.pig.runtime.LongPrimitive? = null,
+            eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAac =
             MultiWordDomain.AabAac(
                 bField = bField,
@@ -5465,10 +5465,10 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AabAad].
          */
         fun aabAad(
-                    bField: Long,
-                    cField: String,
-                    dField: kotlin.collections.List<Long> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            bField: Long,
+            cField: String,
+            dField: kotlin.collections.List<Long> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
                 bField = bField.asPrimitive(),
@@ -5485,10 +5485,10 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aabAad_(
-                    bField: org.partiql.pig.runtime.LongPrimitive,
-                    cField: org.partiql.pig.runtime.SymbolPrimitive,
-                    dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
                 bField = bField,
@@ -5501,10 +5501,10 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AabAad].
          */
         fun aabAad(
-                    bField: Long,
-                    cField: String,
-                    vararg dField: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            bField: Long,
+            cField: String,
+            vararg dField: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
                 bField = bField?.asPrimitive(),
@@ -5521,10 +5521,10 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aabAad_(
-                    bField: org.partiql.pig.runtime.LongPrimitive,
-                    cField: org.partiql.pig.runtime.SymbolPrimitive,
-                    vararg dField: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            vararg dField: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
                 bField = bField,
@@ -5538,10 +5538,10 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AabAae].
          */
         fun aabAae(
-                    bField: Long,
-                    cField: String,
-                    dField: kotlin.collections.List<Long>,
-                metas: MetaContainer = emptyMetaContainer()
+            bField: Long,
+            cField: String,
+            dField: kotlin.collections.List<Long>,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
                 bField = bField.asPrimitive(),
@@ -5558,10 +5558,10 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aabAae_(
-                    bField: org.partiql.pig.runtime.LongPrimitive,
-                    cField: org.partiql.pig.runtime.SymbolPrimitive,
-                    dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-                metas: MetaContainer = emptyMetaContainer()
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
                 bField = bField,
@@ -5574,12 +5574,12 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.AabAae].
          */
         fun aabAae(
-                    bField: Long,
-                    cField: String,
-                    dField0: Long,
-                    dField1: Long,
-                    vararg dField: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            bField: Long,
+            cField: String,
+            dField0: Long,
+            dField1: Long,
+            vararg dField: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
                 bField = bField?.asPrimitive(),
@@ -5596,12 +5596,12 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun aabAae_(
-                    bField: org.partiql.pig.runtime.LongPrimitive,
-                    cField: org.partiql.pig.runtime.SymbolPrimitive,
-                    dField0: org.partiql.pig.runtime.LongPrimitive,
-                    dField1: org.partiql.pig.runtime.LongPrimitive,
-                    vararg dField: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            bField: org.partiql.pig.runtime.LongPrimitive,
+            cField: org.partiql.pig.runtime.SymbolPrimitive,
+            dField0: org.partiql.pig.runtime.LongPrimitive,
+            dField1: org.partiql.pig.runtime.LongPrimitive,
+            vararg dField: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
                 bField = bField,
@@ -5615,9 +5615,9 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.Rrr].
          */
         fun rrr(
-                    aField: Long,
-                    bbbField: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            aField: Long,
+            bbbField: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.Rrr =
             MultiWordDomain.Rrr(
                 aField = aField.asPrimitive(),
@@ -5633,9 +5633,9 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun rrr_(
-                    aField: org.partiql.pig.runtime.LongPrimitive,
-                    bbbField: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            aField: org.partiql.pig.runtime.LongPrimitive,
+            bbbField: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.Rrr =
             MultiWordDomain.Rrr(
                 aField = aField,
@@ -5649,8 +5649,8 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.SssTtt.Lll].
          */
         fun lll(
-                    uField: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            uField: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Lll =
             MultiWordDomain.SssTtt.Lll(
                 uField = uField.asPrimitive(),
@@ -5665,8 +5665,8 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun lll_(
-                    uField: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            uField: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Lll =
             MultiWordDomain.SssTtt.Lll(
                 uField = uField,
@@ -5678,8 +5678,8 @@ class MultiWordDomain private constructor() {
          * Creates an instance of [MultiWordDomain.SssTtt.Mmm].
          */
         fun mmm(
-                    vField: String,
-                metas: MetaContainer = emptyMetaContainer()
+            vField: String,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Mmm =
             MultiWordDomain.SssTtt.Mmm(
                 vField = vField.asPrimitive(),
@@ -5694,8 +5694,8 @@ class MultiWordDomain private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun mmm_(
-                    vField: org.partiql.pig.runtime.SymbolPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            vField: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Mmm =
             MultiWordDomain.SssTtt.Mmm(
                 vField = vField,
@@ -7259,8 +7259,8 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.ProductToRemove].
          */
         fun productToRemove(
-                    whatever: String,
-                metas: MetaContainer = emptyMetaContainer()
+            whatever: String,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.ProductToRemove =
             DomainA.ProductToRemove(
                 whatever = whatever.asPrimitive(),
@@ -7275,8 +7275,8 @@ class DomainA private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun productToRemove_(
-                    whatever: org.partiql.pig.runtime.SymbolPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            whatever: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.ProductToRemove =
             DomainA.ProductToRemove(
                 whatever = whatever,
@@ -7288,8 +7288,8 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.RecordToRemove].
          */
         fun recordToRemove(
-                    irrelevant: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            irrelevant: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.RecordToRemove =
             DomainA.RecordToRemove(
                 irrelevant = irrelevant.asPrimitive(),
@@ -7304,8 +7304,8 @@ class DomainA private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun recordToRemove_(
-                    irrelevant: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            irrelevant: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.RecordToRemove =
             DomainA.RecordToRemove(
                 irrelevant = irrelevant,
@@ -7317,8 +7317,8 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.ProductA].
          */
         fun productA(
-                    one: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            one: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.ProductA =
             DomainA.ProductA(
                 one = one.asPrimitive(),
@@ -7333,8 +7333,8 @@ class DomainA private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun productA_(
-                    one: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            one: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.ProductA =
             DomainA.ProductA(
                 one = one,
@@ -7346,8 +7346,8 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.RecordA].
          */
         fun recordA(
-                    one: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            one: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.RecordA =
             DomainA.RecordA(
                 one = one.asPrimitive(),
@@ -7362,8 +7362,8 @@ class DomainA private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun recordA_(
-                    one: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            one: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.RecordA =
             DomainA.RecordA(
                 one = one,
@@ -7375,9 +7375,9 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.UnpermutedProduct].
          */
         fun unpermutedProduct(
-                    foo: String,
-                    bar: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: String,
+            bar: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedProduct =
             DomainA.UnpermutedProduct(
                 foo = foo.asPrimitive(),
@@ -7393,9 +7393,9 @@ class DomainA private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun unpermutedProduct_(
-                    foo: org.partiql.pig.runtime.SymbolPrimitive,
-                    bar: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: org.partiql.pig.runtime.SymbolPrimitive,
+            bar: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedProduct =
             DomainA.UnpermutedProduct(
                 foo = foo,
@@ -7408,9 +7408,9 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.UnpermutedRecord].
          */
         fun unpermutedRecord(
-                    foo: String,
-                    bar: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: String,
+            bar: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedRecord =
             DomainA.UnpermutedRecord(
                 foo = foo.asPrimitive(),
@@ -7426,9 +7426,9 @@ class DomainA private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun unpermutedRecord_(
-                    foo: org.partiql.pig.runtime.SymbolPrimitive,
-                    bar: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: org.partiql.pig.runtime.SymbolPrimitive,
+            bar: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedRecord =
             DomainA.UnpermutedRecord(
                 foo = foo,
@@ -7442,7 +7442,7 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.SumToRemove.Doesnt].
          */
         fun doesnt(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumToRemove.Doesnt =
             DomainA.SumToRemove.Doesnt(
                 metas = newMetaContainer() + metas
@@ -7453,7 +7453,7 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.SumToRemove.Matter].
          */
         fun matter(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumToRemove.Matter =
             DomainA.SumToRemove.Matter(
                 metas = newMetaContainer() + metas
@@ -7465,7 +7465,7 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.SumA.Who].
          */
         fun who(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumA.Who =
             DomainA.SumA.Who(
                 metas = newMetaContainer() + metas
@@ -7476,7 +7476,7 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.SumA.Cares].
          */
         fun cares(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumA.Cares =
             DomainA.SumA.Cares(
                 metas = newMetaContainer() + metas
@@ -7488,7 +7488,7 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.SumB.WillBeUnchanged].
          */
         fun willBeUnchanged(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumB.WillBeUnchanged =
             DomainA.SumB.WillBeUnchanged(
                 metas = newMetaContainer() + metas
@@ -7499,7 +7499,7 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.SumB.WillBeRemoved].
          */
         fun willBeRemoved(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumB.WillBeRemoved =
             DomainA.SumB.WillBeRemoved(
                 metas = newMetaContainer() + metas
@@ -7510,8 +7510,8 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.SumB.WillBeReplaced].
          */
         fun willBeReplaced(
-                    something: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            something: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumB.WillBeReplaced =
             DomainA.SumB.WillBeReplaced(
                 something = something.asPrimitive(),
@@ -7526,8 +7526,8 @@ class DomainA private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun willBeReplaced_(
-                    something: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            something: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumB.WillBeReplaced =
             DomainA.SumB.WillBeReplaced(
                 something = something,
@@ -7540,9 +7540,9 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.UnpermutedSum.UnpermutedProductVariant].
          */
         fun unpermutedProductVariant(
-                    foo: String,
-                    bar: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: String,
+            bar: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedSum.UnpermutedProductVariant =
             DomainA.UnpermutedSum.UnpermutedProductVariant(
                 foo = foo.asPrimitive(),
@@ -7558,9 +7558,9 @@ class DomainA private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun unpermutedProductVariant_(
-                    foo: org.partiql.pig.runtime.SymbolPrimitive,
-                    bar: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: org.partiql.pig.runtime.SymbolPrimitive,
+            bar: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedSum.UnpermutedProductVariant =
             DomainA.UnpermutedSum.UnpermutedProductVariant(
                 foo = foo,
@@ -7573,9 +7573,9 @@ class DomainA private constructor() {
          * Creates an instance of [DomainA.UnpermutedSum.UnpermutedRecordVariant].
          */
         fun unpermutedRecordVariant(
-                    foo: String,
-                    bar: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: String,
+            bar: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedSum.UnpermutedRecordVariant =
             DomainA.UnpermutedSum.UnpermutedRecordVariant(
                 foo = foo.asPrimitive(),
@@ -7591,9 +7591,9 @@ class DomainA private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun unpermutedRecordVariant_(
-                    foo: org.partiql.pig.runtime.SymbolPrimitive,
-                    bar: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: org.partiql.pig.runtime.SymbolPrimitive,
+            bar: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedSum.UnpermutedRecordVariant =
             DomainA.UnpermutedSum.UnpermutedRecordVariant(
                 foo = foo,
@@ -9267,9 +9267,9 @@ class DomainB private constructor() {
          * Creates an instance of [DomainB.UnpermutedProduct].
          */
         fun unpermutedProduct(
-                    foo: String,
-                    bar: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: String,
+            bar: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedProduct =
             DomainB.UnpermutedProduct(
                 foo = foo.asPrimitive(),
@@ -9285,9 +9285,9 @@ class DomainB private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun unpermutedProduct_(
-                    foo: org.partiql.pig.runtime.SymbolPrimitive,
-                    bar: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: org.partiql.pig.runtime.SymbolPrimitive,
+            bar: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedProduct =
             DomainB.UnpermutedProduct(
                 foo = foo,
@@ -9300,9 +9300,9 @@ class DomainB private constructor() {
          * Creates an instance of [DomainB.UnpermutedRecord].
          */
         fun unpermutedRecord(
-                    foo: String,
-                    bar: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: String,
+            bar: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedRecord =
             DomainB.UnpermutedRecord(
                 foo = foo.asPrimitive(),
@@ -9318,9 +9318,9 @@ class DomainB private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun unpermutedRecord_(
-                    foo: org.partiql.pig.runtime.SymbolPrimitive,
-                    bar: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: org.partiql.pig.runtime.SymbolPrimitive,
+            bar: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedRecord =
             DomainB.UnpermutedRecord(
                 foo = foo,
@@ -9333,8 +9333,8 @@ class DomainB private constructor() {
          * Creates an instance of [DomainB.ProductA].
          */
         fun productA(
-                    one: String,
-                metas: MetaContainer = emptyMetaContainer()
+            one: String,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.ProductA =
             DomainB.ProductA(
                 one = one.asPrimitive(),
@@ -9349,8 +9349,8 @@ class DomainB private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun productA_(
-                    one: org.partiql.pig.runtime.SymbolPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            one: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.ProductA =
             DomainB.ProductA(
                 one = one,
@@ -9362,8 +9362,8 @@ class DomainB private constructor() {
          * Creates an instance of [DomainB.RecordA].
          */
         fun recordA(
-                    one: String,
-                metas: MetaContainer = emptyMetaContainer()
+            one: String,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.RecordA =
             DomainB.RecordA(
                 one = one.asPrimitive(),
@@ -9378,8 +9378,8 @@ class DomainB private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun recordA_(
-                    one: org.partiql.pig.runtime.SymbolPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            one: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.RecordA =
             DomainB.RecordA(
                 one = one,
@@ -9391,8 +9391,8 @@ class DomainB private constructor() {
          * Creates an instance of [DomainB.NewProduct].
          */
         fun newProduct(
-                    foo: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewProduct =
             DomainB.NewProduct(
                 foo = foo.asPrimitive(),
@@ -9407,8 +9407,8 @@ class DomainB private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun newProduct_(
-                    foo: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewProduct =
             DomainB.NewProduct(
                 foo = foo,
@@ -9420,8 +9420,8 @@ class DomainB private constructor() {
          * Creates an instance of [DomainB.NewRecord].
          */
         fun newRecord(
-                    foo: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewRecord =
             DomainB.NewRecord(
                 foo = foo.asPrimitive(),
@@ -9436,8 +9436,8 @@ class DomainB private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun newRecord_(
-                    foo: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewRecord =
             DomainB.NewRecord(
                 foo = foo,
@@ -9450,9 +9450,9 @@ class DomainB private constructor() {
          * Creates an instance of [DomainB.UnpermutedSum.UnpermutedProductVariant].
          */
         fun unpermutedProductVariant(
-                    foo: String,
-                    bar: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: String,
+            bar: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedSum.UnpermutedProductVariant =
             DomainB.UnpermutedSum.UnpermutedProductVariant(
                 foo = foo.asPrimitive(),
@@ -9468,9 +9468,9 @@ class DomainB private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun unpermutedProductVariant_(
-                    foo: org.partiql.pig.runtime.SymbolPrimitive,
-                    bar: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: org.partiql.pig.runtime.SymbolPrimitive,
+            bar: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedSum.UnpermutedProductVariant =
             DomainB.UnpermutedSum.UnpermutedProductVariant(
                 foo = foo,
@@ -9483,9 +9483,9 @@ class DomainB private constructor() {
          * Creates an instance of [DomainB.UnpermutedSum.UnpermutedRecordVariant].
          */
         fun unpermutedRecordVariant(
-                    foo: String,
-                    bar: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: String,
+            bar: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedSum.UnpermutedRecordVariant =
             DomainB.UnpermutedSum.UnpermutedRecordVariant(
                 foo = foo.asPrimitive(),
@@ -9501,9 +9501,9 @@ class DomainB private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun unpermutedRecordVariant_(
-                    foo: org.partiql.pig.runtime.SymbolPrimitive,
-                    bar: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            foo: org.partiql.pig.runtime.SymbolPrimitive,
+            bar: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedSum.UnpermutedRecordVariant =
             DomainB.UnpermutedSum.UnpermutedRecordVariant(
                 foo = foo,
@@ -9517,7 +9517,7 @@ class DomainB private constructor() {
          * Creates an instance of [DomainB.SumB.WillBeUnchanged].
          */
         fun willBeUnchanged(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.SumB.WillBeUnchanged =
             DomainB.SumB.WillBeUnchanged(
                 metas = newMetaContainer() + metas
@@ -9528,8 +9528,8 @@ class DomainB private constructor() {
          * Creates an instance of [DomainB.SumB.WillBeReplaced].
          */
         fun willBeReplaced(
-                    something: String,
-                metas: MetaContainer = emptyMetaContainer()
+            something: String,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.SumB.WillBeReplaced =
             DomainB.SumB.WillBeReplaced(
                 something = something.asPrimitive(),
@@ -9544,8 +9544,8 @@ class DomainB private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun willBeReplaced_(
-                    something: org.partiql.pig.runtime.SymbolPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            something: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.SumB.WillBeReplaced =
             DomainB.SumB.WillBeReplaced(
                 something = something,
@@ -9558,7 +9558,7 @@ class DomainB private constructor() {
          * Creates an instance of [DomainB.NewSum.Eek].
          */
         fun eek(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewSum.Eek =
             DomainB.NewSum.Eek(
                 metas = newMetaContainer() + metas
@@ -9569,7 +9569,7 @@ class DomainB private constructor() {
          * Creates an instance of [DomainB.NewSum.Whatever].
          */
         fun whatever(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewSum.Whatever =
             DomainB.NewSum.Whatever(
                 metas = newMetaContainer() + metas

--- a/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
@@ -37,14 +37,14 @@ class TestDomain private constructor() {
         * Creates an instance of [TestDomain.BoolPair].
         */
         fun boolPair(
-            first: Boolean,
-            second: Boolean,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Boolean,
+                    second: Boolean,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.BoolPair =
             TestDomain.BoolPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.BoolPair].
@@ -54,28 +54,28 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun boolPair_(
-            first: org.partiql.pig.runtime.BoolPrimitive,
-            second: org.partiql.pig.runtime.BoolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: org.partiql.pig.runtime.BoolPrimitive,
+                    second: org.partiql.pig.runtime.BoolPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.BoolPair =
             TestDomain.BoolPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.IntPair].
         */
         fun intPair(
-            first: Long,
-            second: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Long,
+                    second: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntPair =
             TestDomain.IntPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.IntPair].
@@ -85,28 +85,28 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun intPair_(
-            first: org.partiql.pig.runtime.LongPrimitive,
-            second: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: org.partiql.pig.runtime.LongPrimitive,
+                    second: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntPair =
             TestDomain.IntPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.SymbolPair].
         */
         fun symbolPair(
-            first: String,
-            second: String,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: String,
+                    second: String,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolPair =
             TestDomain.SymbolPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.SymbolPair].
@@ -116,42 +116,42 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun symbolPair_(
-            first: org.partiql.pig.runtime.SymbolPrimitive,
-            second: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: org.partiql.pig.runtime.SymbolPrimitive,
+                    second: org.partiql.pig.runtime.SymbolPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolPair =
             TestDomain.SymbolPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.IonPair].
         */
         fun ionPair(
-            first: com.amazon.ionelement.api.IonElement,
-            second: com.amazon.ionelement.api.IonElement,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: com.amazon.ionelement.api.IonElement,
+                    second: com.amazon.ionelement.api.IonElement,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IonPair =
             TestDomain.IonPair(
                 first = first.asAnyElement(),
                 second = second.asAnyElement(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.IntSymbolPair].
         */
         fun intSymbolPair(
-            first: Long,
-            second: String,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Long,
+                    second: String,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntSymbolPair =
             TestDomain.IntSymbolPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.IntSymbolPair].
@@ -161,28 +161,28 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun intSymbolPair_(
-            first: org.partiql.pig.runtime.LongPrimitive,
-            second: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: org.partiql.pig.runtime.LongPrimitive,
+                    second: org.partiql.pig.runtime.SymbolPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntSymbolPair =
             TestDomain.IntSymbolPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.SymbolIntPair].
         */
         fun symbolIntPair(
-            first: String,
-            second: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: String,
+                    second: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolIntPair =
             TestDomain.SymbolIntPair(
                 first = first.asPrimitive(),
                 second = second.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.SymbolIntPair].
@@ -192,28 +192,28 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun symbolIntPair_(
-            first: org.partiql.pig.runtime.SymbolPrimitive,
-            second: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: org.partiql.pig.runtime.SymbolPrimitive,
+                    second: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolIntPair =
             TestDomain.SymbolIntPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.IonIntPair].
         */
         fun ionIntPair(
-            first: com.amazon.ionelement.api.IonElement,
-            second: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: com.amazon.ionelement.api.IonElement,
+                    second: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IonIntPair =
             TestDomain.IonIntPair(
                 first = first.asAnyElement(),
                 second = second.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.IonIntPair].
@@ -223,84 +223,84 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun ionIntPair_(
-            first: com.amazon.ionelement.api.IonElement,
-            second: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: com.amazon.ionelement.api.IonElement,
+                    second: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IonIntPair =
             TestDomain.IonIntPair(
                 first = first.asAnyElement(),
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.IonSymbolPair].
         */
         fun ionSymbolPair(
-            first: com.amazon.ionelement.api.IonElement,
-            second: com.amazon.ionelement.api.IonElement,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: com.amazon.ionelement.api.IonElement,
+                    second: com.amazon.ionelement.api.IonElement,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IonSymbolPair =
             TestDomain.IonSymbolPair(
                 first = first.asAnyElement(),
                 second = second.asAnyElement(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.IntPairPair].
         */
         fun intPairPair(
-            first: IntPair,
-            second: IntPair,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: IntPair,
+                    second: IntPair,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntPairPair =
             TestDomain.IntPairPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.SymbolPairPair].
         */
         fun symbolPairPair(
-            first: SymbolPair,
-            second: SymbolPair,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: SymbolPair,
+                    second: SymbolPair,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolPairPair =
             TestDomain.SymbolPairPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.IonPairPair].
         */
         fun ionPairPair(
-            first: IonPair,
-            second: IonPair,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: IonPair,
+                    second: IonPair,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IonPairPair =
             TestDomain.IonPairPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.RecursivePair].
         */
         fun recursivePair(
-            first: Long,
-            second: RecursivePair? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Long,
+                    second: RecursivePair? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.RecursivePair =
             TestDomain.RecursivePair(
                 first = first.asPrimitive(),
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.RecursivePair].
@@ -310,42 +310,42 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun recursivePair_(
-            first: org.partiql.pig.runtime.LongPrimitive,
-            second: RecursivePair? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: org.partiql.pig.runtime.LongPrimitive,
+                    second: RecursivePair? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.RecursivePair =
             TestDomain.RecursivePair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.AnswerPair].
         */
         fun answerPair(
-            first: Answer,
-            second: Answer,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Answer,
+                    second: Answer,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.AnswerPair =
             TestDomain.AnswerPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.AnswerIntPair].
         */
         fun answerIntPair(
-            first: Answer,
-            second: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Answer,
+                    second: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.AnswerIntPair =
             TestDomain.AnswerIntPair(
                 first = first,
                 second = second.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.AnswerIntPair].
@@ -355,28 +355,28 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun answerIntPair_(
-            first: Answer,
-            second: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Answer,
+                    second: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.AnswerIntPair =
             TestDomain.AnswerIntPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.IntAnswerPair].
         */
         fun intAnswerPair(
-            first: Long,
-            second: Answer,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Long,
+                    second: Answer,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntAnswerPair =
             TestDomain.IntAnswerPair(
                 first = first.asPrimitive(),
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.IntAnswerPair].
@@ -386,28 +386,28 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun intAnswerPair_(
-            first: org.partiql.pig.runtime.LongPrimitive,
-            second: Answer,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: org.partiql.pig.runtime.LongPrimitive,
+                    second: Answer,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.IntAnswerPair =
             TestDomain.IntAnswerPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.SymbolAnswerPair].
         */
         fun symbolAnswerPair(
-            first: String,
-            second: Answer,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: String,
+                    second: Answer,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolAnswerPair =
             TestDomain.SymbolAnswerPair(
                 first = first.asPrimitive(),
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.SymbolAnswerPair].
@@ -417,28 +417,28 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun symbolAnswerPair_(
-            first: org.partiql.pig.runtime.SymbolPrimitive,
-            second: Answer,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: org.partiql.pig.runtime.SymbolPrimitive,
+                    second: Answer,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SymbolAnswerPair =
             TestDomain.SymbolAnswerPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.AnswerSymbolPair].
         */
         fun answerSymbolPair(
-            first: Answer,
-            second: String,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Answer,
+                    second: String,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.AnswerSymbolPair =
             TestDomain.AnswerSymbolPair(
                 first = first,
                 second = second.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.AnswerSymbolPair].
@@ -448,26 +448,26 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun answerSymbolPair_(
-            first: Answer,
-            second: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Answer,
+                    second: org.partiql.pig.runtime.SymbolPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.AnswerSymbolPair =
             TestDomain.AnswerSymbolPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.VariadicMin0].
         */
         fun variadicMin0(
-            ints: kotlin.collections.List<Long> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    ints: kotlin.collections.List<Long> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.VariadicMin0].
@@ -477,23 +477,23 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun variadicMin0_(
-            ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.VariadicMin0].
         */
         fun variadicMin0(
-            vararg ints: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    vararg ints: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.VariadicMin0].
@@ -503,24 +503,24 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun variadicMin0_(
-            vararg ints: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    vararg ints: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin0 =
             TestDomain.VariadicMin0(
                 ints = ints.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.VariadicMin1].
         */
         fun variadicMin1(
-            ints: kotlin.collections.List<Long>,
-            metas: MetaContainer = emptyMetaContainer()
+                    ints: kotlin.collections.List<Long>,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = ints.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.VariadicMin1].
@@ -530,24 +530,24 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun variadicMin1_(
-            ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-            metas: MetaContainer = emptyMetaContainer()
+                    ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = ints,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.VariadicMin1].
         */
         fun variadicMin1(
-            ints0: Long,
-            vararg ints: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    ints0: Long,
+                    vararg ints: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = listOfPrimitives(ints0) + ints.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.VariadicMin1].
@@ -557,27 +557,27 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun variadicMin1_(
-            ints0: org.partiql.pig.runtime.LongPrimitive,
-            vararg ints: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    ints0: org.partiql.pig.runtime.LongPrimitive,
+                    vararg ints: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.VariadicMin1 =
             TestDomain.VariadicMin1(
                 ints = listOfPrimitives(ints0) + ints.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.ElementVariadic].
         */
         fun elementVariadic(
-            name: String,
-            ints: kotlin.collections.List<Long> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    name: String,
+                    ints: kotlin.collections.List<Long> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
                 name = name.asPrimitive(),
                 ints = ints.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.ElementVariadic].
@@ -587,27 +587,27 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun elementVariadic_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    name: org.partiql.pig.runtime.SymbolPrimitive,
+                    ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
                 name = name,
                 ints = ints,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.ElementVariadic].
         */
         fun elementVariadic(
-            name: String,
-            vararg ints: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: String,
+                    vararg ints: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
                 name = name?.asPrimitive(),
                 ints = ints.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.ElementVariadic].
@@ -617,26 +617,26 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun elementVariadic_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            vararg ints: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: org.partiql.pig.runtime.SymbolPrimitive,
+                    vararg ints: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
                 name = name,
                 ints = ints.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.Optional1].
         */
         fun optional1(
-            value: Long? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: Long? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Optional1 =
             TestDomain.Optional1(
                 value = value?.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.Optional1].
@@ -646,26 +646,26 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun optional1_(
-            value: org.partiql.pig.runtime.LongPrimitive? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: org.partiql.pig.runtime.LongPrimitive? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Optional1 =
             TestDomain.Optional1(
                 value = value,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.Optional2].
         */
         fun optional2(
-            first: Long? = null,
-            second: Long? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Long? = null,
+                    second: Long? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Optional2 =
             TestDomain.Optional2(
                 first = first?.asPrimitive(),
                 second = second?.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.Optional2].
@@ -675,30 +675,30 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun optional2_(
-            first: org.partiql.pig.runtime.LongPrimitive? = null,
-            second: org.partiql.pig.runtime.LongPrimitive? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: org.partiql.pig.runtime.LongPrimitive? = null,
+                    second: org.partiql.pig.runtime.LongPrimitive? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Optional2 =
             TestDomain.Optional2(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.DomainLevelRecord].
         */
         fun domainLevelRecord(
-            someField: Long,
-            anotherField: String,
-            optionalField: Long? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    someField: Long,
+                    anotherField: String,
+                    optionalField: Long? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.DomainLevelRecord =
             TestDomain.DomainLevelRecord(
                 someField = someField.asPrimitive(),
                 anotherField = anotherField.asPrimitive(),
                 optionalField = optionalField?.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.DomainLevelRecord].
@@ -708,30 +708,30 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun domainLevelRecord_(
-            someField: org.partiql.pig.runtime.LongPrimitive,
-            anotherField: org.partiql.pig.runtime.SymbolPrimitive,
-            optionalField: org.partiql.pig.runtime.LongPrimitive? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    someField: org.partiql.pig.runtime.LongPrimitive,
+                    anotherField: org.partiql.pig.runtime.SymbolPrimitive,
+                    optionalField: org.partiql.pig.runtime.LongPrimitive? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.DomainLevelRecord =
             TestDomain.DomainLevelRecord(
                 someField = someField,
                 anotherField = anotherField,
                 optionalField = optionalField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.ProductWithRecord].
         */
         fun productWithRecord(
-            value: Long,
-            dlr: DomainLevelRecord,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: Long,
+                    dlr: DomainLevelRecord,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ProductWithRecord =
             TestDomain.ProductWithRecord(
                 value = value.asPrimitive(),
                 dlr = dlr,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.ProductWithRecord].
@@ -741,44 +741,44 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun productWithRecord_(
-            value: org.partiql.pig.runtime.LongPrimitive,
-            dlr: DomainLevelRecord,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: org.partiql.pig.runtime.LongPrimitive,
+                    dlr: DomainLevelRecord,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ProductWithRecord =
             TestDomain.ProductWithRecord(
                 value = value,
                 dlr = dlr,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.TestSumTriplet].
         */
         fun testSumTriplet(
-            a: TestSum,
-            b: TestSum,
-            c: TestSum,
-            metas: MetaContainer = emptyMetaContainer()
+                    a: TestSum,
+                    b: TestSum,
+                    c: TestSum,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSumTriplet =
             TestDomain.TestSumTriplet(
                 a = a,
                 b = b,
                 c = c,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.EntityPair].
         */
         fun entityPair(
-            first: Entity,
-            second: Entity,
-            metas: MetaContainer = emptyMetaContainer()
+                    first: Entity,
+                    second: Entity,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.EntityPair =
             TestDomain.EntityPair(
                 first = first,
                 second = second,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: Answer 
@@ -786,20 +786,20 @@ class TestDomain private constructor() {
         * Creates an instance of [TestDomain.Answer.No].
         */
         fun no(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Answer.No =
             TestDomain.Answer.No(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.Answer.Yes].
         */
         fun yes(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Answer.Yes =
             TestDomain.Answer.Yes(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: SumWithRecord 
@@ -807,14 +807,14 @@ class TestDomain private constructor() {
         * Creates an instance of [TestDomain.SumWithRecord.VariantWithRecord].
         */
         fun variantWithRecord(
-            value: Long,
-            dlr: DomainLevelRecord,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: Long,
+                    dlr: DomainLevelRecord,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SumWithRecord.VariantWithRecord =
             TestDomain.SumWithRecord.VariantWithRecord(
                 value = value.asPrimitive(),
                 dlr = dlr,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.SumWithRecord.VariantWithRecord].
@@ -824,14 +824,14 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun variantWithRecord_(
-            value: org.partiql.pig.runtime.LongPrimitive,
-            dlr: DomainLevelRecord,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: org.partiql.pig.runtime.LongPrimitive,
+                    dlr: DomainLevelRecord,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.SumWithRecord.VariantWithRecord =
             TestDomain.SumWithRecord.VariantWithRecord(
                 value = value,
                 dlr = dlr,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: TestSum 
@@ -839,12 +839,12 @@ class TestDomain private constructor() {
         * Creates an instance of [TestDomain.TestSum.One].
         */
         fun one(
-            a: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    a: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.One =
             TestDomain.TestSum.One(
                 a = a.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.TestSum.One].
@@ -854,26 +854,26 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun one_(
-            a: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    a: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.One =
             TestDomain.TestSum.One(
                 a = a,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.TestSum.Two].
         */
         fun two(
-            a: Long,
-            b: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    a: Long,
+                    b: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.Two =
             TestDomain.TestSum.Two(
                 a = a.asPrimitive(),
                 b = b.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.TestSum.Two].
@@ -883,30 +883,30 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun two_(
-            a: org.partiql.pig.runtime.LongPrimitive,
-            b: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    a: org.partiql.pig.runtime.LongPrimitive,
+                    b: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.Two =
             TestDomain.TestSum.Two(
                 a = a,
                 b = b,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.TestSum.Three].
         */
         fun three(
-            a: Long,
-            b: Long,
-            c: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    a: Long,
+                    b: Long,
+                    c: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.Three =
             TestDomain.TestSum.Three(
                 a = a.asPrimitive(),
                 b = b.asPrimitive(),
                 c = c.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.TestSum.Three].
@@ -916,16 +916,16 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun three_(
-            a: org.partiql.pig.runtime.LongPrimitive,
-            b: org.partiql.pig.runtime.LongPrimitive,
-            c: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    a: org.partiql.pig.runtime.LongPrimitive,
+                    b: org.partiql.pig.runtime.LongPrimitive,
+                    c: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.TestSum.Three =
             TestDomain.TestSum.Three(
                 a = a,
                 b = b,
                 c = c,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: Entity 
@@ -933,22 +933,22 @@ class TestDomain private constructor() {
         * Creates an instance of [TestDomain.Entity.Slug].
         */
         fun slug(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Slug =
             TestDomain.Entity.Slug(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.Entity.Android].
         */
         fun android(
-            id: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    id: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Android =
             TestDomain.Entity.Android(
                 id = id.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.Entity.Android].
@@ -958,24 +958,24 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun android_(
-            id: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    id: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Android =
             TestDomain.Entity.Android(
                 id = id,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [TestDomain.Entity.Human].
         */
         fun human(
-            firstName: String,
-            middleNames: kotlin.collections.List<String> = emptyList(),
-            lastName: String,
-            title: String? = null,
-            parent: Entity? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    firstName: String,
+                    middleNames: kotlin.collections.List<String> = emptyList(),
+                    lastName: String,
+                    title: String? = null,
+                    parent: Entity? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Human =
             TestDomain.Entity.Human(
                 firstName = firstName.asPrimitive(),
@@ -983,7 +983,7 @@ class TestDomain private constructor() {
                 lastName = lastName.asPrimitive(),
                 title = title?.asPrimitive(),
                 parent = parent,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [TestDomain.Entity.Human].
@@ -993,12 +993,12 @@ class TestDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun human_(
-            firstName: org.partiql.pig.runtime.SymbolPrimitive,
-            middleNames: kotlin.collections.List<org.partiql.pig.runtime.SymbolPrimitive> = emptyList(),
-            lastName: org.partiql.pig.runtime.SymbolPrimitive,
-            title: org.partiql.pig.runtime.SymbolPrimitive? = null,
-            parent: Entity? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    firstName: org.partiql.pig.runtime.SymbolPrimitive,
+                    middleNames: kotlin.collections.List<org.partiql.pig.runtime.SymbolPrimitive> = emptyList(),
+                    lastName: org.partiql.pig.runtime.SymbolPrimitive,
+                    title: org.partiql.pig.runtime.SymbolPrimitive? = null,
+                    parent: Entity? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Human =
             TestDomain.Entity.Human(
                 firstName = firstName,
@@ -1006,7 +1006,7 @@ class TestDomain private constructor() {
                 lastName = lastName,
                 title = title,
                 parent = parent,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */
@@ -5098,22 +5098,22 @@ class MultiWordDomain private constructor() {
         * Creates an instance of [MultiWordDomain.AaaAaa].
         */
         fun aaaAaa(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAaa =
             MultiWordDomain.AaaAaa(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [MultiWordDomain.AaaAab].
         */
         fun aaaAab(
-            dField: Long? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    dField: Long? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAab =
             MultiWordDomain.AaaAab(
                 dField = dField?.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AaaAab].
@@ -5123,26 +5123,26 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aaaAab_(
-            dField: org.partiql.pig.runtime.LongPrimitive? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    dField: org.partiql.pig.runtime.LongPrimitive? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAab =
             MultiWordDomain.AaaAab(
                 dField = dField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [MultiWordDomain.AaaAac].
         */
         fun aaaAac(
-            dField: Long? = null,
-            eField: String? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    dField: Long? = null,
+                    eField: String? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAac =
             MultiWordDomain.AaaAac(
                 dField = dField?.asPrimitive(),
                 eField = eField?.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AaaAac].
@@ -5152,26 +5152,26 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aaaAac_(
-            dField: org.partiql.pig.runtime.LongPrimitive? = null,
-            eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    dField: org.partiql.pig.runtime.LongPrimitive? = null,
+                    eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAac =
             MultiWordDomain.AaaAac(
                 dField = dField,
                 eField = eField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [MultiWordDomain.AaaAad].
         */
         fun aaaAad(
-            dField: kotlin.collections.List<Long> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    dField: kotlin.collections.List<Long> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AaaAad].
@@ -5181,23 +5181,23 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aaaAad_(
-            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AaaAad].
         */
         fun aaaAad(
-            vararg dField: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    vararg dField: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AaaAad].
@@ -5207,24 +5207,24 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aaaAad_(
-            vararg dField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    vararg dField: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAad =
             MultiWordDomain.AaaAad(
                 dField = dField.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [MultiWordDomain.AaaAae].
         */
         fun aaaAae(
-            dField: kotlin.collections.List<Long>,
-            metas: MetaContainer = emptyMetaContainer()
+                    dField: kotlin.collections.List<Long>,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = dField.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AaaAae].
@@ -5234,25 +5234,25 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aaaAae_(
-            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-            metas: MetaContainer = emptyMetaContainer()
+                    dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = dField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AaaAae].
         */
         fun aaaAae(
-            dField0: Long,
-            dField1: Long,
-            vararg dField: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    dField0: Long,
+                    dField1: Long,
+                    vararg dField: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AaaAae].
@@ -5262,28 +5262,28 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aaaAae_(
-            dField0: org.partiql.pig.runtime.LongPrimitive,
-            dField1: org.partiql.pig.runtime.LongPrimitive,
-            vararg dField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    dField0: org.partiql.pig.runtime.LongPrimitive,
+                    dField1: org.partiql.pig.runtime.LongPrimitive,
+                    vararg dField: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AaaAae =
             MultiWordDomain.AaaAae(
                 dField = listOfPrimitives(dField0, dField1) + dField.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [MultiWordDomain.AabAaa].
         */
         fun aabAaa(
-            bField: Long,
-            cField: String,
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: Long,
+                    cField: String,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAaa =
             MultiWordDomain.AabAaa(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AabAaa].
@@ -5293,30 +5293,30 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aabAaa_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: org.partiql.pig.runtime.LongPrimitive,
+                    cField: org.partiql.pig.runtime.SymbolPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAaa =
             MultiWordDomain.AabAaa(
                 bField = bField,
                 cField = cField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [MultiWordDomain.AabAab].
         */
         fun aabAab(
-            bField: Long,
-            cField: String,
-            dField: Long? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: Long,
+                    cField: String,
+                    dField: Long? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAab =
             MultiWordDomain.AabAab(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
                 dField = dField?.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AabAab].
@@ -5326,34 +5326,34 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aabAab_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            dField: org.partiql.pig.runtime.LongPrimitive? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: org.partiql.pig.runtime.LongPrimitive,
+                    cField: org.partiql.pig.runtime.SymbolPrimitive,
+                    dField: org.partiql.pig.runtime.LongPrimitive? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAab =
             MultiWordDomain.AabAab(
                 bField = bField,
                 cField = cField,
                 dField = dField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [MultiWordDomain.AabAac].
         */
         fun aabAac(
-            bField: Long,
-            cField: String,
-            dField: Long? = null,
-            eField: String? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: Long,
+                    cField: String,
+                    dField: Long? = null,
+                    eField: String? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAac =
             MultiWordDomain.AabAac(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
                 dField = dField?.asPrimitive(),
                 eField = eField?.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AabAac].
@@ -5363,34 +5363,34 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aabAac_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            dField: org.partiql.pig.runtime.LongPrimitive? = null,
-            eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: org.partiql.pig.runtime.LongPrimitive,
+                    cField: org.partiql.pig.runtime.SymbolPrimitive,
+                    dField: org.partiql.pig.runtime.LongPrimitive? = null,
+                    eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAac =
             MultiWordDomain.AabAac(
                 bField = bField,
                 cField = cField,
                 dField = dField,
                 eField = eField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [MultiWordDomain.AabAad].
         */
         fun aabAad(
-            bField: Long,
-            cField: String,
-            dField: kotlin.collections.List<Long> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: Long,
+                    cField: String,
+                    dField: kotlin.collections.List<Long> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
                 dField = dField.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AabAad].
@@ -5400,31 +5400,31 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aabAad_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: org.partiql.pig.runtime.LongPrimitive,
+                    cField: org.partiql.pig.runtime.SymbolPrimitive,
+                    dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
                 bField = bField,
                 cField = cField,
                 dField = dField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AabAad].
         */
         fun aabAad(
-            bField: Long,
-            cField: String,
-            vararg dField: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: Long,
+                    cField: String,
+                    vararg dField: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
                 bField = bField?.asPrimitive(),
                 cField = cField?.asPrimitive(),
                 dField = dField.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AabAad].
@@ -5434,32 +5434,32 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aabAad_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            vararg dField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: org.partiql.pig.runtime.LongPrimitive,
+                    cField: org.partiql.pig.runtime.SymbolPrimitive,
+                    vararg dField: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
                 bField = bField,
                 cField = cField,
                 dField = dField.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [MultiWordDomain.AabAae].
         */
         fun aabAae(
-            bField: Long,
-            cField: String,
-            dField: kotlin.collections.List<Long>,
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: Long,
+                    cField: String,
+                    dField: kotlin.collections.List<Long>,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
                 bField = bField.asPrimitive(),
                 cField = cField.asPrimitive(),
                 dField = dField.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AabAae].
@@ -5469,33 +5469,33 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aabAae_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: org.partiql.pig.runtime.LongPrimitive,
+                    cField: org.partiql.pig.runtime.SymbolPrimitive,
+                    dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
                 bField = bField,
                 cField = cField,
                 dField = dField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AabAae].
         */
         fun aabAae(
-            bField: Long,
-            cField: String,
-            dField0: Long,
-            dField1: Long,
-            vararg dField: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: Long,
+                    cField: String,
+                    dField0: Long,
+                    dField1: Long,
+                    vararg dField: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
                 bField = bField?.asPrimitive(),
                 cField = cField?.asPrimitive(),
                 dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.AabAae].
@@ -5505,32 +5505,32 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun aabAae_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            dField0: org.partiql.pig.runtime.LongPrimitive,
-            dField1: org.partiql.pig.runtime.LongPrimitive,
-            vararg dField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    bField: org.partiql.pig.runtime.LongPrimitive,
+                    cField: org.partiql.pig.runtime.SymbolPrimitive,
+                    dField0: org.partiql.pig.runtime.LongPrimitive,
+                    dField1: org.partiql.pig.runtime.LongPrimitive,
+                    vararg dField: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
                 bField = bField,
                 cField = cField,
                 dField = listOfPrimitives(dField0, dField1) + dField.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [MultiWordDomain.Rrr].
         */
         fun rrr(
-            aField: Long,
-            bbbField: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    aField: Long,
+                    bbbField: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.Rrr =
             MultiWordDomain.Rrr(
                 aField = aField.asPrimitive(),
                 bbbField = bbbField.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.Rrr].
@@ -5540,14 +5540,14 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun rrr_(
-            aField: org.partiql.pig.runtime.LongPrimitive,
-            bbbField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    aField: org.partiql.pig.runtime.LongPrimitive,
+                    bbbField: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.Rrr =
             MultiWordDomain.Rrr(
                 aField = aField,
                 bbbField = bbbField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: SssTtt 
@@ -5555,12 +5555,12 @@ class MultiWordDomain private constructor() {
         * Creates an instance of [MultiWordDomain.SssTtt.Lll].
         */
         fun lll(
-            uField: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    uField: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Lll =
             MultiWordDomain.SssTtt.Lll(
                 uField = uField.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.SssTtt.Lll].
@@ -5570,24 +5570,24 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun lll_(
-            uField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    uField: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Lll =
             MultiWordDomain.SssTtt.Lll(
                 uField = uField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [MultiWordDomain.SssTtt.Mmm].
         */
         fun mmm(
-            vField: String,
-            metas: MetaContainer = emptyMetaContainer()
+                    vField: String,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Mmm =
             MultiWordDomain.SssTtt.Mmm(
                 vField = vField.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [MultiWordDomain.SssTtt.Mmm].
@@ -5597,12 +5597,12 @@ class MultiWordDomain private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun mmm_(
-            vField: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    vField: org.partiql.pig.runtime.SymbolPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Mmm =
             MultiWordDomain.SssTtt.Mmm(
                 vField = vField,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */
@@ -7161,12 +7161,12 @@ class DomainA private constructor() {
         * Creates an instance of [DomainA.ProductToRemove].
         */
         fun productToRemove(
-            whatever: String,
-            metas: MetaContainer = emptyMetaContainer()
+                    whatever: String,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.ProductToRemove =
             DomainA.ProductToRemove(
                 whatever = whatever.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainA.ProductToRemove].
@@ -7176,24 +7176,24 @@ class DomainA private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun productToRemove_(
-            whatever: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    whatever: org.partiql.pig.runtime.SymbolPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.ProductToRemove =
             DomainA.ProductToRemove(
                 whatever = whatever,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainA.RecordToRemove].
         */
         fun recordToRemove(
-            irrelevant: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    irrelevant: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.RecordToRemove =
             DomainA.RecordToRemove(
                 irrelevant = irrelevant.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainA.RecordToRemove].
@@ -7203,24 +7203,24 @@ class DomainA private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun recordToRemove_(
-            irrelevant: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    irrelevant: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.RecordToRemove =
             DomainA.RecordToRemove(
                 irrelevant = irrelevant,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainA.ProductA].
         */
         fun productA(
-            one: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    one: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.ProductA =
             DomainA.ProductA(
                 one = one.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainA.ProductA].
@@ -7230,24 +7230,24 @@ class DomainA private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun productA_(
-            one: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    one: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.ProductA =
             DomainA.ProductA(
                 one = one,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainA.RecordA].
         */
         fun recordA(
-            one: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    one: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.RecordA =
             DomainA.RecordA(
                 one = one.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainA.RecordA].
@@ -7257,26 +7257,26 @@ class DomainA private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun recordA_(
-            one: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    one: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.RecordA =
             DomainA.RecordA(
                 one = one,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainA.UnpermutedProduct].
         */
         fun unpermutedProduct(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: String,
+                    bar: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedProduct =
             DomainA.UnpermutedProduct(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainA.UnpermutedProduct].
@@ -7286,28 +7286,28 @@ class DomainA private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun unpermutedProduct_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: org.partiql.pig.runtime.SymbolPrimitive,
+                    bar: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedProduct =
             DomainA.UnpermutedProduct(
                 foo = foo,
                 bar = bar,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainA.UnpermutedRecord].
         */
         fun unpermutedRecord(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: String,
+                    bar: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedRecord =
             DomainA.UnpermutedRecord(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainA.UnpermutedRecord].
@@ -7317,14 +7317,14 @@ class DomainA private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun unpermutedRecord_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: org.partiql.pig.runtime.SymbolPrimitive,
+                    bar: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedRecord =
             DomainA.UnpermutedRecord(
                 foo = foo,
                 bar = bar,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: SumToRemove 
@@ -7332,20 +7332,20 @@ class DomainA private constructor() {
         * Creates an instance of [DomainA.SumToRemove.Doesnt].
         */
         fun doesnt(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumToRemove.Doesnt =
             DomainA.SumToRemove.Doesnt(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainA.SumToRemove.Matter].
         */
         fun matter(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumToRemove.Matter =
             DomainA.SumToRemove.Matter(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: SumA 
@@ -7353,20 +7353,20 @@ class DomainA private constructor() {
         * Creates an instance of [DomainA.SumA.Who].
         */
         fun who(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumA.Who =
             DomainA.SumA.Who(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainA.SumA.Cares].
         */
         fun cares(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumA.Cares =
             DomainA.SumA.Cares(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: SumB 
@@ -7374,32 +7374,32 @@ class DomainA private constructor() {
         * Creates an instance of [DomainA.SumB.WillBeUnchanged].
         */
         fun willBeUnchanged(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumB.WillBeUnchanged =
             DomainA.SumB.WillBeUnchanged(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainA.SumB.WillBeRemoved].
         */
         fun willBeRemoved(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumB.WillBeRemoved =
             DomainA.SumB.WillBeRemoved(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainA.SumB.WillBeReplaced].
         */
         fun willBeReplaced(
-            something: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    something: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumB.WillBeReplaced =
             DomainA.SumB.WillBeReplaced(
                 something = something.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainA.SumB.WillBeReplaced].
@@ -7409,12 +7409,12 @@ class DomainA private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun willBeReplaced_(
-            something: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    something: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.SumB.WillBeReplaced =
             DomainA.SumB.WillBeReplaced(
                 something = something,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: UnpermutedSum 
@@ -7422,14 +7422,14 @@ class DomainA private constructor() {
         * Creates an instance of [DomainA.UnpermutedSum.UnpermutedProductVariant].
         */
         fun unpermutedProductVariant(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: String,
+                    bar: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedSum.UnpermutedProductVariant =
             DomainA.UnpermutedSum.UnpermutedProductVariant(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainA.UnpermutedSum.UnpermutedProductVariant].
@@ -7439,28 +7439,28 @@ class DomainA private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun unpermutedProductVariant_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: org.partiql.pig.runtime.SymbolPrimitive,
+                    bar: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedSum.UnpermutedProductVariant =
             DomainA.UnpermutedSum.UnpermutedProductVariant(
                 foo = foo,
                 bar = bar,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainA.UnpermutedSum.UnpermutedRecordVariant].
         */
         fun unpermutedRecordVariant(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: String,
+                    bar: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedSum.UnpermutedRecordVariant =
             DomainA.UnpermutedSum.UnpermutedRecordVariant(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainA.UnpermutedSum.UnpermutedRecordVariant].
@@ -7470,14 +7470,14 @@ class DomainA private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun unpermutedRecordVariant_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: org.partiql.pig.runtime.SymbolPrimitive,
+                    bar: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainA.UnpermutedSum.UnpermutedRecordVariant =
             DomainA.UnpermutedSum.UnpermutedRecordVariant(
                 foo = foo,
                 bar = bar,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */
@@ -9145,14 +9145,14 @@ class DomainB private constructor() {
         * Creates an instance of [DomainB.UnpermutedProduct].
         */
         fun unpermutedProduct(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: String,
+                    bar: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedProduct =
             DomainB.UnpermutedProduct(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainB.UnpermutedProduct].
@@ -9162,28 +9162,28 @@ class DomainB private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun unpermutedProduct_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: org.partiql.pig.runtime.SymbolPrimitive,
+                    bar: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedProduct =
             DomainB.UnpermutedProduct(
                 foo = foo,
                 bar = bar,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainB.UnpermutedRecord].
         */
         fun unpermutedRecord(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: String,
+                    bar: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedRecord =
             DomainB.UnpermutedRecord(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainB.UnpermutedRecord].
@@ -9193,26 +9193,26 @@ class DomainB private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun unpermutedRecord_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: org.partiql.pig.runtime.SymbolPrimitive,
+                    bar: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedRecord =
             DomainB.UnpermutedRecord(
                 foo = foo,
                 bar = bar,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainB.ProductA].
         */
         fun productA(
-            one: String,
-            metas: MetaContainer = emptyMetaContainer()
+                    one: String,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.ProductA =
             DomainB.ProductA(
                 one = one.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainB.ProductA].
@@ -9222,24 +9222,24 @@ class DomainB private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun productA_(
-            one: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    one: org.partiql.pig.runtime.SymbolPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.ProductA =
             DomainB.ProductA(
                 one = one,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainB.RecordA].
         */
         fun recordA(
-            one: String,
-            metas: MetaContainer = emptyMetaContainer()
+                    one: String,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.RecordA =
             DomainB.RecordA(
                 one = one.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainB.RecordA].
@@ -9249,24 +9249,24 @@ class DomainB private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun recordA_(
-            one: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    one: org.partiql.pig.runtime.SymbolPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.RecordA =
             DomainB.RecordA(
                 one = one,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainB.NewProduct].
         */
         fun newProduct(
-            foo: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewProduct =
             DomainB.NewProduct(
                 foo = foo.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainB.NewProduct].
@@ -9276,24 +9276,24 @@ class DomainB private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun newProduct_(
-            foo: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewProduct =
             DomainB.NewProduct(
                 foo = foo,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainB.NewRecord].
         */
         fun newRecord(
-            foo: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewRecord =
             DomainB.NewRecord(
                 foo = foo.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainB.NewRecord].
@@ -9303,12 +9303,12 @@ class DomainB private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun newRecord_(
-            foo: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewRecord =
             DomainB.NewRecord(
                 foo = foo,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: UnpermutedSum 
@@ -9316,14 +9316,14 @@ class DomainB private constructor() {
         * Creates an instance of [DomainB.UnpermutedSum.UnpermutedProductVariant].
         */
         fun unpermutedProductVariant(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: String,
+                    bar: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedSum.UnpermutedProductVariant =
             DomainB.UnpermutedSum.UnpermutedProductVariant(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainB.UnpermutedSum.UnpermutedProductVariant].
@@ -9333,28 +9333,28 @@ class DomainB private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun unpermutedProductVariant_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: org.partiql.pig.runtime.SymbolPrimitive,
+                    bar: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedSum.UnpermutedProductVariant =
             DomainB.UnpermutedSum.UnpermutedProductVariant(
                 foo = foo,
                 bar = bar,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainB.UnpermutedSum.UnpermutedRecordVariant].
         */
         fun unpermutedRecordVariant(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: String,
+                    bar: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedSum.UnpermutedRecordVariant =
             DomainB.UnpermutedSum.UnpermutedRecordVariant(
                 foo = foo.asPrimitive(),
                 bar = bar.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainB.UnpermutedSum.UnpermutedRecordVariant].
@@ -9364,14 +9364,14 @@ class DomainB private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun unpermutedRecordVariant_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    foo: org.partiql.pig.runtime.SymbolPrimitive,
+                    bar: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.UnpermutedSum.UnpermutedRecordVariant =
             DomainB.UnpermutedSum.UnpermutedRecordVariant(
                 foo = foo,
                 bar = bar,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: SumB 
@@ -9379,22 +9379,22 @@ class DomainB private constructor() {
         * Creates an instance of [DomainB.SumB.WillBeUnchanged].
         */
         fun willBeUnchanged(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.SumB.WillBeUnchanged =
             DomainB.SumB.WillBeUnchanged(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainB.SumB.WillBeReplaced].
         */
         fun willBeReplaced(
-            something: String,
-            metas: MetaContainer = emptyMetaContainer()
+                    something: String,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.SumB.WillBeReplaced =
             DomainB.SumB.WillBeReplaced(
                 something = something.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [DomainB.SumB.WillBeReplaced].
@@ -9404,12 +9404,12 @@ class DomainB private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun willBeReplaced_(
-            something: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    something: org.partiql.pig.runtime.SymbolPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.SumB.WillBeReplaced =
             DomainB.SumB.WillBeReplaced(
                 something = something,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: NewSum 
@@ -9417,20 +9417,20 @@ class DomainB private constructor() {
         * Creates an instance of [DomainB.NewSum.Eek].
         */
         fun eek(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewSum.Eek =
             DomainB.NewSum.Eek(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [DomainB.NewSum.Whatever].
         */
         fun whatever(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewSum.Whatever =
             DomainB.NewSum.Whatever(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */

--- a/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/sample-universe.kt
@@ -30,706 +30,945 @@ class TestDomain private constructor() {
     }
     
     interface Builder {
-                // Tuples
+        fun newMetaContainer() = emptyMetaContainer()
+    
+                    // Tuples
         /**
-         * Creates an instance of [TestDomain.BoolPair].
-         */
+        * Creates an instance of [TestDomain.BoolPair].
+        */
         fun boolPair(
             first: Boolean,
             second: Boolean,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.BoolPair
+        ): TestDomain.BoolPair =
+            TestDomain.BoolPair(
+                first = first.asPrimitive(),
+                second = second.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.BoolPair].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.BoolPair].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun boolPair_(
             first: org.partiql.pig.runtime.BoolPrimitive,
             second: org.partiql.pig.runtime.BoolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.BoolPair
+        ): TestDomain.BoolPair =
+            TestDomain.BoolPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.IntPair].
-         */
+        * Creates an instance of [TestDomain.IntPair].
+        */
         fun intPair(
             first: Long,
             second: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntPair
+        ): TestDomain.IntPair =
+            TestDomain.IntPair(
+                first = first.asPrimitive(),
+                second = second.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.IntPair].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.IntPair].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun intPair_(
             first: org.partiql.pig.runtime.LongPrimitive,
             second: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntPair
+        ): TestDomain.IntPair =
+            TestDomain.IntPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.SymbolPair].
-         */
+        * Creates an instance of [TestDomain.SymbolPair].
+        */
         fun symbolPair(
             first: String,
             second: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolPair
+        ): TestDomain.SymbolPair =
+            TestDomain.SymbolPair(
+                first = first.asPrimitive(),
+                second = second.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.SymbolPair].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.SymbolPair].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun symbolPair_(
             first: org.partiql.pig.runtime.SymbolPrimitive,
             second: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolPair
+        ): TestDomain.SymbolPair =
+            TestDomain.SymbolPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.IonPair].
-         */
+        * Creates an instance of [TestDomain.IonPair].
+        */
         fun ionPair(
             first: com.amazon.ionelement.api.IonElement,
             second: com.amazon.ionelement.api.IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IonPair
+        ): TestDomain.IonPair =
+            TestDomain.IonPair(
+                first = first.asAnyElement(),
+                second = second.asAnyElement(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.IntSymbolPair].
-         */
+        * Creates an instance of [TestDomain.IntSymbolPair].
+        */
         fun intSymbolPair(
             first: Long,
             second: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntSymbolPair
+        ): TestDomain.IntSymbolPair =
+            TestDomain.IntSymbolPair(
+                first = first.asPrimitive(),
+                second = second.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.IntSymbolPair].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.IntSymbolPair].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun intSymbolPair_(
             first: org.partiql.pig.runtime.LongPrimitive,
             second: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntSymbolPair
+        ): TestDomain.IntSymbolPair =
+            TestDomain.IntSymbolPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.SymbolIntPair].
-         */
+        * Creates an instance of [TestDomain.SymbolIntPair].
+        */
         fun symbolIntPair(
             first: String,
             second: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolIntPair
+        ): TestDomain.SymbolIntPair =
+            TestDomain.SymbolIntPair(
+                first = first.asPrimitive(),
+                second = second.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.SymbolIntPair].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.SymbolIntPair].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun symbolIntPair_(
             first: org.partiql.pig.runtime.SymbolPrimitive,
             second: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolIntPair
+        ): TestDomain.SymbolIntPair =
+            TestDomain.SymbolIntPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.IonIntPair].
-         */
+        * Creates an instance of [TestDomain.IonIntPair].
+        */
         fun ionIntPair(
             first: com.amazon.ionelement.api.IonElement,
             second: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IonIntPair
+        ): TestDomain.IonIntPair =
+            TestDomain.IonIntPair(
+                first = first.asAnyElement(),
+                second = second.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.IonIntPair].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.IonIntPair].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun ionIntPair_(
             first: com.amazon.ionelement.api.IonElement,
             second: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IonIntPair
+        ): TestDomain.IonIntPair =
+            TestDomain.IonIntPair(
+                first = first.asAnyElement(),
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.IonSymbolPair].
-         */
+        * Creates an instance of [TestDomain.IonSymbolPair].
+        */
         fun ionSymbolPair(
             first: com.amazon.ionelement.api.IonElement,
             second: com.amazon.ionelement.api.IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IonSymbolPair
+        ): TestDomain.IonSymbolPair =
+            TestDomain.IonSymbolPair(
+                first = first.asAnyElement(),
+                second = second.asAnyElement(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.IntPairPair].
-         */
+        * Creates an instance of [TestDomain.IntPairPair].
+        */
         fun intPairPair(
             first: IntPair,
             second: IntPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntPairPair
+        ): TestDomain.IntPairPair =
+            TestDomain.IntPairPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.SymbolPairPair].
-         */
+        * Creates an instance of [TestDomain.SymbolPairPair].
+        */
         fun symbolPairPair(
             first: SymbolPair,
             second: SymbolPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolPairPair
+        ): TestDomain.SymbolPairPair =
+            TestDomain.SymbolPairPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.IonPairPair].
-         */
+        * Creates an instance of [TestDomain.IonPairPair].
+        */
         fun ionPairPair(
             first: IonPair,
             second: IonPair,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IonPairPair
+        ): TestDomain.IonPairPair =
+            TestDomain.IonPairPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.RecursivePair].
-         */
+        * Creates an instance of [TestDomain.RecursivePair].
+        */
         fun recursivePair(
             first: Long,
             second: RecursivePair? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.RecursivePair
+        ): TestDomain.RecursivePair =
+            TestDomain.RecursivePair(
+                first = first.asPrimitive(),
+                second = second,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.RecursivePair].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.RecursivePair].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun recursivePair_(
             first: org.partiql.pig.runtime.LongPrimitive,
             second: RecursivePair? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.RecursivePair
+        ): TestDomain.RecursivePair =
+            TestDomain.RecursivePair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.AnswerPair].
-         */
+        * Creates an instance of [TestDomain.AnswerPair].
+        */
         fun answerPair(
             first: Answer,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.AnswerPair
+        ): TestDomain.AnswerPair =
+            TestDomain.AnswerPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.AnswerIntPair].
-         */
+        * Creates an instance of [TestDomain.AnswerIntPair].
+        */
         fun answerIntPair(
             first: Answer,
             second: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.AnswerIntPair
+        ): TestDomain.AnswerIntPair =
+            TestDomain.AnswerIntPair(
+                first = first,
+                second = second.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.AnswerIntPair].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.AnswerIntPair].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun answerIntPair_(
             first: Answer,
             second: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.AnswerIntPair
+        ): TestDomain.AnswerIntPair =
+            TestDomain.AnswerIntPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.IntAnswerPair].
-         */
+        * Creates an instance of [TestDomain.IntAnswerPair].
+        */
         fun intAnswerPair(
             first: Long,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntAnswerPair
+        ): TestDomain.IntAnswerPair =
+            TestDomain.IntAnswerPair(
+                first = first.asPrimitive(),
+                second = second,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.IntAnswerPair].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.IntAnswerPair].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun intAnswerPair_(
             first: org.partiql.pig.runtime.LongPrimitive,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.IntAnswerPair
+        ): TestDomain.IntAnswerPair =
+            TestDomain.IntAnswerPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.SymbolAnswerPair].
-         */
+        * Creates an instance of [TestDomain.SymbolAnswerPair].
+        */
         fun symbolAnswerPair(
             first: String,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolAnswerPair
+        ): TestDomain.SymbolAnswerPair =
+            TestDomain.SymbolAnswerPair(
+                first = first.asPrimitive(),
+                second = second,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.SymbolAnswerPair].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.SymbolAnswerPair].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun symbolAnswerPair_(
             first: org.partiql.pig.runtime.SymbolPrimitive,
             second: Answer,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SymbolAnswerPair
+        ): TestDomain.SymbolAnswerPair =
+            TestDomain.SymbolAnswerPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.AnswerSymbolPair].
-         */
+        * Creates an instance of [TestDomain.AnswerSymbolPair].
+        */
         fun answerSymbolPair(
             first: Answer,
             second: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.AnswerSymbolPair
+        ): TestDomain.AnswerSymbolPair =
+            TestDomain.AnswerSymbolPair(
+                first = first,
+                second = second.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.AnswerSymbolPair].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.AnswerSymbolPair].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun answerSymbolPair_(
             first: Answer,
             second: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.AnswerSymbolPair
+        ): TestDomain.AnswerSymbolPair =
+            TestDomain.AnswerSymbolPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.VariadicMin0].
-         */
+        * Creates an instance of [TestDomain.VariadicMin0].
+        */
         fun variadicMin0(
             ints: kotlin.collections.List<Long> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin0
+        ): TestDomain.VariadicMin0 =
+            TestDomain.VariadicMin0(
+                ints = ints.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.VariadicMin0].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.VariadicMin0].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun variadicMin0_(
             ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin0
+        ): TestDomain.VariadicMin0 =
+            TestDomain.VariadicMin0(
+                ints = ints,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.VariadicMin0].
-         */
+        * Creates an instance of [TestDomain.VariadicMin0].
+        */
         fun variadicMin0(
             vararg ints: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin0
+        ): TestDomain.VariadicMin0 =
+            TestDomain.VariadicMin0(
+                ints = ints.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.VariadicMin0].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.VariadicMin0].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun variadicMin0_(
             vararg ints: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin0
+        ): TestDomain.VariadicMin0 =
+            TestDomain.VariadicMin0(
+                ints = ints.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.VariadicMin1].
-         */
+        * Creates an instance of [TestDomain.VariadicMin1].
+        */
         fun variadicMin1(
             ints: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin1
+        ): TestDomain.VariadicMin1 =
+            TestDomain.VariadicMin1(
+                ints = ints.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.VariadicMin1].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.VariadicMin1].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun variadicMin1_(
             ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin1
+        ): TestDomain.VariadicMin1 =
+            TestDomain.VariadicMin1(
+                ints = ints,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.VariadicMin1].
-         */
+        * Creates an instance of [TestDomain.VariadicMin1].
+        */
         fun variadicMin1(
             ints0: Long,
             vararg ints: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin1
+        ): TestDomain.VariadicMin1 =
+            TestDomain.VariadicMin1(
+                ints = listOfPrimitives(ints0) + ints.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.VariadicMin1].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.VariadicMin1].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun variadicMin1_(
             ints0: org.partiql.pig.runtime.LongPrimitive,
             vararg ints: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.VariadicMin1
+        ): TestDomain.VariadicMin1 =
+            TestDomain.VariadicMin1(
+                ints = listOfPrimitives(ints0) + ints.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.ElementVariadic].
-         */
+        * Creates an instance of [TestDomain.ElementVariadic].
+        */
         fun elementVariadic(
             name: String,
             ints: kotlin.collections.List<Long> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.ElementVariadic
+        ): TestDomain.ElementVariadic =
+            TestDomain.ElementVariadic(
+                name = name.asPrimitive(),
+                ints = ints.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.ElementVariadic].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.ElementVariadic].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun elementVariadic_(
             name: org.partiql.pig.runtime.SymbolPrimitive,
             ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.ElementVariadic
+        ): TestDomain.ElementVariadic =
+            TestDomain.ElementVariadic(
+                name = name,
+                ints = ints,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.ElementVariadic].
-         */
+        * Creates an instance of [TestDomain.ElementVariadic].
+        */
         fun elementVariadic(
             name: String,
             vararg ints: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.ElementVariadic
+        ): TestDomain.ElementVariadic =
+            TestDomain.ElementVariadic(
+                name = name?.asPrimitive(),
+                ints = ints.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.ElementVariadic].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.ElementVariadic].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun elementVariadic_(
             name: org.partiql.pig.runtime.SymbolPrimitive,
             vararg ints: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.ElementVariadic
+        ): TestDomain.ElementVariadic =
+            TestDomain.ElementVariadic(
+                name = name,
+                ints = ints.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.Optional1].
-         */
+        * Creates an instance of [TestDomain.Optional1].
+        */
         fun optional1(
             value: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Optional1
+        ): TestDomain.Optional1 =
+            TestDomain.Optional1(
+                value = value?.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.Optional1].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.Optional1].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun optional1_(
             value: org.partiql.pig.runtime.LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Optional1
+        ): TestDomain.Optional1 =
+            TestDomain.Optional1(
+                value = value,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.Optional2].
-         */
+        * Creates an instance of [TestDomain.Optional2].
+        */
         fun optional2(
             first: Long? = null,
             second: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Optional2
+        ): TestDomain.Optional2 =
+            TestDomain.Optional2(
+                first = first?.asPrimitive(),
+                second = second?.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.Optional2].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.Optional2].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun optional2_(
             first: org.partiql.pig.runtime.LongPrimitive? = null,
             second: org.partiql.pig.runtime.LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Optional2
+        ): TestDomain.Optional2 =
+            TestDomain.Optional2(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.DomainLevelRecord].
-         */
+        * Creates an instance of [TestDomain.DomainLevelRecord].
+        */
         fun domainLevelRecord(
             someField: Long,
             anotherField: String,
             optionalField: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.DomainLevelRecord
+        ): TestDomain.DomainLevelRecord =
+            TestDomain.DomainLevelRecord(
+                someField = someField.asPrimitive(),
+                anotherField = anotherField.asPrimitive(),
+                optionalField = optionalField?.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.DomainLevelRecord].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.DomainLevelRecord].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun domainLevelRecord_(
             someField: org.partiql.pig.runtime.LongPrimitive,
             anotherField: org.partiql.pig.runtime.SymbolPrimitive,
             optionalField: org.partiql.pig.runtime.LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.DomainLevelRecord
+        ): TestDomain.DomainLevelRecord =
+            TestDomain.DomainLevelRecord(
+                someField = someField,
+                anotherField = anotherField,
+                optionalField = optionalField,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.ProductWithRecord].
-         */
+        * Creates an instance of [TestDomain.ProductWithRecord].
+        */
         fun productWithRecord(
             value: Long,
             dlr: DomainLevelRecord,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.ProductWithRecord
+        ): TestDomain.ProductWithRecord =
+            TestDomain.ProductWithRecord(
+                value = value.asPrimitive(),
+                dlr = dlr,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.ProductWithRecord].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.ProductWithRecord].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun productWithRecord_(
             value: org.partiql.pig.runtime.LongPrimitive,
             dlr: DomainLevelRecord,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.ProductWithRecord
+        ): TestDomain.ProductWithRecord =
+            TestDomain.ProductWithRecord(
+                value = value,
+                dlr = dlr,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.TestSumTriplet].
-         */
+        * Creates an instance of [TestDomain.TestSumTriplet].
+        */
         fun testSumTriplet(
             a: TestSum,
             b: TestSum,
             c: TestSum,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSumTriplet
+        ): TestDomain.TestSumTriplet =
+            TestDomain.TestSumTriplet(
+                a = a,
+                b = b,
+                c = c,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.EntityPair].
-         */
+        * Creates an instance of [TestDomain.EntityPair].
+        */
         fun entityPair(
             first: Entity,
             second: Entity,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.EntityPair
+        ): TestDomain.EntityPair =
+            TestDomain.EntityPair(
+                first = first,
+                second = second,
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: Answer 
         /**
-         * Creates an instance of [TestDomain.Answer.No].
-         */
+        * Creates an instance of [TestDomain.Answer.No].
+        */
         fun no(
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Answer.No
+        ): TestDomain.Answer.No =
+            TestDomain.Answer.No(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.Answer.Yes].
-         */
+        * Creates an instance of [TestDomain.Answer.Yes].
+        */
         fun yes(
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Answer.Yes
+        ): TestDomain.Answer.Yes =
+            TestDomain.Answer.Yes(
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: SumWithRecord 
         /**
-         * Creates an instance of [TestDomain.SumWithRecord.VariantWithRecord].
-         */
+        * Creates an instance of [TestDomain.SumWithRecord.VariantWithRecord].
+        */
         fun variantWithRecord(
             value: Long,
             dlr: DomainLevelRecord,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SumWithRecord.VariantWithRecord
+        ): TestDomain.SumWithRecord.VariantWithRecord =
+            TestDomain.SumWithRecord.VariantWithRecord(
+                value = value.asPrimitive(),
+                dlr = dlr,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.SumWithRecord.VariantWithRecord].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.SumWithRecord.VariantWithRecord].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun variantWithRecord_(
             value: org.partiql.pig.runtime.LongPrimitive,
             dlr: DomainLevelRecord,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.SumWithRecord.VariantWithRecord
+        ): TestDomain.SumWithRecord.VariantWithRecord =
+            TestDomain.SumWithRecord.VariantWithRecord(
+                value = value,
+                dlr = dlr,
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: TestSum 
         /**
-         * Creates an instance of [TestDomain.TestSum.One].
-         */
+        * Creates an instance of [TestDomain.TestSum.One].
+        */
         fun one(
             a: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSum.One
+        ): TestDomain.TestSum.One =
+            TestDomain.TestSum.One(
+                a = a.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.TestSum.One].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.TestSum.One].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun one_(
             a: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSum.One
+        ): TestDomain.TestSum.One =
+            TestDomain.TestSum.One(
+                a = a,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.TestSum.Two].
-         */
+        * Creates an instance of [TestDomain.TestSum.Two].
+        */
         fun two(
             a: Long,
             b: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSum.Two
+        ): TestDomain.TestSum.Two =
+            TestDomain.TestSum.Two(
+                a = a.asPrimitive(),
+                b = b.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.TestSum.Two].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.TestSum.Two].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun two_(
             a: org.partiql.pig.runtime.LongPrimitive,
             b: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSum.Two
+        ): TestDomain.TestSum.Two =
+            TestDomain.TestSum.Two(
+                a = a,
+                b = b,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.TestSum.Three].
-         */
+        * Creates an instance of [TestDomain.TestSum.Three].
+        */
         fun three(
             a: Long,
             b: Long,
             c: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSum.Three
+        ): TestDomain.TestSum.Three =
+            TestDomain.TestSum.Three(
+                a = a.asPrimitive(),
+                b = b.asPrimitive(),
+                c = c.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.TestSum.Three].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.TestSum.Three].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun three_(
             a: org.partiql.pig.runtime.LongPrimitive,
             b: org.partiql.pig.runtime.LongPrimitive,
             c: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.TestSum.Three
+        ): TestDomain.TestSum.Three =
+            TestDomain.TestSum.Three(
+                a = a,
+                b = b,
+                c = c,
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: Entity 
         /**
-         * Creates an instance of [TestDomain.Entity.Slug].
-         */
+        * Creates an instance of [TestDomain.Entity.Slug].
+        */
         fun slug(
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Entity.Slug
+        ): TestDomain.Entity.Slug =
+            TestDomain.Entity.Slug(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.Entity.Android].
-         */
+        * Creates an instance of [TestDomain.Entity.Android].
+        */
         fun android(
             id: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Entity.Android
+        ): TestDomain.Entity.Android =
+            TestDomain.Entity.Android(
+                id = id.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [TestDomain.Entity.Android].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [TestDomain.Entity.Android].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun android_(
             id: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Entity.Android
+        ): TestDomain.Entity.Android =
+            TestDomain.Entity.Android(
+                id = id,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [TestDomain.Entity.Human].
-         */
+        * Creates an instance of [TestDomain.Entity.Human].
+        */
         fun human(
             firstName: String,
             middleNames: kotlin.collections.List<String> = emptyList(),
@@ -737,674 +976,6 @@ class TestDomain private constructor() {
             title: String? = null,
             parent: Entity? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Entity.Human
-        
-        /**
-         * Creates an instance of [TestDomain.Entity.Human].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
-        fun human_(
-            firstName: org.partiql.pig.runtime.SymbolPrimitive,
-            middleNames: kotlin.collections.List<org.partiql.pig.runtime.SymbolPrimitive> = emptyList(),
-            lastName: org.partiql.pig.runtime.SymbolPrimitive,
-            title: org.partiql.pig.runtime.SymbolPrimitive? = null,
-            parent: Entity? = null,
-            metas: MetaContainer = emptyMetaContainer()
-        ): TestDomain.Entity.Human
-    }
-    
-    private object TestDomainBuilder : Builder {
-                // Tuples
-        override fun boolPair(
-            first: Boolean,
-            second: Boolean,
-            metas: MetaContainer
-        ): TestDomain.BoolPair =
-            TestDomain.BoolPair(
-                first = first.asPrimitive(),
-                second = second.asPrimitive(),
-                metas = metas)
-        
-        override fun boolPair_(
-            first: org.partiql.pig.runtime.BoolPrimitive,
-            second: org.partiql.pig.runtime.BoolPrimitive,
-            metas: MetaContainer
-        ): TestDomain.BoolPair =
-            TestDomain.BoolPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun intPair(
-            first: Long,
-            second: Long,
-            metas: MetaContainer
-        ): TestDomain.IntPair =
-            TestDomain.IntPair(
-                first = first.asPrimitive(),
-                second = second.asPrimitive(),
-                metas = metas)
-        
-        override fun intPair_(
-            first: org.partiql.pig.runtime.LongPrimitive,
-            second: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): TestDomain.IntPair =
-            TestDomain.IntPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun symbolPair(
-            first: String,
-            second: String,
-            metas: MetaContainer
-        ): TestDomain.SymbolPair =
-            TestDomain.SymbolPair(
-                first = first.asPrimitive(),
-                second = second.asPrimitive(),
-                metas = metas)
-        
-        override fun symbolPair_(
-            first: org.partiql.pig.runtime.SymbolPrimitive,
-            second: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer
-        ): TestDomain.SymbolPair =
-            TestDomain.SymbolPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun ionPair(
-            first: com.amazon.ionelement.api.IonElement,
-            second: com.amazon.ionelement.api.IonElement,
-            metas: MetaContainer
-        ): TestDomain.IonPair =
-            TestDomain.IonPair(
-                first = first.asAnyElement(),
-                second = second.asAnyElement(),
-                metas = metas)
-        
-        
-        override fun intSymbolPair(
-            first: Long,
-            second: String,
-            metas: MetaContainer
-        ): TestDomain.IntSymbolPair =
-            TestDomain.IntSymbolPair(
-                first = first.asPrimitive(),
-                second = second.asPrimitive(),
-                metas = metas)
-        
-        override fun intSymbolPair_(
-            first: org.partiql.pig.runtime.LongPrimitive,
-            second: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer
-        ): TestDomain.IntSymbolPair =
-            TestDomain.IntSymbolPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun symbolIntPair(
-            first: String,
-            second: Long,
-            metas: MetaContainer
-        ): TestDomain.SymbolIntPair =
-            TestDomain.SymbolIntPair(
-                first = first.asPrimitive(),
-                second = second.asPrimitive(),
-                metas = metas)
-        
-        override fun symbolIntPair_(
-            first: org.partiql.pig.runtime.SymbolPrimitive,
-            second: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): TestDomain.SymbolIntPair =
-            TestDomain.SymbolIntPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun ionIntPair(
-            first: com.amazon.ionelement.api.IonElement,
-            second: Long,
-            metas: MetaContainer
-        ): TestDomain.IonIntPair =
-            TestDomain.IonIntPair(
-                first = first.asAnyElement(),
-                second = second.asPrimitive(),
-                metas = metas)
-        
-        override fun ionIntPair_(
-            first: com.amazon.ionelement.api.IonElement,
-            second: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): TestDomain.IonIntPair =
-            TestDomain.IonIntPair(
-                first = first.asAnyElement(),
-                second = second,
-                metas = metas)
-        
-        
-        override fun ionSymbolPair(
-            first: com.amazon.ionelement.api.IonElement,
-            second: com.amazon.ionelement.api.IonElement,
-            metas: MetaContainer
-        ): TestDomain.IonSymbolPair =
-            TestDomain.IonSymbolPair(
-                first = first.asAnyElement(),
-                second = second.asAnyElement(),
-                metas = metas)
-        
-        
-        override fun intPairPair(
-            first: IntPair,
-            second: IntPair,
-            metas: MetaContainer
-        ): TestDomain.IntPairPair =
-            TestDomain.IntPairPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun symbolPairPair(
-            first: SymbolPair,
-            second: SymbolPair,
-            metas: MetaContainer
-        ): TestDomain.SymbolPairPair =
-            TestDomain.SymbolPairPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun ionPairPair(
-            first: IonPair,
-            second: IonPair,
-            metas: MetaContainer
-        ): TestDomain.IonPairPair =
-            TestDomain.IonPairPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun recursivePair(
-            first: Long,
-            second: RecursivePair?,
-            metas: MetaContainer
-        ): TestDomain.RecursivePair =
-            TestDomain.RecursivePair(
-                first = first.asPrimitive(),
-                second = second,
-                metas = metas)
-        
-        override fun recursivePair_(
-            first: org.partiql.pig.runtime.LongPrimitive,
-            second: RecursivePair?,
-            metas: MetaContainer
-        ): TestDomain.RecursivePair =
-            TestDomain.RecursivePair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun answerPair(
-            first: Answer,
-            second: Answer,
-            metas: MetaContainer
-        ): TestDomain.AnswerPair =
-            TestDomain.AnswerPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun answerIntPair(
-            first: Answer,
-            second: Long,
-            metas: MetaContainer
-        ): TestDomain.AnswerIntPair =
-            TestDomain.AnswerIntPair(
-                first = first,
-                second = second.asPrimitive(),
-                metas = metas)
-        
-        override fun answerIntPair_(
-            first: Answer,
-            second: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): TestDomain.AnswerIntPair =
-            TestDomain.AnswerIntPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun intAnswerPair(
-            first: Long,
-            second: Answer,
-            metas: MetaContainer
-        ): TestDomain.IntAnswerPair =
-            TestDomain.IntAnswerPair(
-                first = first.asPrimitive(),
-                second = second,
-                metas = metas)
-        
-        override fun intAnswerPair_(
-            first: org.partiql.pig.runtime.LongPrimitive,
-            second: Answer,
-            metas: MetaContainer
-        ): TestDomain.IntAnswerPair =
-            TestDomain.IntAnswerPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun symbolAnswerPair(
-            first: String,
-            second: Answer,
-            metas: MetaContainer
-        ): TestDomain.SymbolAnswerPair =
-            TestDomain.SymbolAnswerPair(
-                first = first.asPrimitive(),
-                second = second,
-                metas = metas)
-        
-        override fun symbolAnswerPair_(
-            first: org.partiql.pig.runtime.SymbolPrimitive,
-            second: Answer,
-            metas: MetaContainer
-        ): TestDomain.SymbolAnswerPair =
-            TestDomain.SymbolAnswerPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun answerSymbolPair(
-            first: Answer,
-            second: String,
-            metas: MetaContainer
-        ): TestDomain.AnswerSymbolPair =
-            TestDomain.AnswerSymbolPair(
-                first = first,
-                second = second.asPrimitive(),
-                metas = metas)
-        
-        override fun answerSymbolPair_(
-            first: Answer,
-            second: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer
-        ): TestDomain.AnswerSymbolPair =
-            TestDomain.AnswerSymbolPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun variadicMin0(
-            ints: kotlin.collections.List<Long>,
-            metas: MetaContainer
-        ): TestDomain.VariadicMin0 =
-            TestDomain.VariadicMin0(
-                ints = ints.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun variadicMin0_(
-            ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-            metas: MetaContainer
-        ): TestDomain.VariadicMin0 =
-            TestDomain.VariadicMin0(
-                ints = ints,
-                metas = metas)
-        
-        override fun variadicMin0(
-            vararg ints: Long,
-            metas: MetaContainer
-        ): TestDomain.VariadicMin0 =
-            TestDomain.VariadicMin0(
-                ints = ints.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun variadicMin0_(
-            vararg ints: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): TestDomain.VariadicMin0 =
-            TestDomain.VariadicMin0(
-                ints = ints.toList(),
-                metas = metas)
-        
-        
-        override fun variadicMin1(
-            ints: kotlin.collections.List<Long>,
-            metas: MetaContainer
-        ): TestDomain.VariadicMin1 =
-            TestDomain.VariadicMin1(
-                ints = ints.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun variadicMin1_(
-            ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-            metas: MetaContainer
-        ): TestDomain.VariadicMin1 =
-            TestDomain.VariadicMin1(
-                ints = ints,
-                metas = metas)
-        
-        override fun variadicMin1(
-            ints0: Long,
-            vararg ints: Long,
-            metas: MetaContainer
-        ): TestDomain.VariadicMin1 =
-            TestDomain.VariadicMin1(
-                ints = listOfPrimitives(ints0) + ints.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun variadicMin1_(
-            ints0: org.partiql.pig.runtime.LongPrimitive,
-            vararg ints: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): TestDomain.VariadicMin1 =
-            TestDomain.VariadicMin1(
-                ints = listOfPrimitives(ints0) + ints.toList(),
-                metas = metas)
-        
-        
-        override fun elementVariadic(
-            name: String,
-            ints: kotlin.collections.List<Long>,
-            metas: MetaContainer
-        ): TestDomain.ElementVariadic =
-            TestDomain.ElementVariadic(
-                name = name.asPrimitive(),
-                ints = ints.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun elementVariadic_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            ints: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-            metas: MetaContainer
-        ): TestDomain.ElementVariadic =
-            TestDomain.ElementVariadic(
-                name = name,
-                ints = ints,
-                metas = metas)
-        
-        override fun elementVariadic(
-            name: String,
-            vararg ints: Long,
-            metas: MetaContainer
-        ): TestDomain.ElementVariadic =
-            TestDomain.ElementVariadic(
-                name = name?.asPrimitive(),
-                ints = ints.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun elementVariadic_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            vararg ints: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): TestDomain.ElementVariadic =
-            TestDomain.ElementVariadic(
-                name = name,
-                ints = ints.toList(),
-                metas = metas)
-        
-        
-        override fun optional1(
-            value: Long?,
-            metas: MetaContainer
-        ): TestDomain.Optional1 =
-            TestDomain.Optional1(
-                value = value?.asPrimitive(),
-                metas = metas)
-        
-        override fun optional1_(
-            value: org.partiql.pig.runtime.LongPrimitive?,
-            metas: MetaContainer
-        ): TestDomain.Optional1 =
-            TestDomain.Optional1(
-                value = value,
-                metas = metas)
-        
-        
-        override fun optional2(
-            first: Long?,
-            second: Long?,
-            metas: MetaContainer
-        ): TestDomain.Optional2 =
-            TestDomain.Optional2(
-                first = first?.asPrimitive(),
-                second = second?.asPrimitive(),
-                metas = metas)
-        
-        override fun optional2_(
-            first: org.partiql.pig.runtime.LongPrimitive?,
-            second: org.partiql.pig.runtime.LongPrimitive?,
-            metas: MetaContainer
-        ): TestDomain.Optional2 =
-            TestDomain.Optional2(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        override fun domainLevelRecord(
-            someField: Long,
-            anotherField: String,
-            optionalField: Long?,
-            metas: MetaContainer
-        ): TestDomain.DomainLevelRecord =
-            TestDomain.DomainLevelRecord(
-                someField = someField.asPrimitive(),
-                anotherField = anotherField.asPrimitive(),
-                optionalField = optionalField?.asPrimitive(),
-                metas = metas)
-        
-        override fun domainLevelRecord_(
-            someField: org.partiql.pig.runtime.LongPrimitive,
-            anotherField: org.partiql.pig.runtime.SymbolPrimitive,
-            optionalField: org.partiql.pig.runtime.LongPrimitive?,
-            metas: MetaContainer
-        ): TestDomain.DomainLevelRecord =
-            TestDomain.DomainLevelRecord(
-                someField = someField,
-                anotherField = anotherField,
-                optionalField = optionalField,
-                metas = metas)
-        
-        
-        override fun productWithRecord(
-            value: Long,
-            dlr: DomainLevelRecord,
-            metas: MetaContainer
-        ): TestDomain.ProductWithRecord =
-            TestDomain.ProductWithRecord(
-                value = value.asPrimitive(),
-                dlr = dlr,
-                metas = metas)
-        
-        override fun productWithRecord_(
-            value: org.partiql.pig.runtime.LongPrimitive,
-            dlr: DomainLevelRecord,
-            metas: MetaContainer
-        ): TestDomain.ProductWithRecord =
-            TestDomain.ProductWithRecord(
-                value = value,
-                dlr = dlr,
-                metas = metas)
-        
-        
-        override fun testSumTriplet(
-            a: TestSum,
-            b: TestSum,
-            c: TestSum,
-            metas: MetaContainer
-        ): TestDomain.TestSumTriplet =
-            TestDomain.TestSumTriplet(
-                a = a,
-                b = b,
-                c = c,
-                metas = metas)
-        
-        
-        override fun entityPair(
-            first: Entity,
-            second: Entity,
-            metas: MetaContainer
-        ): TestDomain.EntityPair =
-            TestDomain.EntityPair(
-                first = first,
-                second = second,
-                metas = metas)
-        
-        
-        // Variants for Sum: Answer 
-        override fun no(
-            metas: MetaContainer
-        ): TestDomain.Answer.No =
-            TestDomain.Answer.No(
-                metas = metas)
-        
-        
-        override fun yes(
-            metas: MetaContainer
-        ): TestDomain.Answer.Yes =
-            TestDomain.Answer.Yes(
-                metas = metas)
-        
-        
-        // Variants for Sum: SumWithRecord 
-        override fun variantWithRecord(
-            value: Long,
-            dlr: DomainLevelRecord,
-            metas: MetaContainer
-        ): TestDomain.SumWithRecord.VariantWithRecord =
-            TestDomain.SumWithRecord.VariantWithRecord(
-                value = value.asPrimitive(),
-                dlr = dlr,
-                metas = metas)
-        
-        override fun variantWithRecord_(
-            value: org.partiql.pig.runtime.LongPrimitive,
-            dlr: DomainLevelRecord,
-            metas: MetaContainer
-        ): TestDomain.SumWithRecord.VariantWithRecord =
-            TestDomain.SumWithRecord.VariantWithRecord(
-                value = value,
-                dlr = dlr,
-                metas = metas)
-        
-        
-        // Variants for Sum: TestSum 
-        override fun one(
-            a: Long,
-            metas: MetaContainer
-        ): TestDomain.TestSum.One =
-            TestDomain.TestSum.One(
-                a = a.asPrimitive(),
-                metas = metas)
-        
-        override fun one_(
-            a: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): TestDomain.TestSum.One =
-            TestDomain.TestSum.One(
-                a = a,
-                metas = metas)
-        
-        
-        override fun two(
-            a: Long,
-            b: Long,
-            metas: MetaContainer
-        ): TestDomain.TestSum.Two =
-            TestDomain.TestSum.Two(
-                a = a.asPrimitive(),
-                b = b.asPrimitive(),
-                metas = metas)
-        
-        override fun two_(
-            a: org.partiql.pig.runtime.LongPrimitive,
-            b: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): TestDomain.TestSum.Two =
-            TestDomain.TestSum.Two(
-                a = a,
-                b = b,
-                metas = metas)
-        
-        
-        override fun three(
-            a: Long,
-            b: Long,
-            c: Long,
-            metas: MetaContainer
-        ): TestDomain.TestSum.Three =
-            TestDomain.TestSum.Three(
-                a = a.asPrimitive(),
-                b = b.asPrimitive(),
-                c = c.asPrimitive(),
-                metas = metas)
-        
-        override fun three_(
-            a: org.partiql.pig.runtime.LongPrimitive,
-            b: org.partiql.pig.runtime.LongPrimitive,
-            c: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): TestDomain.TestSum.Three =
-            TestDomain.TestSum.Three(
-                a = a,
-                b = b,
-                c = c,
-                metas = metas)
-        
-        
-        // Variants for Sum: Entity 
-        override fun slug(
-            metas: MetaContainer
-        ): TestDomain.Entity.Slug =
-            TestDomain.Entity.Slug(
-                metas = metas)
-        
-        
-        override fun android(
-            id: Long,
-            metas: MetaContainer
-        ): TestDomain.Entity.Android =
-            TestDomain.Entity.Android(
-                id = id.asPrimitive(),
-                metas = metas)
-        
-        override fun android_(
-            id: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): TestDomain.Entity.Android =
-            TestDomain.Entity.Android(
-                id = id,
-                metas = metas)
-        
-        
-        override fun human(
-            firstName: String,
-            middleNames: kotlin.collections.List<String>,
-            lastName: String,
-            title: String?,
-            parent: Entity?,
-            metas: MetaContainer
         ): TestDomain.Entity.Human =
             TestDomain.Entity.Human(
                 firstName = firstName.asPrimitive(),
@@ -1412,15 +983,22 @@ class TestDomain private constructor() {
                 lastName = lastName.asPrimitive(),
                 title = title?.asPrimitive(),
                 parent = parent,
-                metas = metas)
+                metas = metas + newMetaContainer())
         
-        override fun human_(
+        /**
+        * Creates an instance of [TestDomain.Entity.Human].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
+        fun human_(
             firstName: org.partiql.pig.runtime.SymbolPrimitive,
-            middleNames: kotlin.collections.List<org.partiql.pig.runtime.SymbolPrimitive>,
+            middleNames: kotlin.collections.List<org.partiql.pig.runtime.SymbolPrimitive> = emptyList(),
             lastName: org.partiql.pig.runtime.SymbolPrimitive,
-            title: org.partiql.pig.runtime.SymbolPrimitive?,
-            parent: Entity?,
-            metas: MetaContainer
+            title: org.partiql.pig.runtime.SymbolPrimitive? = null,
+            parent: Entity? = null,
+            metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.Entity.Human =
             TestDomain.Entity.Human(
                 firstName = firstName,
@@ -1428,8 +1006,11 @@ class TestDomain private constructor() {
                 lastName = lastName,
                 title = title,
                 parent = parent,
-                metas = metas)
+                metas = metas + newMetaContainer())
     }
+    
+    /** Default implementation of [Builder] that uses all default method implementations. */
+    private object TestDomainBuilder : Builder
     
     /** Base class for all TestDomain types. */
     abstract class TestDomainNode : DomainNode {
@@ -5510,296 +5091,398 @@ class MultiWordDomain private constructor() {
     }
     
     interface Builder {
-                // Tuples
+        fun newMetaContainer() = emptyMetaContainer()
+    
+                    // Tuples
         /**
-         * Creates an instance of [MultiWordDomain.AaaAaa].
-         */
+        * Creates an instance of [MultiWordDomain.AaaAaa].
+        */
         fun aaaAaa(
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAaa
+        ): MultiWordDomain.AaaAaa =
+            MultiWordDomain.AaaAaa(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [MultiWordDomain.AaaAab].
-         */
+        * Creates an instance of [MultiWordDomain.AaaAab].
+        */
         fun aaaAab(
             dField: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAab
+        ): MultiWordDomain.AaaAab =
+            MultiWordDomain.AaaAab(
+                dField = dField?.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AaaAab].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AaaAab].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aaaAab_(
             dField: org.partiql.pig.runtime.LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAab
+        ): MultiWordDomain.AaaAab =
+            MultiWordDomain.AaaAab(
+                dField = dField,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [MultiWordDomain.AaaAac].
-         */
+        * Creates an instance of [MultiWordDomain.AaaAac].
+        */
         fun aaaAac(
             dField: Long? = null,
             eField: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAac
+        ): MultiWordDomain.AaaAac =
+            MultiWordDomain.AaaAac(
+                dField = dField?.asPrimitive(),
+                eField = eField?.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AaaAac].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AaaAac].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aaaAac_(
             dField: org.partiql.pig.runtime.LongPrimitive? = null,
             eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAac
+        ): MultiWordDomain.AaaAac =
+            MultiWordDomain.AaaAac(
+                dField = dField,
+                eField = eField,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [MultiWordDomain.AaaAad].
-         */
+        * Creates an instance of [MultiWordDomain.AaaAad].
+        */
         fun aaaAad(
             dField: kotlin.collections.List<Long> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAad
+        ): MultiWordDomain.AaaAad =
+            MultiWordDomain.AaaAad(
+                dField = dField.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AaaAad].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AaaAad].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aaaAad_(
             dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAad
+        ): MultiWordDomain.AaaAad =
+            MultiWordDomain.AaaAad(
+                dField = dField,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AaaAad].
-         */
+        * Creates an instance of [MultiWordDomain.AaaAad].
+        */
         fun aaaAad(
             vararg dField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAad
+        ): MultiWordDomain.AaaAad =
+            MultiWordDomain.AaaAad(
+                dField = dField.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AaaAad].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AaaAad].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aaaAad_(
             vararg dField: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAad
+        ): MultiWordDomain.AaaAad =
+            MultiWordDomain.AaaAad(
+                dField = dField.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [MultiWordDomain.AaaAae].
-         */
+        * Creates an instance of [MultiWordDomain.AaaAae].
+        */
         fun aaaAae(
             dField: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAae
+        ): MultiWordDomain.AaaAae =
+            MultiWordDomain.AaaAae(
+                dField = dField.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AaaAae].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AaaAae].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aaaAae_(
             dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAae
+        ): MultiWordDomain.AaaAae =
+            MultiWordDomain.AaaAae(
+                dField = dField,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AaaAae].
-         */
+        * Creates an instance of [MultiWordDomain.AaaAae].
+        */
         fun aaaAae(
             dField0: Long,
             dField1: Long,
             vararg dField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAae
+        ): MultiWordDomain.AaaAae =
+            MultiWordDomain.AaaAae(
+                dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AaaAae].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AaaAae].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aaaAae_(
             dField0: org.partiql.pig.runtime.LongPrimitive,
             dField1: org.partiql.pig.runtime.LongPrimitive,
             vararg dField: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AaaAae
+        ): MultiWordDomain.AaaAae =
+            MultiWordDomain.AaaAae(
+                dField = listOfPrimitives(dField0, dField1) + dField.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAaa].
-         */
+        * Creates an instance of [MultiWordDomain.AabAaa].
+        */
         fun aabAaa(
             bField: Long,
             cField: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAaa
+        ): MultiWordDomain.AabAaa =
+            MultiWordDomain.AabAaa(
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAaa].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AabAaa].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aabAaa_(
             bField: org.partiql.pig.runtime.LongPrimitive,
             cField: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAaa
+        ): MultiWordDomain.AabAaa =
+            MultiWordDomain.AabAaa(
+                bField = bField,
+                cField = cField,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAab].
-         */
+        * Creates an instance of [MultiWordDomain.AabAab].
+        */
         fun aabAab(
             bField: Long,
             cField: String,
             dField: Long? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAab
+        ): MultiWordDomain.AabAab =
+            MultiWordDomain.AabAab(
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
+                dField = dField?.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAab].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AabAab].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aabAab_(
             bField: org.partiql.pig.runtime.LongPrimitive,
             cField: org.partiql.pig.runtime.SymbolPrimitive,
             dField: org.partiql.pig.runtime.LongPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAab
+        ): MultiWordDomain.AabAab =
+            MultiWordDomain.AabAab(
+                bField = bField,
+                cField = cField,
+                dField = dField,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAac].
-         */
+        * Creates an instance of [MultiWordDomain.AabAac].
+        */
         fun aabAac(
             bField: Long,
             cField: String,
             dField: Long? = null,
             eField: String? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAac
+        ): MultiWordDomain.AabAac =
+            MultiWordDomain.AabAac(
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
+                dField = dField?.asPrimitive(),
+                eField = eField?.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAac].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AabAac].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aabAac_(
             bField: org.partiql.pig.runtime.LongPrimitive,
             cField: org.partiql.pig.runtime.SymbolPrimitive,
             dField: org.partiql.pig.runtime.LongPrimitive? = null,
             eField: org.partiql.pig.runtime.SymbolPrimitive? = null,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAac
+        ): MultiWordDomain.AabAac =
+            MultiWordDomain.AabAac(
+                bField = bField,
+                cField = cField,
+                dField = dField,
+                eField = eField,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAad].
-         */
+        * Creates an instance of [MultiWordDomain.AabAad].
+        */
         fun aabAad(
             bField: Long,
             cField: String,
             dField: kotlin.collections.List<Long> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAad
+        ): MultiWordDomain.AabAad =
+            MultiWordDomain.AabAad(
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
+                dField = dField.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAad].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AabAad].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aabAad_(
             bField: org.partiql.pig.runtime.LongPrimitive,
             cField: org.partiql.pig.runtime.SymbolPrimitive,
             dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAad
+        ): MultiWordDomain.AabAad =
+            MultiWordDomain.AabAad(
+                bField = bField,
+                cField = cField,
+                dField = dField,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAad].
-         */
+        * Creates an instance of [MultiWordDomain.AabAad].
+        */
         fun aabAad(
             bField: Long,
             cField: String,
             vararg dField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAad
+        ): MultiWordDomain.AabAad =
+            MultiWordDomain.AabAad(
+                bField = bField?.asPrimitive(),
+                cField = cField?.asPrimitive(),
+                dField = dField.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAad].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AabAad].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aabAad_(
             bField: org.partiql.pig.runtime.LongPrimitive,
             cField: org.partiql.pig.runtime.SymbolPrimitive,
             vararg dField: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAad
+        ): MultiWordDomain.AabAad =
+            MultiWordDomain.AabAad(
+                bField = bField,
+                cField = cField,
+                dField = dField.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAae].
-         */
+        * Creates an instance of [MultiWordDomain.AabAae].
+        */
         fun aabAae(
             bField: Long,
             cField: String,
             dField: kotlin.collections.List<Long>,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAae
+        ): MultiWordDomain.AabAae =
+            MultiWordDomain.AabAae(
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
+                dField = dField.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAae].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AabAae].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aabAae_(
             bField: org.partiql.pig.runtime.LongPrimitive,
             cField: org.partiql.pig.runtime.SymbolPrimitive,
             dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAae
+        ): MultiWordDomain.AabAae =
+            MultiWordDomain.AabAae(
+                bField = bField,
+                cField = cField,
+                dField = dField,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAae].
-         */
+        * Creates an instance of [MultiWordDomain.AabAae].
+        */
         fun aabAae(
             bField: Long,
             cField: String,
@@ -5807,15 +5490,20 @@ class MultiWordDomain private constructor() {
             dField1: Long,
             vararg dField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAae
+        ): MultiWordDomain.AabAae =
+            MultiWordDomain.AabAae(
+                bField = bField?.asPrimitive(),
+                cField = cField?.asPrimitive(),
+                dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [MultiWordDomain.AabAae].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [MultiWordDomain.AabAae].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun aabAae_(
             bField: org.partiql.pig.runtime.LongPrimitive,
             cField: org.partiql.pig.runtime.SymbolPrimitive,
@@ -5823,424 +5511,102 @@ class MultiWordDomain private constructor() {
             dField1: org.partiql.pig.runtime.LongPrimitive,
             vararg dField: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.AabAae
+        ): MultiWordDomain.AabAae =
+            MultiWordDomain.AabAae(
+                bField = bField,
+                cField = cField,
+                dField = listOfPrimitives(dField0, dField1) + dField.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [MultiWordDomain.Rrr].
-         */
+        * Creates an instance of [MultiWordDomain.Rrr].
+        */
         fun rrr(
             aField: Long,
             bbbField: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.Rrr
-        
-        /**
-         * Creates an instance of [MultiWordDomain.Rrr].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
-        fun rrr_(
-            aField: org.partiql.pig.runtime.LongPrimitive,
-            bbbField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.Rrr
-        
-        
-        // Variants for Sum: SssTtt 
-        /**
-         * Creates an instance of [MultiWordDomain.SssTtt.Lll].
-         */
-        fun lll(
-            uField: Long,
-            metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.SssTtt.Lll
-        
-        /**
-         * Creates an instance of [MultiWordDomain.SssTtt.Lll].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
-        fun lll_(
-            uField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.SssTtt.Lll
-        
-        
-        /**
-         * Creates an instance of [MultiWordDomain.SssTtt.Mmm].
-         */
-        fun mmm(
-            vField: String,
-            metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.SssTtt.Mmm
-        
-        /**
-         * Creates an instance of [MultiWordDomain.SssTtt.Mmm].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
-        fun mmm_(
-            vField: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
-        ): MultiWordDomain.SssTtt.Mmm
-    }
-    
-    private object MultiWordDomainBuilder : Builder {
-                // Tuples
-        override fun aaaAaa(
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAaa =
-            MultiWordDomain.AaaAaa(
-                metas = metas)
-        
-        
-        override fun aaaAab(
-            dField: Long?,
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAab =
-            MultiWordDomain.AaaAab(
-                dField = dField?.asPrimitive(),
-                metas = metas)
-        
-        override fun aaaAab_(
-            dField: org.partiql.pig.runtime.LongPrimitive?,
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAab =
-            MultiWordDomain.AaaAab(
-                dField = dField,
-                metas = metas)
-        
-        
-        override fun aaaAac(
-            dField: Long?,
-            eField: String?,
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAac =
-            MultiWordDomain.AaaAac(
-                dField = dField?.asPrimitive(),
-                eField = eField?.asPrimitive(),
-                metas = metas)
-        
-        override fun aaaAac_(
-            dField: org.partiql.pig.runtime.LongPrimitive?,
-            eField: org.partiql.pig.runtime.SymbolPrimitive?,
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAac =
-            MultiWordDomain.AaaAac(
-                dField = dField,
-                eField = eField,
-                metas = metas)
-        
-        
-        override fun aaaAad(
-            dField: kotlin.collections.List<Long>,
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAad =
-            MultiWordDomain.AaaAad(
-                dField = dField.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun aaaAad_(
-            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAad =
-            MultiWordDomain.AaaAad(
-                dField = dField,
-                metas = metas)
-        
-        override fun aaaAad(
-            vararg dField: Long,
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAad =
-            MultiWordDomain.AaaAad(
-                dField = dField.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun aaaAad_(
-            vararg dField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAad =
-            MultiWordDomain.AaaAad(
-                dField = dField.toList(),
-                metas = metas)
-        
-        
-        override fun aaaAae(
-            dField: kotlin.collections.List<Long>,
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAae =
-            MultiWordDomain.AaaAae(
-                dField = dField.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun aaaAae_(
-            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAae =
-            MultiWordDomain.AaaAae(
-                dField = dField,
-                metas = metas)
-        
-        override fun aaaAae(
-            dField0: Long,
-            dField1: Long,
-            vararg dField: Long,
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAae =
-            MultiWordDomain.AaaAae(
-                dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun aaaAae_(
-            dField0: org.partiql.pig.runtime.LongPrimitive,
-            dField1: org.partiql.pig.runtime.LongPrimitive,
-            vararg dField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): MultiWordDomain.AaaAae =
-            MultiWordDomain.AaaAae(
-                dField = listOfPrimitives(dField0, dField1) + dField.toList(),
-                metas = metas)
-        
-        
-        override fun aabAaa(
-            bField: Long,
-            cField: String,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAaa =
-            MultiWordDomain.AabAaa(
-                bField = bField.asPrimitive(),
-                cField = cField.asPrimitive(),
-                metas = metas)
-        
-        override fun aabAaa_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAaa =
-            MultiWordDomain.AabAaa(
-                bField = bField,
-                cField = cField,
-                metas = metas)
-        
-        
-        override fun aabAab(
-            bField: Long,
-            cField: String,
-            dField: Long?,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAab =
-            MultiWordDomain.AabAab(
-                bField = bField.asPrimitive(),
-                cField = cField.asPrimitive(),
-                dField = dField?.asPrimitive(),
-                metas = metas)
-        
-        override fun aabAab_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            dField: org.partiql.pig.runtime.LongPrimitive?,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAab =
-            MultiWordDomain.AabAab(
-                bField = bField,
-                cField = cField,
-                dField = dField,
-                metas = metas)
-        
-        
-        override fun aabAac(
-            bField: Long,
-            cField: String,
-            dField: Long?,
-            eField: String?,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAac =
-            MultiWordDomain.AabAac(
-                bField = bField.asPrimitive(),
-                cField = cField.asPrimitive(),
-                dField = dField?.asPrimitive(),
-                eField = eField?.asPrimitive(),
-                metas = metas)
-        
-        override fun aabAac_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            dField: org.partiql.pig.runtime.LongPrimitive?,
-            eField: org.partiql.pig.runtime.SymbolPrimitive?,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAac =
-            MultiWordDomain.AabAac(
-                bField = bField,
-                cField = cField,
-                dField = dField,
-                eField = eField,
-                metas = metas)
-        
-        
-        override fun aabAad(
-            bField: Long,
-            cField: String,
-            dField: kotlin.collections.List<Long>,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAad =
-            MultiWordDomain.AabAad(
-                bField = bField.asPrimitive(),
-                cField = cField.asPrimitive(),
-                dField = dField.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun aabAad_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAad =
-            MultiWordDomain.AabAad(
-                bField = bField,
-                cField = cField,
-                dField = dField,
-                metas = metas)
-        
-        override fun aabAad(
-            bField: Long,
-            cField: String,
-            vararg dField: Long,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAad =
-            MultiWordDomain.AabAad(
-                bField = bField?.asPrimitive(),
-                cField = cField?.asPrimitive(),
-                dField = dField.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun aabAad_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            vararg dField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAad =
-            MultiWordDomain.AabAad(
-                bField = bField,
-                cField = cField,
-                dField = dField.toList(),
-                metas = metas)
-        
-        
-        override fun aabAae(
-            bField: Long,
-            cField: String,
-            dField: kotlin.collections.List<Long>,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAae =
-            MultiWordDomain.AabAae(
-                bField = bField.asPrimitive(),
-                cField = cField.asPrimitive(),
-                dField = dField.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun aabAae_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            dField: kotlin.collections.List<org.partiql.pig.runtime.LongPrimitive>,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAae =
-            MultiWordDomain.AabAae(
-                bField = bField,
-                cField = cField,
-                dField = dField,
-                metas = metas)
-        
-        override fun aabAae(
-            bField: Long,
-            cField: String,
-            dField0: Long,
-            dField1: Long,
-            vararg dField: Long,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAae =
-            MultiWordDomain.AabAae(
-                bField = bField?.asPrimitive(),
-                cField = cField?.asPrimitive(),
-                dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
-                metas = metas)
-        
-        override fun aabAae_(
-            bField: org.partiql.pig.runtime.LongPrimitive,
-            cField: org.partiql.pig.runtime.SymbolPrimitive,
-            dField0: org.partiql.pig.runtime.LongPrimitive,
-            dField1: org.partiql.pig.runtime.LongPrimitive,
-            vararg dField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): MultiWordDomain.AabAae =
-            MultiWordDomain.AabAae(
-                bField = bField,
-                cField = cField,
-                dField = listOfPrimitives(dField0, dField1) + dField.toList(),
-                metas = metas)
-        
-        
-        override fun rrr(
-            aField: Long,
-            bbbField: Long,
-            metas: MetaContainer
         ): MultiWordDomain.Rrr =
             MultiWordDomain.Rrr(
                 aField = aField.asPrimitive(),
                 bbbField = bbbField.asPrimitive(),
-                metas = metas)
+                metas = metas + newMetaContainer())
         
-        override fun rrr_(
+        /**
+        * Creates an instance of [MultiWordDomain.Rrr].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
+        fun rrr_(
             aField: org.partiql.pig.runtime.LongPrimitive,
             bbbField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.Rrr =
             MultiWordDomain.Rrr(
                 aField = aField,
                 bbbField = bbbField,
-                metas = metas)
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: SssTtt 
-        override fun lll(
+        /**
+        * Creates an instance of [MultiWordDomain.SssTtt.Lll].
+        */
+        fun lll(
             uField: Long,
-            metas: MetaContainer
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Lll =
             MultiWordDomain.SssTtt.Lll(
                 uField = uField.asPrimitive(),
-                metas = metas)
+                metas = metas + newMetaContainer())
         
-        override fun lll_(
+        /**
+        * Creates an instance of [MultiWordDomain.SssTtt.Lll].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
+        fun lll_(
             uField: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Lll =
             MultiWordDomain.SssTtt.Lll(
                 uField = uField,
-                metas = metas)
+                metas = metas + newMetaContainer())
         
         
-        override fun mmm(
+        /**
+        * Creates an instance of [MultiWordDomain.SssTtt.Mmm].
+        */
+        fun mmm(
             vField: String,
-            metas: MetaContainer
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Mmm =
             MultiWordDomain.SssTtt.Mmm(
                 vField = vField.asPrimitive(),
-                metas = metas)
+                metas = metas + newMetaContainer())
         
-        override fun mmm_(
+        /**
+        * Creates an instance of [MultiWordDomain.SssTtt.Mmm].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
+        fun mmm_(
             vField: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer
+            metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.SssTtt.Mmm =
             MultiWordDomain.SssTtt.Mmm(
                 vField = vField,
-                metas = metas)
+                metas = metas + newMetaContainer())
     }
+    
+    /** Default implementation of [Builder] that uses all default method implementations. */
+    private object MultiWordDomainBuilder : Builder
     
     /** Base class for all MultiWordDomain types. */
     abstract class MultiWordDomainNode : DomainNode {
@@ -7788,472 +7154,334 @@ class DomainA private constructor() {
     }
     
     interface Builder {
-                // Tuples
+        fun newMetaContainer() = emptyMetaContainer()
+    
+                    // Tuples
         /**
-         * Creates an instance of [DomainA.ProductToRemove].
-         */
+        * Creates an instance of [DomainA.ProductToRemove].
+        */
         fun productToRemove(
             whatever: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.ProductToRemove
+        ): DomainA.ProductToRemove =
+            DomainA.ProductToRemove(
+                whatever = whatever.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainA.ProductToRemove].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainA.ProductToRemove].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun productToRemove_(
             whatever: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.ProductToRemove
+        ): DomainA.ProductToRemove =
+            DomainA.ProductToRemove(
+                whatever = whatever,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainA.RecordToRemove].
-         */
+        * Creates an instance of [DomainA.RecordToRemove].
+        */
         fun recordToRemove(
             irrelevant: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.RecordToRemove
+        ): DomainA.RecordToRemove =
+            DomainA.RecordToRemove(
+                irrelevant = irrelevant.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainA.RecordToRemove].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainA.RecordToRemove].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun recordToRemove_(
             irrelevant: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.RecordToRemove
+        ): DomainA.RecordToRemove =
+            DomainA.RecordToRemove(
+                irrelevant = irrelevant,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainA.ProductA].
-         */
+        * Creates an instance of [DomainA.ProductA].
+        */
         fun productA(
             one: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.ProductA
+        ): DomainA.ProductA =
+            DomainA.ProductA(
+                one = one.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainA.ProductA].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainA.ProductA].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun productA_(
             one: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.ProductA
+        ): DomainA.ProductA =
+            DomainA.ProductA(
+                one = one,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainA.RecordA].
-         */
+        * Creates an instance of [DomainA.RecordA].
+        */
         fun recordA(
             one: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.RecordA
+        ): DomainA.RecordA =
+            DomainA.RecordA(
+                one = one.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainA.RecordA].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainA.RecordA].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun recordA_(
             one: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.RecordA
+        ): DomainA.RecordA =
+            DomainA.RecordA(
+                one = one,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainA.UnpermutedProduct].
-         */
+        * Creates an instance of [DomainA.UnpermutedProduct].
+        */
         fun unpermutedProduct(
             foo: String,
             bar: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.UnpermutedProduct
+        ): DomainA.UnpermutedProduct =
+            DomainA.UnpermutedProduct(
+                foo = foo.asPrimitive(),
+                bar = bar.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainA.UnpermutedProduct].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainA.UnpermutedProduct].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun unpermutedProduct_(
             foo: org.partiql.pig.runtime.SymbolPrimitive,
             bar: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.UnpermutedProduct
+        ): DomainA.UnpermutedProduct =
+            DomainA.UnpermutedProduct(
+                foo = foo,
+                bar = bar,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainA.UnpermutedRecord].
-         */
+        * Creates an instance of [DomainA.UnpermutedRecord].
+        */
         fun unpermutedRecord(
             foo: String,
             bar: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.UnpermutedRecord
+        ): DomainA.UnpermutedRecord =
+            DomainA.UnpermutedRecord(
+                foo = foo.asPrimitive(),
+                bar = bar.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainA.UnpermutedRecord].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainA.UnpermutedRecord].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun unpermutedRecord_(
             foo: org.partiql.pig.runtime.SymbolPrimitive,
             bar: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.UnpermutedRecord
+        ): DomainA.UnpermutedRecord =
+            DomainA.UnpermutedRecord(
+                foo = foo,
+                bar = bar,
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: SumToRemove 
         /**
-         * Creates an instance of [DomainA.SumToRemove.Doesnt].
-         */
+        * Creates an instance of [DomainA.SumToRemove.Doesnt].
+        */
         fun doesnt(
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.SumToRemove.Doesnt
+        ): DomainA.SumToRemove.Doesnt =
+            DomainA.SumToRemove.Doesnt(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainA.SumToRemove.Matter].
-         */
+        * Creates an instance of [DomainA.SumToRemove.Matter].
+        */
         fun matter(
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.SumToRemove.Matter
+        ): DomainA.SumToRemove.Matter =
+            DomainA.SumToRemove.Matter(
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: SumA 
         /**
-         * Creates an instance of [DomainA.SumA.Who].
-         */
+        * Creates an instance of [DomainA.SumA.Who].
+        */
         fun who(
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.SumA.Who
+        ): DomainA.SumA.Who =
+            DomainA.SumA.Who(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainA.SumA.Cares].
-         */
+        * Creates an instance of [DomainA.SumA.Cares].
+        */
         fun cares(
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.SumA.Cares
+        ): DomainA.SumA.Cares =
+            DomainA.SumA.Cares(
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: SumB 
         /**
-         * Creates an instance of [DomainA.SumB.WillBeUnchanged].
-         */
+        * Creates an instance of [DomainA.SumB.WillBeUnchanged].
+        */
         fun willBeUnchanged(
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.SumB.WillBeUnchanged
+        ): DomainA.SumB.WillBeUnchanged =
+            DomainA.SumB.WillBeUnchanged(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainA.SumB.WillBeRemoved].
-         */
+        * Creates an instance of [DomainA.SumB.WillBeRemoved].
+        */
         fun willBeRemoved(
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.SumB.WillBeRemoved
+        ): DomainA.SumB.WillBeRemoved =
+            DomainA.SumB.WillBeRemoved(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainA.SumB.WillBeReplaced].
-         */
+        * Creates an instance of [DomainA.SumB.WillBeReplaced].
+        */
         fun willBeReplaced(
             something: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.SumB.WillBeReplaced
+        ): DomainA.SumB.WillBeReplaced =
+            DomainA.SumB.WillBeReplaced(
+                something = something.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainA.SumB.WillBeReplaced].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainA.SumB.WillBeReplaced].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun willBeReplaced_(
             something: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.SumB.WillBeReplaced
+        ): DomainA.SumB.WillBeReplaced =
+            DomainA.SumB.WillBeReplaced(
+                something = something,
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: UnpermutedSum 
         /**
-         * Creates an instance of [DomainA.UnpermutedSum.UnpermutedProductVariant].
-         */
+        * Creates an instance of [DomainA.UnpermutedSum.UnpermutedProductVariant].
+        */
         fun unpermutedProductVariant(
             foo: String,
             bar: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.UnpermutedSum.UnpermutedProductVariant
+        ): DomainA.UnpermutedSum.UnpermutedProductVariant =
+            DomainA.UnpermutedSum.UnpermutedProductVariant(
+                foo = foo.asPrimitive(),
+                bar = bar.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainA.UnpermutedSum.UnpermutedProductVariant].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainA.UnpermutedSum.UnpermutedProductVariant].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun unpermutedProductVariant_(
             foo: org.partiql.pig.runtime.SymbolPrimitive,
             bar: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.UnpermutedSum.UnpermutedProductVariant
+        ): DomainA.UnpermutedSum.UnpermutedProductVariant =
+            DomainA.UnpermutedSum.UnpermutedProductVariant(
+                foo = foo,
+                bar = bar,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainA.UnpermutedSum.UnpermutedRecordVariant].
-         */
+        * Creates an instance of [DomainA.UnpermutedSum.UnpermutedRecordVariant].
+        */
         fun unpermutedRecordVariant(
             foo: String,
             bar: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.UnpermutedSum.UnpermutedRecordVariant
+        ): DomainA.UnpermutedSum.UnpermutedRecordVariant =
+            DomainA.UnpermutedSum.UnpermutedRecordVariant(
+                foo = foo.asPrimitive(),
+                bar = bar.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainA.UnpermutedSum.UnpermutedRecordVariant].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainA.UnpermutedSum.UnpermutedRecordVariant].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun unpermutedRecordVariant_(
             foo: org.partiql.pig.runtime.SymbolPrimitive,
             bar: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainA.UnpermutedSum.UnpermutedRecordVariant
+        ): DomainA.UnpermutedSum.UnpermutedRecordVariant =
+            DomainA.UnpermutedSum.UnpermutedRecordVariant(
+                foo = foo,
+                bar = bar,
+                metas = metas + newMetaContainer())
     }
     
-    private object DomainABuilder : Builder {
-                // Tuples
-        override fun productToRemove(
-            whatever: String,
-            metas: MetaContainer
-        ): DomainA.ProductToRemove =
-            DomainA.ProductToRemove(
-                whatever = whatever.asPrimitive(),
-                metas = metas)
-        
-        override fun productToRemove_(
-            whatever: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer
-        ): DomainA.ProductToRemove =
-            DomainA.ProductToRemove(
-                whatever = whatever,
-                metas = metas)
-        
-        
-        override fun recordToRemove(
-            irrelevant: Long,
-            metas: MetaContainer
-        ): DomainA.RecordToRemove =
-            DomainA.RecordToRemove(
-                irrelevant = irrelevant.asPrimitive(),
-                metas = metas)
-        
-        override fun recordToRemove_(
-            irrelevant: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainA.RecordToRemove =
-            DomainA.RecordToRemove(
-                irrelevant = irrelevant,
-                metas = metas)
-        
-        
-        override fun productA(
-            one: Long,
-            metas: MetaContainer
-        ): DomainA.ProductA =
-            DomainA.ProductA(
-                one = one.asPrimitive(),
-                metas = metas)
-        
-        override fun productA_(
-            one: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainA.ProductA =
-            DomainA.ProductA(
-                one = one,
-                metas = metas)
-        
-        
-        override fun recordA(
-            one: Long,
-            metas: MetaContainer
-        ): DomainA.RecordA =
-            DomainA.RecordA(
-                one = one.asPrimitive(),
-                metas = metas)
-        
-        override fun recordA_(
-            one: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainA.RecordA =
-            DomainA.RecordA(
-                one = one,
-                metas = metas)
-        
-        
-        override fun unpermutedProduct(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer
-        ): DomainA.UnpermutedProduct =
-            DomainA.UnpermutedProduct(
-                foo = foo.asPrimitive(),
-                bar = bar.asPrimitive(),
-                metas = metas)
-        
-        override fun unpermutedProduct_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainA.UnpermutedProduct =
-            DomainA.UnpermutedProduct(
-                foo = foo,
-                bar = bar,
-                metas = metas)
-        
-        
-        override fun unpermutedRecord(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer
-        ): DomainA.UnpermutedRecord =
-            DomainA.UnpermutedRecord(
-                foo = foo.asPrimitive(),
-                bar = bar.asPrimitive(),
-                metas = metas)
-        
-        override fun unpermutedRecord_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainA.UnpermutedRecord =
-            DomainA.UnpermutedRecord(
-                foo = foo,
-                bar = bar,
-                metas = metas)
-        
-        
-        // Variants for Sum: SumToRemove 
-        override fun doesnt(
-            metas: MetaContainer
-        ): DomainA.SumToRemove.Doesnt =
-            DomainA.SumToRemove.Doesnt(
-                metas = metas)
-        
-        
-        override fun matter(
-            metas: MetaContainer
-        ): DomainA.SumToRemove.Matter =
-            DomainA.SumToRemove.Matter(
-                metas = metas)
-        
-        
-        // Variants for Sum: SumA 
-        override fun who(
-            metas: MetaContainer
-        ): DomainA.SumA.Who =
-            DomainA.SumA.Who(
-                metas = metas)
-        
-        
-        override fun cares(
-            metas: MetaContainer
-        ): DomainA.SumA.Cares =
-            DomainA.SumA.Cares(
-                metas = metas)
-        
-        
-        // Variants for Sum: SumB 
-        override fun willBeUnchanged(
-            metas: MetaContainer
-        ): DomainA.SumB.WillBeUnchanged =
-            DomainA.SumB.WillBeUnchanged(
-                metas = metas)
-        
-        
-        override fun willBeRemoved(
-            metas: MetaContainer
-        ): DomainA.SumB.WillBeRemoved =
-            DomainA.SumB.WillBeRemoved(
-                metas = metas)
-        
-        
-        override fun willBeReplaced(
-            something: Long,
-            metas: MetaContainer
-        ): DomainA.SumB.WillBeReplaced =
-            DomainA.SumB.WillBeReplaced(
-                something = something.asPrimitive(),
-                metas = metas)
-        
-        override fun willBeReplaced_(
-            something: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainA.SumB.WillBeReplaced =
-            DomainA.SumB.WillBeReplaced(
-                something = something,
-                metas = metas)
-        
-        
-        // Variants for Sum: UnpermutedSum 
-        override fun unpermutedProductVariant(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer
-        ): DomainA.UnpermutedSum.UnpermutedProductVariant =
-            DomainA.UnpermutedSum.UnpermutedProductVariant(
-                foo = foo.asPrimitive(),
-                bar = bar.asPrimitive(),
-                metas = metas)
-        
-        override fun unpermutedProductVariant_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainA.UnpermutedSum.UnpermutedProductVariant =
-            DomainA.UnpermutedSum.UnpermutedProductVariant(
-                foo = foo,
-                bar = bar,
-                metas = metas)
-        
-        
-        override fun unpermutedRecordVariant(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer
-        ): DomainA.UnpermutedSum.UnpermutedRecordVariant =
-            DomainA.UnpermutedSum.UnpermutedRecordVariant(
-                foo = foo.asPrimitive(),
-                bar = bar.asPrimitive(),
-                metas = metas)
-        
-        override fun unpermutedRecordVariant_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainA.UnpermutedSum.UnpermutedRecordVariant =
-            DomainA.UnpermutedSum.UnpermutedRecordVariant(
-                foo = foo,
-                bar = bar,
-                metas = metas)
-    }
+    /** Default implementation of [Builder] that uses all default method implementations. */
+    private object DomainABuilder : Builder
     
     /** Base class for all DomainA types. */
     abstract class DomainANode : DomainNode {
@@ -9910,425 +9138,303 @@ class DomainB private constructor() {
     }
     
     interface Builder {
-                // Tuples
+        fun newMetaContainer() = emptyMetaContainer()
+    
+                    // Tuples
         /**
-         * Creates an instance of [DomainB.UnpermutedProduct].
-         */
+        * Creates an instance of [DomainB.UnpermutedProduct].
+        */
         fun unpermutedProduct(
             foo: String,
             bar: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.UnpermutedProduct
+        ): DomainB.UnpermutedProduct =
+            DomainB.UnpermutedProduct(
+                foo = foo.asPrimitive(),
+                bar = bar.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainB.UnpermutedProduct].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainB.UnpermutedProduct].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun unpermutedProduct_(
             foo: org.partiql.pig.runtime.SymbolPrimitive,
             bar: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.UnpermutedProduct
+        ): DomainB.UnpermutedProduct =
+            DomainB.UnpermutedProduct(
+                foo = foo,
+                bar = bar,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainB.UnpermutedRecord].
-         */
+        * Creates an instance of [DomainB.UnpermutedRecord].
+        */
         fun unpermutedRecord(
             foo: String,
             bar: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.UnpermutedRecord
+        ): DomainB.UnpermutedRecord =
+            DomainB.UnpermutedRecord(
+                foo = foo.asPrimitive(),
+                bar = bar.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainB.UnpermutedRecord].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainB.UnpermutedRecord].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun unpermutedRecord_(
             foo: org.partiql.pig.runtime.SymbolPrimitive,
             bar: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.UnpermutedRecord
+        ): DomainB.UnpermutedRecord =
+            DomainB.UnpermutedRecord(
+                foo = foo,
+                bar = bar,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainB.ProductA].
-         */
+        * Creates an instance of [DomainB.ProductA].
+        */
         fun productA(
             one: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.ProductA
+        ): DomainB.ProductA =
+            DomainB.ProductA(
+                one = one.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainB.ProductA].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainB.ProductA].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun productA_(
             one: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.ProductA
+        ): DomainB.ProductA =
+            DomainB.ProductA(
+                one = one,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainB.RecordA].
-         */
+        * Creates an instance of [DomainB.RecordA].
+        */
         fun recordA(
             one: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.RecordA
+        ): DomainB.RecordA =
+            DomainB.RecordA(
+                one = one.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainB.RecordA].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainB.RecordA].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun recordA_(
             one: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.RecordA
+        ): DomainB.RecordA =
+            DomainB.RecordA(
+                one = one,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainB.NewProduct].
-         */
+        * Creates an instance of [DomainB.NewProduct].
+        */
         fun newProduct(
             foo: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.NewProduct
+        ): DomainB.NewProduct =
+            DomainB.NewProduct(
+                foo = foo.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainB.NewProduct].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainB.NewProduct].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun newProduct_(
             foo: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.NewProduct
+        ): DomainB.NewProduct =
+            DomainB.NewProduct(
+                foo = foo,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainB.NewRecord].
-         */
+        * Creates an instance of [DomainB.NewRecord].
+        */
         fun newRecord(
             foo: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.NewRecord
+        ): DomainB.NewRecord =
+            DomainB.NewRecord(
+                foo = foo.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainB.NewRecord].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainB.NewRecord].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun newRecord_(
             foo: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.NewRecord
+        ): DomainB.NewRecord =
+            DomainB.NewRecord(
+                foo = foo,
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: UnpermutedSum 
         /**
-         * Creates an instance of [DomainB.UnpermutedSum.UnpermutedProductVariant].
-         */
+        * Creates an instance of [DomainB.UnpermutedSum.UnpermutedProductVariant].
+        */
         fun unpermutedProductVariant(
             foo: String,
             bar: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.UnpermutedSum.UnpermutedProductVariant
+        ): DomainB.UnpermutedSum.UnpermutedProductVariant =
+            DomainB.UnpermutedSum.UnpermutedProductVariant(
+                foo = foo.asPrimitive(),
+                bar = bar.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainB.UnpermutedSum.UnpermutedProductVariant].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainB.UnpermutedSum.UnpermutedProductVariant].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun unpermutedProductVariant_(
             foo: org.partiql.pig.runtime.SymbolPrimitive,
             bar: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.UnpermutedSum.UnpermutedProductVariant
+        ): DomainB.UnpermutedSum.UnpermutedProductVariant =
+            DomainB.UnpermutedSum.UnpermutedProductVariant(
+                foo = foo,
+                bar = bar,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainB.UnpermutedSum.UnpermutedRecordVariant].
-         */
+        * Creates an instance of [DomainB.UnpermutedSum.UnpermutedRecordVariant].
+        */
         fun unpermutedRecordVariant(
             foo: String,
             bar: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.UnpermutedSum.UnpermutedRecordVariant
+        ): DomainB.UnpermutedSum.UnpermutedRecordVariant =
+            DomainB.UnpermutedSum.UnpermutedRecordVariant(
+                foo = foo.asPrimitive(),
+                bar = bar.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [DomainB.UnpermutedSum.UnpermutedRecordVariant].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [DomainB.UnpermutedSum.UnpermutedRecordVariant].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun unpermutedRecordVariant_(
             foo: org.partiql.pig.runtime.SymbolPrimitive,
             bar: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.UnpermutedSum.UnpermutedRecordVariant
+        ): DomainB.UnpermutedSum.UnpermutedRecordVariant =
+            DomainB.UnpermutedSum.UnpermutedRecordVariant(
+                foo = foo,
+                bar = bar,
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: SumB 
         /**
-         * Creates an instance of [DomainB.SumB.WillBeUnchanged].
-         */
+        * Creates an instance of [DomainB.SumB.WillBeUnchanged].
+        */
         fun willBeUnchanged(
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.SumB.WillBeUnchanged
+        ): DomainB.SumB.WillBeUnchanged =
+            DomainB.SumB.WillBeUnchanged(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [DomainB.SumB.WillBeReplaced].
-         */
+        * Creates an instance of [DomainB.SumB.WillBeReplaced].
+        */
         fun willBeReplaced(
             something: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.SumB.WillBeReplaced
-        
-        /**
-         * Creates an instance of [DomainB.SumB.WillBeReplaced].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
-        fun willBeReplaced_(
-            something: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.SumB.WillBeReplaced
-        
-        
-        // Variants for Sum: NewSum 
-        /**
-         * Creates an instance of [DomainB.NewSum.Eek].
-         */
-        fun eek(
-            metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.NewSum.Eek
-        
-        
-        /**
-         * Creates an instance of [DomainB.NewSum.Whatever].
-         */
-        fun whatever(
-            metas: MetaContainer = emptyMetaContainer()
-        ): DomainB.NewSum.Whatever
-    }
-    
-    private object DomainBBuilder : Builder {
-                // Tuples
-        override fun unpermutedProduct(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer
-        ): DomainB.UnpermutedProduct =
-            DomainB.UnpermutedProduct(
-                foo = foo.asPrimitive(),
-                bar = bar.asPrimitive(),
-                metas = metas)
-        
-        override fun unpermutedProduct_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainB.UnpermutedProduct =
-            DomainB.UnpermutedProduct(
-                foo = foo,
-                bar = bar,
-                metas = metas)
-        
-        
-        override fun unpermutedRecord(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer
-        ): DomainB.UnpermutedRecord =
-            DomainB.UnpermutedRecord(
-                foo = foo.asPrimitive(),
-                bar = bar.asPrimitive(),
-                metas = metas)
-        
-        override fun unpermutedRecord_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainB.UnpermutedRecord =
-            DomainB.UnpermutedRecord(
-                foo = foo,
-                bar = bar,
-                metas = metas)
-        
-        
-        override fun productA(
-            one: String,
-            metas: MetaContainer
-        ): DomainB.ProductA =
-            DomainB.ProductA(
-                one = one.asPrimitive(),
-                metas = metas)
-        
-        override fun productA_(
-            one: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer
-        ): DomainB.ProductA =
-            DomainB.ProductA(
-                one = one,
-                metas = metas)
-        
-        
-        override fun recordA(
-            one: String,
-            metas: MetaContainer
-        ): DomainB.RecordA =
-            DomainB.RecordA(
-                one = one.asPrimitive(),
-                metas = metas)
-        
-        override fun recordA_(
-            one: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer
-        ): DomainB.RecordA =
-            DomainB.RecordA(
-                one = one,
-                metas = metas)
-        
-        
-        override fun newProduct(
-            foo: Long,
-            metas: MetaContainer
-        ): DomainB.NewProduct =
-            DomainB.NewProduct(
-                foo = foo.asPrimitive(),
-                metas = metas)
-        
-        override fun newProduct_(
-            foo: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainB.NewProduct =
-            DomainB.NewProduct(
-                foo = foo,
-                metas = metas)
-        
-        
-        override fun newRecord(
-            foo: Long,
-            metas: MetaContainer
-        ): DomainB.NewRecord =
-            DomainB.NewRecord(
-                foo = foo.asPrimitive(),
-                metas = metas)
-        
-        override fun newRecord_(
-            foo: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainB.NewRecord =
-            DomainB.NewRecord(
-                foo = foo,
-                metas = metas)
-        
-        
-        // Variants for Sum: UnpermutedSum 
-        override fun unpermutedProductVariant(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer
-        ): DomainB.UnpermutedSum.UnpermutedProductVariant =
-            DomainB.UnpermutedSum.UnpermutedProductVariant(
-                foo = foo.asPrimitive(),
-                bar = bar.asPrimitive(),
-                metas = metas)
-        
-        override fun unpermutedProductVariant_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainB.UnpermutedSum.UnpermutedProductVariant =
-            DomainB.UnpermutedSum.UnpermutedProductVariant(
-                foo = foo,
-                bar = bar,
-                metas = metas)
-        
-        
-        override fun unpermutedRecordVariant(
-            foo: String,
-            bar: Long,
-            metas: MetaContainer
-        ): DomainB.UnpermutedSum.UnpermutedRecordVariant =
-            DomainB.UnpermutedSum.UnpermutedRecordVariant(
-                foo = foo.asPrimitive(),
-                bar = bar.asPrimitive(),
-                metas = metas)
-        
-        override fun unpermutedRecordVariant_(
-            foo: org.partiql.pig.runtime.SymbolPrimitive,
-            bar: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): DomainB.UnpermutedSum.UnpermutedRecordVariant =
-            DomainB.UnpermutedSum.UnpermutedRecordVariant(
-                foo = foo,
-                bar = bar,
-                metas = metas)
-        
-        
-        // Variants for Sum: SumB 
-        override fun willBeUnchanged(
-            metas: MetaContainer
-        ): DomainB.SumB.WillBeUnchanged =
-            DomainB.SumB.WillBeUnchanged(
-                metas = metas)
-        
-        
-        override fun willBeReplaced(
-            something: String,
-            metas: MetaContainer
         ): DomainB.SumB.WillBeReplaced =
             DomainB.SumB.WillBeReplaced(
                 something = something.asPrimitive(),
-                metas = metas)
+                metas = metas + newMetaContainer())
         
-        override fun willBeReplaced_(
+        /**
+        * Creates an instance of [DomainB.SumB.WillBeReplaced].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
+        fun willBeReplaced_(
             something: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.SumB.WillBeReplaced =
             DomainB.SumB.WillBeReplaced(
                 something = something,
-                metas = metas)
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: NewSum 
-        override fun eek(
-            metas: MetaContainer
+        /**
+        * Creates an instance of [DomainB.NewSum.Eek].
+        */
+        fun eek(
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewSum.Eek =
             DomainB.NewSum.Eek(
-                metas = metas)
+                metas = metas + newMetaContainer())
         
         
-        override fun whatever(
-            metas: MetaContainer
+        /**
+        * Creates an instance of [DomainB.NewSum.Whatever].
+        */
+        fun whatever(
+            metas: MetaContainer = emptyMetaContainer()
         ): DomainB.NewSum.Whatever =
             DomainB.NewSum.Whatever(
-                metas = metas)
+                metas = metas + newMetaContainer())
     }
+    
+    /** Default implementation of [Builder] that uses all default method implementations. */
+    private object DomainBBuilder : Builder
     
     /** Base class for all DomainB types. */
     abstract class DomainBNode : DomainNode {

--- a/pig-tests/src/org/partiql/pig/tests/generated/toy-lang.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/toy-lang.kt
@@ -37,7 +37,7 @@ class ToyLang private constructor() {
          * Creates an instance of [ToyLang.Operator.Plus].
          */
         fun plus(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Plus =
             ToyLang.Operator.Plus(
                 metas = newMetaContainer() + metas
@@ -48,7 +48,7 @@ class ToyLang private constructor() {
          * Creates an instance of [ToyLang.Operator.Minus].
          */
         fun minus(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Minus =
             ToyLang.Operator.Minus(
                 metas = newMetaContainer() + metas
@@ -59,7 +59,7 @@ class ToyLang private constructor() {
          * Creates an instance of [ToyLang.Operator.Times].
          */
         fun times(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Times =
             ToyLang.Operator.Times(
                 metas = newMetaContainer() + metas
@@ -70,7 +70,7 @@ class ToyLang private constructor() {
          * Creates an instance of [ToyLang.Operator.Divide].
          */
         fun divide(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Divide =
             ToyLang.Operator.Divide(
                 metas = newMetaContainer() + metas
@@ -81,7 +81,7 @@ class ToyLang private constructor() {
          * Creates an instance of [ToyLang.Operator.Modulo].
          */
         fun modulo(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Modulo =
             ToyLang.Operator.Modulo(
                 metas = newMetaContainer() + metas
@@ -93,8 +93,8 @@ class ToyLang private constructor() {
          * Creates an instance of [ToyLang.Expr.Lit].
          */
         fun lit(
-                    value: com.amazon.ionelement.api.IonElement,
-                metas: MetaContainer = emptyMetaContainer()
+            value: com.amazon.ionelement.api.IonElement,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Lit =
             ToyLang.Expr.Lit(
                 value = value.asAnyElement(),
@@ -106,8 +106,8 @@ class ToyLang private constructor() {
          * Creates an instance of [ToyLang.Expr.Variable].
          */
         fun variable(
-                    name: String,
-                metas: MetaContainer = emptyMetaContainer()
+            name: String,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Variable =
             ToyLang.Expr.Variable(
                 name = name.asPrimitive(),
@@ -122,8 +122,8 @@ class ToyLang private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun variable_(
-                    name: org.partiql.pig.runtime.SymbolPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Variable =
             ToyLang.Expr.Variable(
                 name = name,
@@ -135,8 +135,8 @@ class ToyLang private constructor() {
          * Creates an instance of [ToyLang.Expr.Not].
          */
         fun not(
-                    expr: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            expr: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Not =
             ToyLang.Expr.Not(
                 expr = expr,
@@ -148,9 +148,9 @@ class ToyLang private constructor() {
          * Creates an instance of [ToyLang.Expr.Nary].
          */
         fun nary(
-                    op: Operator,
-                    operands: kotlin.collections.List<Expr> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            op: Operator,
+            operands: kotlin.collections.List<Expr> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Nary =
             ToyLang.Expr.Nary(
                 op = op,
@@ -162,9 +162,9 @@ class ToyLang private constructor() {
          * Creates an instance of [ToyLang.Expr.Nary].
          */
         fun nary(
-                    op: Operator,
-                    vararg operands: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            op: Operator,
+            vararg operands: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Nary =
             ToyLang.Expr.Nary(
                 op = op,
@@ -177,10 +177,10 @@ class ToyLang private constructor() {
          * Creates an instance of [ToyLang.Expr.Let].
          */
         fun let(
-                    name: String,
-                    value: Expr,
-                    body: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            name: String,
+            value: Expr,
+            body: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Let =
             ToyLang.Expr.Let(
                 name = name.asPrimitive(),
@@ -197,10 +197,10 @@ class ToyLang private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun let_(
-                    name: org.partiql.pig.runtime.SymbolPrimitive,
-                    value: Expr,
-                    body: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            value: Expr,
+            body: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Let =
             ToyLang.Expr.Let(
                 name = name,
@@ -214,9 +214,9 @@ class ToyLang private constructor() {
          * Creates an instance of [ToyLang.Expr.Function].
          */
         fun function(
-                    varName: String,
-                    body: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            varName: String,
+            body: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Function =
             ToyLang.Expr.Function(
                 varName = varName.asPrimitive(),
@@ -232,9 +232,9 @@ class ToyLang private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun function_(
-                    varName: org.partiql.pig.runtime.SymbolPrimitive,
-                    body: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            varName: org.partiql.pig.runtime.SymbolPrimitive,
+            body: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Function =
             ToyLang.Expr.Function(
                 varName = varName,
@@ -1448,7 +1448,7 @@ class ToyLangIndexed private constructor() {
          * Creates an instance of [ToyLangIndexed.Operator.Plus].
          */
         fun plus(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Plus =
             ToyLangIndexed.Operator.Plus(
                 metas = newMetaContainer() + metas
@@ -1459,7 +1459,7 @@ class ToyLangIndexed private constructor() {
          * Creates an instance of [ToyLangIndexed.Operator.Minus].
          */
         fun minus(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Minus =
             ToyLangIndexed.Operator.Minus(
                 metas = newMetaContainer() + metas
@@ -1470,7 +1470,7 @@ class ToyLangIndexed private constructor() {
          * Creates an instance of [ToyLangIndexed.Operator.Times].
          */
         fun times(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Times =
             ToyLangIndexed.Operator.Times(
                 metas = newMetaContainer() + metas
@@ -1481,7 +1481,7 @@ class ToyLangIndexed private constructor() {
          * Creates an instance of [ToyLangIndexed.Operator.Divide].
          */
         fun divide(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Divide =
             ToyLangIndexed.Operator.Divide(
                 metas = newMetaContainer() + metas
@@ -1492,7 +1492,7 @@ class ToyLangIndexed private constructor() {
          * Creates an instance of [ToyLangIndexed.Operator.Modulo].
          */
         fun modulo(
-                metas: MetaContainer = emptyMetaContainer()
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Modulo =
             ToyLangIndexed.Operator.Modulo(
                 metas = newMetaContainer() + metas
@@ -1504,8 +1504,8 @@ class ToyLangIndexed private constructor() {
          * Creates an instance of [ToyLangIndexed.Expr.Lit].
          */
         fun lit(
-                    value: com.amazon.ionelement.api.IonElement,
-                metas: MetaContainer = emptyMetaContainer()
+            value: com.amazon.ionelement.api.IonElement,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Lit =
             ToyLangIndexed.Expr.Lit(
                 value = value.asAnyElement(),
@@ -1517,8 +1517,8 @@ class ToyLangIndexed private constructor() {
          * Creates an instance of [ToyLangIndexed.Expr.Not].
          */
         fun not(
-                    expr: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            expr: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Not =
             ToyLangIndexed.Expr.Not(
                 expr = expr,
@@ -1530,9 +1530,9 @@ class ToyLangIndexed private constructor() {
          * Creates an instance of [ToyLangIndexed.Expr.Nary].
          */
         fun nary(
-                    op: Operator,
-                    operands: kotlin.collections.List<Expr> = emptyList(),
-                metas: MetaContainer = emptyMetaContainer()
+            op: Operator,
+            operands: kotlin.collections.List<Expr> = emptyList(),
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Nary =
             ToyLangIndexed.Expr.Nary(
                 op = op,
@@ -1544,9 +1544,9 @@ class ToyLangIndexed private constructor() {
          * Creates an instance of [ToyLangIndexed.Expr.Nary].
          */
         fun nary(
-                    op: Operator,
-                    vararg operands: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            op: Operator,
+            vararg operands: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Nary =
             ToyLangIndexed.Expr.Nary(
                 op = op,
@@ -1559,9 +1559,9 @@ class ToyLangIndexed private constructor() {
          * Creates an instance of [ToyLangIndexed.Expr.Function].
          */
         fun function(
-                    varName: String,
-                    body: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            varName: String,
+            body: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Function =
             ToyLangIndexed.Expr.Function(
                 varName = varName.asPrimitive(),
@@ -1577,9 +1577,9 @@ class ToyLangIndexed private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun function_(
-                    varName: org.partiql.pig.runtime.SymbolPrimitive,
-                    body: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            varName: org.partiql.pig.runtime.SymbolPrimitive,
+            body: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Function =
             ToyLangIndexed.Expr.Function(
                 varName = varName,
@@ -1592,9 +1592,9 @@ class ToyLangIndexed private constructor() {
          * Creates an instance of [ToyLangIndexed.Expr.Variable].
          */
         fun variable(
-                    name: String,
-                    index: Long,
-                metas: MetaContainer = emptyMetaContainer()
+            name: String,
+            index: Long,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Variable =
             ToyLangIndexed.Expr.Variable(
                 name = name.asPrimitive(),
@@ -1610,9 +1610,9 @@ class ToyLangIndexed private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun variable_(
-                    name: org.partiql.pig.runtime.SymbolPrimitive,
-                    index: org.partiql.pig.runtime.LongPrimitive,
-                metas: MetaContainer = emptyMetaContainer()
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            index: org.partiql.pig.runtime.LongPrimitive,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Variable =
             ToyLangIndexed.Expr.Variable(
                 name = name,
@@ -1625,11 +1625,11 @@ class ToyLangIndexed private constructor() {
          * Creates an instance of [ToyLangIndexed.Expr.Let].
          */
         fun let(
-                    name: String,
-                    index: Long,
-                    value: Expr,
-                    body: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            name: String,
+            index: Long,
+            value: Expr,
+            body: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Let =
             ToyLangIndexed.Expr.Let(
                 name = name.asPrimitive(),
@@ -1647,11 +1647,11 @@ class ToyLangIndexed private constructor() {
          * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
          */
         fun let_(
-                    name: org.partiql.pig.runtime.SymbolPrimitive,
-                    index: org.partiql.pig.runtime.LongPrimitive,
-                    value: Expr,
-                    body: Expr,
-                metas: MetaContainer = emptyMetaContainer()
+            name: org.partiql.pig.runtime.SymbolPrimitive,
+            index: org.partiql.pig.runtime.LongPrimitive,
+            value: Expr,
+            body: Expr,
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Let =
             ToyLangIndexed.Expr.Let(
                 name = name,

--- a/pig-tests/src/org/partiql/pig/tests/generated/toy-lang.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/toy-lang.kt
@@ -34,110 +34,119 @@ class ToyLang private constructor() {
     
         // Variants for Sum: Operator 
         /**
-        * Creates an instance of [ToyLang.Operator.Plus].
-        */
+         * Creates an instance of [ToyLang.Operator.Plus].
+         */
         fun plus(
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Plus =
             ToyLang.Operator.Plus(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLang.Operator.Minus].
-        */
+         * Creates an instance of [ToyLang.Operator.Minus].
+         */
         fun minus(
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Minus =
             ToyLang.Operator.Minus(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLang.Operator.Times].
-        */
+         * Creates an instance of [ToyLang.Operator.Times].
+         */
         fun times(
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Times =
             ToyLang.Operator.Times(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLang.Operator.Divide].
-        */
+         * Creates an instance of [ToyLang.Operator.Divide].
+         */
         fun divide(
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Divide =
             ToyLang.Operator.Divide(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLang.Operator.Modulo].
-        */
+         * Creates an instance of [ToyLang.Operator.Modulo].
+         */
         fun modulo(
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Modulo =
             ToyLang.Operator.Modulo(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: Expr 
         /**
-        * Creates an instance of [ToyLang.Expr.Lit].
-        */
+         * Creates an instance of [ToyLang.Expr.Lit].
+         */
         fun lit(
                     value: com.amazon.ionelement.api.IonElement,
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Lit =
             ToyLang.Expr.Lit(
                 value = value.asAnyElement(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLang.Expr.Variable].
-        */
+         * Creates an instance of [ToyLang.Expr.Variable].
+         */
         fun variable(
                     name: String,
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Variable =
             ToyLang.Expr.Variable(
                 name = name.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [ToyLang.Expr.Variable].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [ToyLang.Expr.Variable].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun variable_(
                     name: org.partiql.pig.runtime.SymbolPrimitive,
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Variable =
             ToyLang.Expr.Variable(
                 name = name,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLang.Expr.Not].
-        */
+         * Creates an instance of [ToyLang.Expr.Not].
+         */
         fun not(
                     expr: Expr,
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Not =
             ToyLang.Expr.Not(
                 expr = expr,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLang.Expr.Nary].
-        */
+         * Creates an instance of [ToyLang.Expr.Nary].
+         */
         fun nary(
                     op: Operator,
                     operands: kotlin.collections.List<Expr> = emptyList(),
@@ -146,11 +155,12 @@ class ToyLang private constructor() {
             ToyLang.Expr.Nary(
                 op = op,
                 operands = operands,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [ToyLang.Expr.Nary].
-        */
+         * Creates an instance of [ToyLang.Expr.Nary].
+         */
         fun nary(
                     op: Operator,
                     vararg operands: Expr,
@@ -159,12 +169,13 @@ class ToyLang private constructor() {
             ToyLang.Expr.Nary(
                 op = op,
                 operands = operands.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLang.Expr.Let].
-        */
+         * Creates an instance of [ToyLang.Expr.Let].
+         */
         fun let(
                     name: String,
                     value: Expr,
@@ -175,15 +186,16 @@ class ToyLang private constructor() {
                 name = name.asPrimitive(),
                 value = value,
                 body = body,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [ToyLang.Expr.Let].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [ToyLang.Expr.Let].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun let_(
                     name: org.partiql.pig.runtime.SymbolPrimitive,
                     value: Expr,
@@ -194,12 +206,13 @@ class ToyLang private constructor() {
                 name = name,
                 value = value,
                 body = body,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLang.Expr.Function].
-        */
+         * Creates an instance of [ToyLang.Expr.Function].
+         */
         fun function(
                     varName: String,
                     body: Expr,
@@ -208,15 +221,16 @@ class ToyLang private constructor() {
             ToyLang.Expr.Function(
                 varName = varName.asPrimitive(),
                 body = body,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [ToyLang.Expr.Function].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [ToyLang.Expr.Function].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun function_(
                     varName: org.partiql.pig.runtime.SymbolPrimitive,
                     body: Expr,
@@ -225,7 +239,8 @@ class ToyLang private constructor() {
             ToyLang.Expr.Function(
                 varName = varName,
                 body = body,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */
@@ -1430,83 +1445,90 @@ class ToyLangIndexed private constructor() {
     
         // Variants for Sum: Operator 
         /**
-        * Creates an instance of [ToyLangIndexed.Operator.Plus].
-        */
+         * Creates an instance of [ToyLangIndexed.Operator.Plus].
+         */
         fun plus(
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Plus =
             ToyLangIndexed.Operator.Plus(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLangIndexed.Operator.Minus].
-        */
+         * Creates an instance of [ToyLangIndexed.Operator.Minus].
+         */
         fun minus(
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Minus =
             ToyLangIndexed.Operator.Minus(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLangIndexed.Operator.Times].
-        */
+         * Creates an instance of [ToyLangIndexed.Operator.Times].
+         */
         fun times(
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Times =
             ToyLangIndexed.Operator.Times(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLangIndexed.Operator.Divide].
-        */
+         * Creates an instance of [ToyLangIndexed.Operator.Divide].
+         */
         fun divide(
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Divide =
             ToyLangIndexed.Operator.Divide(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLangIndexed.Operator.Modulo].
-        */
+         * Creates an instance of [ToyLangIndexed.Operator.Modulo].
+         */
         fun modulo(
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Modulo =
             ToyLangIndexed.Operator.Modulo(
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         // Variants for Sum: Expr 
         /**
-        * Creates an instance of [ToyLangIndexed.Expr.Lit].
-        */
+         * Creates an instance of [ToyLangIndexed.Expr.Lit].
+         */
         fun lit(
                     value: com.amazon.ionelement.api.IonElement,
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Lit =
             ToyLangIndexed.Expr.Lit(
                 value = value.asAnyElement(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLangIndexed.Expr.Not].
-        */
+         * Creates an instance of [ToyLangIndexed.Expr.Not].
+         */
         fun not(
                     expr: Expr,
                 metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Not =
             ToyLangIndexed.Expr.Not(
                 expr = expr,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLangIndexed.Expr.Nary].
-        */
+         * Creates an instance of [ToyLangIndexed.Expr.Nary].
+         */
         fun nary(
                     op: Operator,
                     operands: kotlin.collections.List<Expr> = emptyList(),
@@ -1515,11 +1537,12 @@ class ToyLangIndexed private constructor() {
             ToyLangIndexed.Expr.Nary(
                 op = op,
                 operands = operands,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [ToyLangIndexed.Expr.Nary].
-        */
+         * Creates an instance of [ToyLangIndexed.Expr.Nary].
+         */
         fun nary(
                     op: Operator,
                     vararg operands: Expr,
@@ -1528,12 +1551,13 @@ class ToyLangIndexed private constructor() {
             ToyLangIndexed.Expr.Nary(
                 op = op,
                 operands = operands.toList(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLangIndexed.Expr.Function].
-        */
+         * Creates an instance of [ToyLangIndexed.Expr.Function].
+         */
         fun function(
                     varName: String,
                     body: Expr,
@@ -1542,15 +1566,16 @@ class ToyLangIndexed private constructor() {
             ToyLangIndexed.Expr.Function(
                 varName = varName.asPrimitive(),
                 body = body,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [ToyLangIndexed.Expr.Function].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [ToyLangIndexed.Expr.Function].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun function_(
                     varName: org.partiql.pig.runtime.SymbolPrimitive,
                     body: Expr,
@@ -1559,12 +1584,13 @@ class ToyLangIndexed private constructor() {
             ToyLangIndexed.Expr.Function(
                 varName = varName,
                 body = body,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLangIndexed.Expr.Variable].
-        */
+         * Creates an instance of [ToyLangIndexed.Expr.Variable].
+         */
         fun variable(
                     name: String,
                     index: Long,
@@ -1573,15 +1599,16 @@ class ToyLangIndexed private constructor() {
             ToyLangIndexed.Expr.Variable(
                 name = name.asPrimitive(),
                 index = index.asPrimitive(),
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [ToyLangIndexed.Expr.Variable].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [ToyLangIndexed.Expr.Variable].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun variable_(
                     name: org.partiql.pig.runtime.SymbolPrimitive,
                     index: org.partiql.pig.runtime.LongPrimitive,
@@ -1590,12 +1617,13 @@ class ToyLangIndexed private constructor() {
             ToyLangIndexed.Expr.Variable(
                 name = name,
                 index = index,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         
         /**
-        * Creates an instance of [ToyLangIndexed.Expr.Let].
-        */
+         * Creates an instance of [ToyLangIndexed.Expr.Let].
+         */
         fun let(
                     name: String,
                     index: Long,
@@ -1608,15 +1636,16 @@ class ToyLangIndexed private constructor() {
                 index = index.asPrimitive(),
                 value = value,
                 body = body,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
         
         /**
-        * Creates an instance of [ToyLangIndexed.Expr.Let].
-        *
-        * Use this variant when metas must be passed to primitive child elements.
-        *
-        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-        */
+         * Creates an instance of [ToyLangIndexed.Expr.Let].
+         *
+         * Use this variant when metas must be passed to primitive child elements.
+         *
+         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+         */
         fun let_(
                     name: org.partiql.pig.runtime.SymbolPrimitive,
                     index: org.partiql.pig.runtime.LongPrimitive,
@@ -1629,7 +1658,8 @@ class ToyLangIndexed private constructor() {
                 index = index,
                 value = value,
                 body = body,
-                metas = newMetaContainer() + metas)
+                metas = newMetaContainer() + metas
+            )
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */

--- a/pig-tests/src/org/partiql/pig/tests/generated/toy-lang.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/toy-lang.kt
@@ -37,50 +37,50 @@ class ToyLang private constructor() {
         * Creates an instance of [ToyLang.Operator.Plus].
         */
         fun plus(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Plus =
             ToyLang.Operator.Plus(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLang.Operator.Minus].
         */
         fun minus(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Minus =
             ToyLang.Operator.Minus(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLang.Operator.Times].
         */
         fun times(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Times =
             ToyLang.Operator.Times(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLang.Operator.Divide].
         */
         fun divide(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Divide =
             ToyLang.Operator.Divide(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLang.Operator.Modulo].
         */
         fun modulo(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Operator.Modulo =
             ToyLang.Operator.Modulo(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: Expr 
@@ -88,24 +88,24 @@ class ToyLang private constructor() {
         * Creates an instance of [ToyLang.Expr.Lit].
         */
         fun lit(
-            value: com.amazon.ionelement.api.IonElement,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: com.amazon.ionelement.api.IonElement,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Lit =
             ToyLang.Expr.Lit(
                 value = value.asAnyElement(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLang.Expr.Variable].
         */
         fun variable(
-            name: String,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: String,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Variable =
             ToyLang.Expr.Variable(
                 name = name.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [ToyLang.Expr.Variable].
@@ -115,67 +115,67 @@ class ToyLang private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun variable_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: org.partiql.pig.runtime.SymbolPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Variable =
             ToyLang.Expr.Variable(
                 name = name,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLang.Expr.Not].
         */
         fun not(
-            expr: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    expr: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Not =
             ToyLang.Expr.Not(
                 expr = expr,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLang.Expr.Nary].
         */
         fun nary(
-            op: Operator,
-            operands: kotlin.collections.List<Expr> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    op: Operator,
+                    operands: kotlin.collections.List<Expr> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Nary =
             ToyLang.Expr.Nary(
                 op = op,
                 operands = operands,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [ToyLang.Expr.Nary].
         */
         fun nary(
-            op: Operator,
-            vararg operands: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    op: Operator,
+                    vararg operands: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Nary =
             ToyLang.Expr.Nary(
                 op = op,
                 operands = operands.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLang.Expr.Let].
         */
         fun let(
-            name: String,
-            value: Expr,
-            body: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: String,
+                    value: Expr,
+                    body: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Let =
             ToyLang.Expr.Let(
                 name = name.asPrimitive(),
                 value = value,
                 body = body,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [ToyLang.Expr.Let].
@@ -185,30 +185,30 @@ class ToyLang private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun let_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            value: Expr,
-            body: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: org.partiql.pig.runtime.SymbolPrimitive,
+                    value: Expr,
+                    body: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Let =
             ToyLang.Expr.Let(
                 name = name,
                 value = value,
                 body = body,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLang.Expr.Function].
         */
         fun function(
-            varName: String,
-            body: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    varName: String,
+                    body: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Function =
             ToyLang.Expr.Function(
                 varName = varName.asPrimitive(),
                 body = body,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [ToyLang.Expr.Function].
@@ -218,14 +218,14 @@ class ToyLang private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun function_(
-            varName: org.partiql.pig.runtime.SymbolPrimitive,
-            body: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    varName: org.partiql.pig.runtime.SymbolPrimitive,
+                    body: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Function =
             ToyLang.Expr.Function(
                 varName = varName,
                 body = body,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */
@@ -1433,50 +1433,50 @@ class ToyLangIndexed private constructor() {
         * Creates an instance of [ToyLangIndexed.Operator.Plus].
         */
         fun plus(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Plus =
             ToyLangIndexed.Operator.Plus(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLangIndexed.Operator.Minus].
         */
         fun minus(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Minus =
             ToyLangIndexed.Operator.Minus(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLangIndexed.Operator.Times].
         */
         fun times(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Times =
             ToyLangIndexed.Operator.Times(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLangIndexed.Operator.Divide].
         */
         fun divide(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Divide =
             ToyLangIndexed.Operator.Divide(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLangIndexed.Operator.Modulo].
         */
         fun modulo(
-            metas: MetaContainer = emptyMetaContainer()
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Operator.Modulo =
             ToyLangIndexed.Operator.Modulo(
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         // Variants for Sum: Expr 
@@ -1484,65 +1484,65 @@ class ToyLangIndexed private constructor() {
         * Creates an instance of [ToyLangIndexed.Expr.Lit].
         */
         fun lit(
-            value: com.amazon.ionelement.api.IonElement,
-            metas: MetaContainer = emptyMetaContainer()
+                    value: com.amazon.ionelement.api.IonElement,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Lit =
             ToyLangIndexed.Expr.Lit(
                 value = value.asAnyElement(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLangIndexed.Expr.Not].
         */
         fun not(
-            expr: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    expr: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Not =
             ToyLangIndexed.Expr.Not(
                 expr = expr,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLangIndexed.Expr.Nary].
         */
         fun nary(
-            op: Operator,
-            operands: kotlin.collections.List<Expr> = emptyList(),
-            metas: MetaContainer = emptyMetaContainer()
+                    op: Operator,
+                    operands: kotlin.collections.List<Expr> = emptyList(),
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Nary =
             ToyLangIndexed.Expr.Nary(
                 op = op,
                 operands = operands,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [ToyLangIndexed.Expr.Nary].
         */
         fun nary(
-            op: Operator,
-            vararg operands: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    op: Operator,
+                    vararg operands: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Nary =
             ToyLangIndexed.Expr.Nary(
                 op = op,
                 operands = operands.toList(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLangIndexed.Expr.Function].
         */
         fun function(
-            varName: String,
-            body: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    varName: String,
+                    body: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Function =
             ToyLangIndexed.Expr.Function(
                 varName = varName.asPrimitive(),
                 body = body,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [ToyLangIndexed.Expr.Function].
@@ -1552,28 +1552,28 @@ class ToyLangIndexed private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun function_(
-            varName: org.partiql.pig.runtime.SymbolPrimitive,
-            body: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    varName: org.partiql.pig.runtime.SymbolPrimitive,
+                    body: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Function =
             ToyLangIndexed.Expr.Function(
                 varName = varName,
                 body = body,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLangIndexed.Expr.Variable].
         */
         fun variable(
-            name: String,
-            index: Long,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: String,
+                    index: Long,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Variable =
             ToyLangIndexed.Expr.Variable(
                 name = name.asPrimitive(),
                 index = index.asPrimitive(),
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [ToyLangIndexed.Expr.Variable].
@@ -1583,32 +1583,32 @@ class ToyLangIndexed private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun variable_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            index: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: org.partiql.pig.runtime.SymbolPrimitive,
+                    index: org.partiql.pig.runtime.LongPrimitive,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Variable =
             ToyLangIndexed.Expr.Variable(
                 name = name,
                 index = index,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         
         /**
         * Creates an instance of [ToyLangIndexed.Expr.Let].
         */
         fun let(
-            name: String,
-            index: Long,
-            value: Expr,
-            body: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: String,
+                    index: Long,
+                    value: Expr,
+                    body: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Let =
             ToyLangIndexed.Expr.Let(
                 name = name.asPrimitive(),
                 index = index.asPrimitive(),
                 value = value,
                 body = body,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
         
         /**
         * Creates an instance of [ToyLangIndexed.Expr.Let].
@@ -1618,18 +1618,18 @@ class ToyLangIndexed private constructor() {
         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
         */
         fun let_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            index: org.partiql.pig.runtime.LongPrimitive,
-            value: Expr,
-            body: Expr,
-            metas: MetaContainer = emptyMetaContainer()
+                    name: org.partiql.pig.runtime.SymbolPrimitive,
+                    index: org.partiql.pig.runtime.LongPrimitive,
+                    value: Expr,
+                    body: Expr,
+                metas: MetaContainer = emptyMetaContainer()
         ): ToyLangIndexed.Expr.Let =
             ToyLangIndexed.Expr.Let(
                 name = name,
                 index = index,
                 value = value,
                 body = body,
-                metas = metas + newMetaContainer())
+                metas = newMetaContainer() + metas)
     }
     
     /** Default implementation of [Builder] that uses all default method implementations. */

--- a/pig-tests/src/org/partiql/pig/tests/generated/toy-lang.kt
+++ b/pig-tests/src/org/partiql/pig/tests/generated/toy-lang.kt
@@ -30,293 +30,206 @@ class ToyLang private constructor() {
     }
     
     interface Builder {
+        fun newMetaContainer() = emptyMetaContainer()
+    
         // Variants for Sum: Operator 
         /**
-         * Creates an instance of [ToyLang.Operator.Plus].
-         */
+        * Creates an instance of [ToyLang.Operator.Plus].
+        */
         fun plus(
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Operator.Plus
+        ): ToyLang.Operator.Plus =
+            ToyLang.Operator.Plus(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLang.Operator.Minus].
-         */
+        * Creates an instance of [ToyLang.Operator.Minus].
+        */
         fun minus(
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Operator.Minus
+        ): ToyLang.Operator.Minus =
+            ToyLang.Operator.Minus(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLang.Operator.Times].
-         */
+        * Creates an instance of [ToyLang.Operator.Times].
+        */
         fun times(
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Operator.Times
+        ): ToyLang.Operator.Times =
+            ToyLang.Operator.Times(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLang.Operator.Divide].
-         */
+        * Creates an instance of [ToyLang.Operator.Divide].
+        */
         fun divide(
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Operator.Divide
+        ): ToyLang.Operator.Divide =
+            ToyLang.Operator.Divide(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLang.Operator.Modulo].
-         */
+        * Creates an instance of [ToyLang.Operator.Modulo].
+        */
         fun modulo(
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Operator.Modulo
+        ): ToyLang.Operator.Modulo =
+            ToyLang.Operator.Modulo(
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: Expr 
         /**
-         * Creates an instance of [ToyLang.Expr.Lit].
-         */
+        * Creates an instance of [ToyLang.Expr.Lit].
+        */
         fun lit(
             value: com.amazon.ionelement.api.IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Lit
+        ): ToyLang.Expr.Lit =
+            ToyLang.Expr.Lit(
+                value = value.asAnyElement(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLang.Expr.Variable].
-         */
+        * Creates an instance of [ToyLang.Expr.Variable].
+        */
         fun variable(
             name: String,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Variable
+        ): ToyLang.Expr.Variable =
+            ToyLang.Expr.Variable(
+                name = name.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [ToyLang.Expr.Variable].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [ToyLang.Expr.Variable].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun variable_(
             name: org.partiql.pig.runtime.SymbolPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Variable
+        ): ToyLang.Expr.Variable =
+            ToyLang.Expr.Variable(
+                name = name,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLang.Expr.Not].
-         */
+        * Creates an instance of [ToyLang.Expr.Not].
+        */
         fun not(
             expr: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Not
+        ): ToyLang.Expr.Not =
+            ToyLang.Expr.Not(
+                expr = expr,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLang.Expr.Nary].
-         */
+        * Creates an instance of [ToyLang.Expr.Nary].
+        */
         fun nary(
             op: Operator,
             operands: kotlin.collections.List<Expr> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Nary
+        ): ToyLang.Expr.Nary =
+            ToyLang.Expr.Nary(
+                op = op,
+                operands = operands,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [ToyLang.Expr.Nary].
-         */
+        * Creates an instance of [ToyLang.Expr.Nary].
+        */
         fun nary(
             op: Operator,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Nary
+        ): ToyLang.Expr.Nary =
+            ToyLang.Expr.Nary(
+                op = op,
+                operands = operands.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLang.Expr.Let].
-         */
+        * Creates an instance of [ToyLang.Expr.Let].
+        */
         fun let(
             name: String,
             value: Expr,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Let
+        ): ToyLang.Expr.Let =
+            ToyLang.Expr.Let(
+                name = name.asPrimitive(),
+                value = value,
+                body = body,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [ToyLang.Expr.Let].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [ToyLang.Expr.Let].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun let_(
             name: org.partiql.pig.runtime.SymbolPrimitive,
             value: Expr,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Let
+        ): ToyLang.Expr.Let =
+            ToyLang.Expr.Let(
+                name = name,
+                value = value,
+                body = body,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLang.Expr.Function].
-         */
+        * Creates an instance of [ToyLang.Expr.Function].
+        */
         fun function(
             varName: String,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Function
-        
-        /**
-         * Creates an instance of [ToyLang.Expr.Function].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
-        fun function_(
-            varName: org.partiql.pig.runtime.SymbolPrimitive,
-            body: Expr,
-            metas: MetaContainer = emptyMetaContainer()
-        ): ToyLang.Expr.Function
-    }
-    
-    private object ToyLangBuilder : Builder {
-        // Variants for Sum: Operator 
-        override fun plus(
-            metas: MetaContainer
-        ): ToyLang.Operator.Plus =
-            ToyLang.Operator.Plus(
-                metas = metas)
-        
-        
-        override fun minus(
-            metas: MetaContainer
-        ): ToyLang.Operator.Minus =
-            ToyLang.Operator.Minus(
-                metas = metas)
-        
-        
-        override fun times(
-            metas: MetaContainer
-        ): ToyLang.Operator.Times =
-            ToyLang.Operator.Times(
-                metas = metas)
-        
-        
-        override fun divide(
-            metas: MetaContainer
-        ): ToyLang.Operator.Divide =
-            ToyLang.Operator.Divide(
-                metas = metas)
-        
-        
-        override fun modulo(
-            metas: MetaContainer
-        ): ToyLang.Operator.Modulo =
-            ToyLang.Operator.Modulo(
-                metas = metas)
-        
-        
-        // Variants for Sum: Expr 
-        override fun lit(
-            value: com.amazon.ionelement.api.IonElement,
-            metas: MetaContainer
-        ): ToyLang.Expr.Lit =
-            ToyLang.Expr.Lit(
-                value = value.asAnyElement(),
-                metas = metas)
-        
-        
-        override fun variable(
-            name: String,
-            metas: MetaContainer
-        ): ToyLang.Expr.Variable =
-            ToyLang.Expr.Variable(
-                name = name.asPrimitive(),
-                metas = metas)
-        
-        override fun variable_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            metas: MetaContainer
-        ): ToyLang.Expr.Variable =
-            ToyLang.Expr.Variable(
-                name = name,
-                metas = metas)
-        
-        
-        override fun not(
-            expr: Expr,
-            metas: MetaContainer
-        ): ToyLang.Expr.Not =
-            ToyLang.Expr.Not(
-                expr = expr,
-                metas = metas)
-        
-        
-        override fun nary(
-            op: Operator,
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer
-        ): ToyLang.Expr.Nary =
-            ToyLang.Expr.Nary(
-                op = op,
-                operands = operands,
-                metas = metas)
-        
-        override fun nary(
-            op: Operator,
-            vararg operands: Expr,
-            metas: MetaContainer
-        ): ToyLang.Expr.Nary =
-            ToyLang.Expr.Nary(
-                op = op,
-                operands = operands.toList(),
-                metas = metas)
-        
-        
-        override fun let(
-            name: String,
-            value: Expr,
-            body: Expr,
-            metas: MetaContainer
-        ): ToyLang.Expr.Let =
-            ToyLang.Expr.Let(
-                name = name.asPrimitive(),
-                value = value,
-                body = body,
-                metas = metas)
-        
-        override fun let_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            value: Expr,
-            body: Expr,
-            metas: MetaContainer
-        ): ToyLang.Expr.Let =
-            ToyLang.Expr.Let(
-                name = name,
-                value = value,
-                body = body,
-                metas = metas)
-        
-        
-        override fun function(
-            varName: String,
-            body: Expr,
-            metas: MetaContainer
         ): ToyLang.Expr.Function =
             ToyLang.Expr.Function(
                 varName = varName.asPrimitive(),
                 body = body,
-                metas = metas)
+                metas = metas + newMetaContainer())
         
-        override fun function_(
+        /**
+        * Creates an instance of [ToyLang.Expr.Function].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
+        fun function_(
             varName: org.partiql.pig.runtime.SymbolPrimitive,
             body: Expr,
-            metas: MetaContainer
+            metas: MetaContainer = emptyMetaContainer()
         ): ToyLang.Expr.Function =
             ToyLang.Expr.Function(
                 varName = varName,
                 body = body,
-                metas = metas)
+                metas = metas + newMetaContainer())
     }
+    
+    /** Default implementation of [Builder] that uses all default method implementations. */
+    private object ToyLangBuilder : Builder
     
     /** Base class for all ToyLang types. */
     abstract class ToyLangNode : DomainNode {
@@ -1513,305 +1426,214 @@ class ToyLangIndexed private constructor() {
     }
     
     interface Builder {
+        fun newMetaContainer() = emptyMetaContainer()
+    
         // Variants for Sum: Operator 
         /**
-         * Creates an instance of [ToyLangIndexed.Operator.Plus].
-         */
+        * Creates an instance of [ToyLangIndexed.Operator.Plus].
+        */
         fun plus(
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Operator.Plus
+        ): ToyLangIndexed.Operator.Plus =
+            ToyLangIndexed.Operator.Plus(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLangIndexed.Operator.Minus].
-         */
+        * Creates an instance of [ToyLangIndexed.Operator.Minus].
+        */
         fun minus(
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Operator.Minus
+        ): ToyLangIndexed.Operator.Minus =
+            ToyLangIndexed.Operator.Minus(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLangIndexed.Operator.Times].
-         */
+        * Creates an instance of [ToyLangIndexed.Operator.Times].
+        */
         fun times(
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Operator.Times
+        ): ToyLangIndexed.Operator.Times =
+            ToyLangIndexed.Operator.Times(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLangIndexed.Operator.Divide].
-         */
+        * Creates an instance of [ToyLangIndexed.Operator.Divide].
+        */
         fun divide(
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Operator.Divide
+        ): ToyLangIndexed.Operator.Divide =
+            ToyLangIndexed.Operator.Divide(
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLangIndexed.Operator.Modulo].
-         */
+        * Creates an instance of [ToyLangIndexed.Operator.Modulo].
+        */
         fun modulo(
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Operator.Modulo
+        ): ToyLangIndexed.Operator.Modulo =
+            ToyLangIndexed.Operator.Modulo(
+                metas = metas + newMetaContainer())
         
         
         // Variants for Sum: Expr 
         /**
-         * Creates an instance of [ToyLangIndexed.Expr.Lit].
-         */
+        * Creates an instance of [ToyLangIndexed.Expr.Lit].
+        */
         fun lit(
             value: com.amazon.ionelement.api.IonElement,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Expr.Lit
+        ): ToyLangIndexed.Expr.Lit =
+            ToyLangIndexed.Expr.Lit(
+                value = value.asAnyElement(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLangIndexed.Expr.Not].
-         */
+        * Creates an instance of [ToyLangIndexed.Expr.Not].
+        */
         fun not(
             expr: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Expr.Not
+        ): ToyLangIndexed.Expr.Not =
+            ToyLangIndexed.Expr.Not(
+                expr = expr,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLangIndexed.Expr.Nary].
-         */
+        * Creates an instance of [ToyLangIndexed.Expr.Nary].
+        */
         fun nary(
             op: Operator,
             operands: kotlin.collections.List<Expr> = emptyList(),
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Expr.Nary
+        ): ToyLangIndexed.Expr.Nary =
+            ToyLangIndexed.Expr.Nary(
+                op = op,
+                operands = operands,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [ToyLangIndexed.Expr.Nary].
-         */
+        * Creates an instance of [ToyLangIndexed.Expr.Nary].
+        */
         fun nary(
             op: Operator,
             vararg operands: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Expr.Nary
+        ): ToyLangIndexed.Expr.Nary =
+            ToyLangIndexed.Expr.Nary(
+                op = op,
+                operands = operands.toList(),
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLangIndexed.Expr.Function].
-         */
+        * Creates an instance of [ToyLangIndexed.Expr.Function].
+        */
         fun function(
             varName: String,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Expr.Function
+        ): ToyLangIndexed.Expr.Function =
+            ToyLangIndexed.Expr.Function(
+                varName = varName.asPrimitive(),
+                body = body,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [ToyLangIndexed.Expr.Function].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [ToyLangIndexed.Expr.Function].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun function_(
             varName: org.partiql.pig.runtime.SymbolPrimitive,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Expr.Function
+        ): ToyLangIndexed.Expr.Function =
+            ToyLangIndexed.Expr.Function(
+                varName = varName,
+                body = body,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLangIndexed.Expr.Variable].
-         */
+        * Creates an instance of [ToyLangIndexed.Expr.Variable].
+        */
         fun variable(
             name: String,
             index: Long,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Expr.Variable
+        ): ToyLangIndexed.Expr.Variable =
+            ToyLangIndexed.Expr.Variable(
+                name = name.asPrimitive(),
+                index = index.asPrimitive(),
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [ToyLangIndexed.Expr.Variable].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [ToyLangIndexed.Expr.Variable].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun variable_(
             name: org.partiql.pig.runtime.SymbolPrimitive,
             index: org.partiql.pig.runtime.LongPrimitive,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Expr.Variable
+        ): ToyLangIndexed.Expr.Variable =
+            ToyLangIndexed.Expr.Variable(
+                name = name,
+                index = index,
+                metas = metas + newMetaContainer())
         
         
         /**
-         * Creates an instance of [ToyLangIndexed.Expr.Let].
-         */
+        * Creates an instance of [ToyLangIndexed.Expr.Let].
+        */
         fun let(
             name: String,
             index: Long,
             value: Expr,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Expr.Let
+        ): ToyLangIndexed.Expr.Let =
+            ToyLangIndexed.Expr.Let(
+                name = name.asPrimitive(),
+                index = index.asPrimitive(),
+                value = value,
+                body = body,
+                metas = metas + newMetaContainer())
         
         /**
-         * Creates an instance of [ToyLangIndexed.Expr.Let].
-         *
-         * Use this variant when metas must be passed to primitive child elements.
-         *
-         * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-         */
+        * Creates an instance of [ToyLangIndexed.Expr.Let].
+        *
+        * Use this variant when metas must be passed to primitive child elements.
+        *
+        * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+        */
         fun let_(
             name: org.partiql.pig.runtime.SymbolPrimitive,
             index: org.partiql.pig.runtime.LongPrimitive,
             value: Expr,
             body: Expr,
             metas: MetaContainer = emptyMetaContainer()
-        ): ToyLangIndexed.Expr.Let
+        ): ToyLangIndexed.Expr.Let =
+            ToyLangIndexed.Expr.Let(
+                name = name,
+                index = index,
+                value = value,
+                body = body,
+                metas = metas + newMetaContainer())
     }
     
-    private object ToyLangIndexedBuilder : Builder {
-        // Variants for Sum: Operator 
-        override fun plus(
-            metas: MetaContainer
-        ): ToyLangIndexed.Operator.Plus =
-            ToyLangIndexed.Operator.Plus(
-                metas = metas)
-        
-        
-        override fun minus(
-            metas: MetaContainer
-        ): ToyLangIndexed.Operator.Minus =
-            ToyLangIndexed.Operator.Minus(
-                metas = metas)
-        
-        
-        override fun times(
-            metas: MetaContainer
-        ): ToyLangIndexed.Operator.Times =
-            ToyLangIndexed.Operator.Times(
-                metas = metas)
-        
-        
-        override fun divide(
-            metas: MetaContainer
-        ): ToyLangIndexed.Operator.Divide =
-            ToyLangIndexed.Operator.Divide(
-                metas = metas)
-        
-        
-        override fun modulo(
-            metas: MetaContainer
-        ): ToyLangIndexed.Operator.Modulo =
-            ToyLangIndexed.Operator.Modulo(
-                metas = metas)
-        
-        
-        // Variants for Sum: Expr 
-        override fun lit(
-            value: com.amazon.ionelement.api.IonElement,
-            metas: MetaContainer
-        ): ToyLangIndexed.Expr.Lit =
-            ToyLangIndexed.Expr.Lit(
-                value = value.asAnyElement(),
-                metas = metas)
-        
-        
-        override fun not(
-            expr: Expr,
-            metas: MetaContainer
-        ): ToyLangIndexed.Expr.Not =
-            ToyLangIndexed.Expr.Not(
-                expr = expr,
-                metas = metas)
-        
-        
-        override fun nary(
-            op: Operator,
-            operands: kotlin.collections.List<Expr>,
-            metas: MetaContainer
-        ): ToyLangIndexed.Expr.Nary =
-            ToyLangIndexed.Expr.Nary(
-                op = op,
-                operands = operands,
-                metas = metas)
-        
-        override fun nary(
-            op: Operator,
-            vararg operands: Expr,
-            metas: MetaContainer
-        ): ToyLangIndexed.Expr.Nary =
-            ToyLangIndexed.Expr.Nary(
-                op = op,
-                operands = operands.toList(),
-                metas = metas)
-        
-        
-        override fun function(
-            varName: String,
-            body: Expr,
-            metas: MetaContainer
-        ): ToyLangIndexed.Expr.Function =
-            ToyLangIndexed.Expr.Function(
-                varName = varName.asPrimitive(),
-                body = body,
-                metas = metas)
-        
-        override fun function_(
-            varName: org.partiql.pig.runtime.SymbolPrimitive,
-            body: Expr,
-            metas: MetaContainer
-        ): ToyLangIndexed.Expr.Function =
-            ToyLangIndexed.Expr.Function(
-                varName = varName,
-                body = body,
-                metas = metas)
-        
-        
-        override fun variable(
-            name: String,
-            index: Long,
-            metas: MetaContainer
-        ): ToyLangIndexed.Expr.Variable =
-            ToyLangIndexed.Expr.Variable(
-                name = name.asPrimitive(),
-                index = index.asPrimitive(),
-                metas = metas)
-        
-        override fun variable_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            index: org.partiql.pig.runtime.LongPrimitive,
-            metas: MetaContainer
-        ): ToyLangIndexed.Expr.Variable =
-            ToyLangIndexed.Expr.Variable(
-                name = name,
-                index = index,
-                metas = metas)
-        
-        
-        override fun let(
-            name: String,
-            index: Long,
-            value: Expr,
-            body: Expr,
-            metas: MetaContainer
-        ): ToyLangIndexed.Expr.Let =
-            ToyLangIndexed.Expr.Let(
-                name = name.asPrimitive(),
-                index = index.asPrimitive(),
-                value = value,
-                body = body,
-                metas = metas)
-        
-        override fun let_(
-            name: org.partiql.pig.runtime.SymbolPrimitive,
-            index: org.partiql.pig.runtime.LongPrimitive,
-            value: Expr,
-            body: Expr,
-            metas: MetaContainer
-        ): ToyLangIndexed.Expr.Let =
-            ToyLangIndexed.Expr.Let(
-                name = name,
-                index = index,
-                value = value,
-                body = body,
-                metas = metas)
-    }
+    /** Default implementation of [Builder] that uses all default method implementations. */
+    private object ToyLangIndexedBuilder : Builder
     
     /** Base class for all ToyLangIndexed types. */
     abstract class ToyLangIndexedNode : DomainNode {

--- a/pig-tests/test/org/partiql/pig/tests/CustomMetasTests.kt
+++ b/pig-tests/test/org/partiql/pig/tests/CustomMetasTests.kt
@@ -1,0 +1,42 @@
+package org.partiql.pig.tests
+
+import com.amazon.ionelement.api.MetaContainer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.partiql.pig.tests.generated.TestDomain
+
+/**
+ * Demonstrates and tests a custom builder implementation that allocates unique IDs to each node constructed with it.
+ */
+class CustomMetasTests {
+
+    class NodeIdAssigningBuilder : TestDomain.Builder {
+        private var nextNodeId = 0
+        override fun newMetaContainer(): MetaContainer = mapOf("nodeId" to nextNodeId++)
+    }
+
+    /**
+     * Typically, a builder function such as this should be created which invokes [block] on a our custom
+     * [TestDomain.Builder] instance.
+     *
+     * Note that the receiver type is [TestDomain.Builder] and not [NodeIdAssigningBuilder].  Callers should never
+     * need to be aware of the specific type of [TestDomain.Builder].
+     */
+    private fun <T> buildTestDomainWithNodeIds(block: TestDomain.Builder.() -> T) = NodeIdAssigningBuilder().block()
+
+    @Test
+    fun testCustomBuilder() {
+        val pairPair = buildTestDomainWithNodeIds {
+            intPairPair(
+                intPair(42, 43),
+                intPair(44, 45)
+            )
+        }
+
+        // Note: nodeIds are allocated in the order the nodes are constructed.
+        assertEquals(2, pairPair.metas["nodeId"])
+        assertEquals(0, pairPair.first.metas["nodeId"])
+        assertEquals(1, pairPair.second.metas["nodeId"])
+    }
+}
+

--- a/pig-tests/test/org/partiql/pig/tests/CustomMetasTests.kt
+++ b/pig-tests/test/org/partiql/pig/tests/CustomMetasTests.kt
@@ -1,6 +1,7 @@
 package org.partiql.pig.tests
 
 import com.amazon.ionelement.api.MetaContainer
+import com.amazon.ionelement.api.metaContainerOf
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.partiql.pig.tests.generated.TestDomain
@@ -30,12 +31,14 @@ class CustomMetasTests {
         val pairPair = buildTestDomainWithNodeIds {
             intPairPair(
                 intPair(42, 43),
-                intPair(44, 45)
+                intPair(44, 45),
+                // should still be able to overwrite the metas returned by [NodeIdAssigningBuilder.newMetaContainer],
+                metas = metaContainerOf("nodeId" to 42)
             )
         }
 
         // Note: nodeIds are allocated in the order the nodes are constructed.
-        assertEquals(2, pairPair.metas["nodeId"])
+        assertEquals(42, pairPair.metas["nodeId"])
         assertEquals(0, pairPair.first.metas["nodeId"])
         assertEquals(1, pairPair.second.metas["nodeId"])
     }

--- a/pig-tests/test/org/partiql/pig/tests/CustomMetasTests.kt
+++ b/pig-tests/test/org/partiql/pig/tests/CustomMetasTests.kt
@@ -10,13 +10,14 @@ import org.partiql.pig.tests.generated.TestDomain
  */
 class CustomMetasTests {
 
+    /** Custom builder implementation that assigns unique Ids to all nodes. */
     class NodeIdAssigningBuilder : TestDomain.Builder {
         private var nextNodeId = 0
         override fun newMetaContainer(): MetaContainer = mapOf("nodeId" to nextNodeId++)
     }
 
     /**
-     * Typically, a builder function such as this should be created which invokes [block] on a our custom
+     * Typically, a builder function such as this should be created which invokes [block] on our custom
      * [TestDomain.Builder] instance.
      *
      * Note that the receiver type is [TestDomain.Builder] and not [NodeIdAssigningBuilder].  Callers should never

--- a/pig/resources/org/partiql/pig/templates/kotlin.ftl
+++ b/pig/resources/org/partiql/pig/templates/kotlin.ftl
@@ -127,24 +127,25 @@ class ${t.kotlinName}(
 [#macro builder_constructor_fun t return_type]
 [#list t.builderFunctions as bf]
 /**
-* Creates an instance of [${return_type}].
-[#if bf.kotlinName?ends_with("_")]
-*
-* Use this variant when metas must be passed to primitive child elements.
-*
-* (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+ * Creates an instance of [${return_type}].
+ [#if bf.kotlinName?ends_with("_")]
+ *
+ * Use this variant when metas must be passed to primitive child elements.
+ *
+ * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
 [/#if]
-*/
+ */
 fun ${bf.kotlinName}(
-    [@indent count=4]
-        [@builder_fun_parameter_list bf.parameters/]
-    [/@indent]
+[@indent count=4]
+    [@builder_fun_parameter_list bf.parameters/]
+[/@indent]
 ): ${return_type} =
     ${return_type}(
     [#list bf.constructorArguments as p]
         ${p.kotlinName} = ${p.value},
     [/#list]
-        metas = newMetaContainer() + metas)
+        metas = newMetaContainer() + metas
+    )
 
 [/#list]
 [/#macro]
@@ -190,7 +191,7 @@ interface Builder {
 
     [@indent count = 4]
         [#if domain.tuples?size > 0]
-            // Tuples
+            // Tuples [#lt]
             [#list domain.tuples as tuple]
                 [@builder_constructor_fun tuple "${domain.kotlinName}.${tuple.kotlinName}"/]
 

--- a/pig/resources/org/partiql/pig/templates/kotlin.ftl
+++ b/pig/resources/org/partiql/pig/templates/kotlin.ftl
@@ -117,10 +117,10 @@ class ${t.kotlinName}(
 
 [#-- Generates a parameter list for a builder function, not including (). --]
 [#macro builder_fun_parameter_list params]
-    [#list params as param]
-        [#if param.variadic]vararg [/#if]${param.kotlinName}: ${param.kotlinType}[#if param.defaultValue??] = ${param.defaultValue}[/#if],
-    [/#list]
-    metas: MetaContainer = emptyMetaContainer()
+[#list params as param]
+[#if param.variadic]vararg [/#if]${param.kotlinName}: ${param.kotlinType}[#if param.defaultValue??] = ${param.defaultValue}[/#if],
+[/#list]
+metas: MetaContainer = emptyMetaContainer()
 [/#macro]
 
 [#--Emits builder functions that wrap the constructors of the domain type defined by the builder interface.  --]
@@ -137,7 +137,7 @@ class ${t.kotlinName}(
  */
 fun ${bf.kotlinName}(
 [@indent count=4]
-    [@builder_fun_parameter_list bf.parameters/]
+[@builder_fun_parameter_list bf.parameters/]
 [/@indent]
 ): ${return_type} =
     ${return_type}(

--- a/pig/resources/org/partiql/pig/templates/kotlin.ftl
+++ b/pig/resources/org/partiql/pig/templates/kotlin.ftl
@@ -12,15 +12,6 @@ https://freemarker.apache.org/docs/index.html
 
 https://freemarker.apache.org/docs/dgui_misc_whitespace.html
 --]
-[#-- Generates a parameter list not including (). --]
-
-
-[#macro builder_fun_parameter_list params]
-[#list params as param]
-[#if param.variadic]vararg [/#if]${param.kotlinName}: ${param.kotlinType}[#if param.defaultValue??] = ${param.defaultValue}[/#if],
-[/#list]
-metas: MetaContainer = emptyMetaContainer()
-[/#macro]
 
 [#-- Template to generate a tuple type class. --]
 [#macro tuple t index]
@@ -124,6 +115,14 @@ class ${t.kotlinName}(
 
 [/#macro]
 
+[#-- Generates a parameter list for a builder function, not including (). --]
+[#macro builder_fun_parameter_list params]
+    [#list params as param]
+        [#if param.variadic]vararg [/#if]${param.kotlinName}: ${param.kotlinType}[#if param.defaultValue??] = ${param.defaultValue}[/#if],
+    [/#list]
+    metas: MetaContainer = emptyMetaContainer()
+[/#macro]
+
 [#--Emits builder functions that wrap the constructors of the domain type defined by the builder interface.  --]
 [#macro builder_constructor_fun t return_type]
 [#list t.builderFunctions as bf]
@@ -145,7 +144,7 @@ fun ${bf.kotlinName}(
     [#list bf.constructorArguments as p]
         ${p.kotlinName} = ${p.value},
     [/#list]
-        metas = metas + newMetaContainer())
+        metas = newMetaContainer() + metas)
 
 [/#list]
 [/#macro]

--- a/pig/resources/org/partiql/pig/templates/kotlin.ftl
+++ b/pig/resources/org/partiql/pig/templates/kotlin.ftl
@@ -15,18 +15,11 @@ https://freemarker.apache.org/docs/dgui_misc_whitespace.html
 [#-- Generates a parameter list not including (). --]
 
 
-[#macro parameter_list_with_defaults params]
+[#macro builder_fun_parameter_list params]
 [#list params as param]
 [#if param.variadic]vararg [/#if]${param.kotlinName}: ${param.kotlinType}[#if param.defaultValue??] = ${param.defaultValue}[/#if],
 [/#list]
 metas: MetaContainer = emptyMetaContainer()
-[/#macro]
-
-[#macro parameter_list_no_defaults params]
-[#list params as param]
-[#if param.variadic]vararg [/#if]${param.kotlinName}: ${param.kotlinType},
-[/#list]
-metas: MetaContainer
 [/#macro]
 
 [#-- Template to generate a tuple type class. --]
@@ -131,40 +124,28 @@ class ${t.kotlinName}(
 
 [/#macro]
 
-[#--Emits the interface for the domain's builder functions that wrap the constructors of the domain type. --]
-[#macro builder_constructor_fun_interface t return_type]
-[#list t.builderFunctions as bf]
-/**
- * Creates an instance of [${return_type}].
-[#if bf.kotlinName?ends_with("_")]
- *
- * Use this variant when metas must be passed to primitive child elements.
- *
- * (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
-[/#if]
- */
-fun ${bf.kotlinName}(
-    [@indent count=4]
-        [@parameter_list_with_defaults bf.parameters/]
-    [/@indent]
-): ${return_type}
-
-[/#list]
-[/#macro]
-
 [#--Emits builder functions that wrap the constructors of the domain type defined by the builder interface.  --]
 [#macro builder_constructor_fun t return_type]
 [#list t.builderFunctions as bf]
-override fun ${bf.kotlinName}(
+/**
+* Creates an instance of [${return_type}].
+[#if bf.kotlinName?ends_with("_")]
+*
+* Use this variant when metas must be passed to primitive child elements.
+*
+* (The "_" suffix is needed to work-around conflicts due to type erasure and ambiguities with null arguments.)
+[/#if]
+*/
+fun ${bf.kotlinName}(
     [@indent count=4]
-        [@parameter_list_no_defaults bf.parameters/]
+        [@builder_fun_parameter_list bf.parameters/]
     [/@indent]
 ): ${return_type} =
     ${return_type}(
     [#list bf.constructorArguments as p]
         ${p.kotlinName} = ${p.value},
     [/#list]
-        metas = metas)
+        metas = metas + newMetaContainer())
 
 [/#list]
 [/#macro]
@@ -206,44 +187,29 @@ companion object {
 }
 
 interface Builder {
+    fun newMetaContainer() = emptyMetaContainer()
+
     [@indent count = 4]
         [#if domain.tuples?size > 0]
-        // Tuples
-        [#list domain.tuples as tuple]
-        [@builder_constructor_fun_interface tuple "${domain.kotlinName}.${tuple.kotlinName}"/]
+            // Tuples
+            [#list domain.tuples as tuple]
+                [@builder_constructor_fun tuple "${domain.kotlinName}.${tuple.kotlinName}"/]
 
-        [/#list]
+            [/#list]
         [/#if]
         [#list domain.sums as s]
         [#-- Not sure why the [#lt] below is needed to emit the correct indentation. --]
-        // Variants for Sum: ${s.kotlinName} [#lt]
-        [#list s.variants as tuple]
-        [@builder_constructor_fun_interface tuple "${domain.kotlinName}.${s.kotlinName}.${tuple.kotlinName}"/]
+            // Variants for Sum: ${s.kotlinName} [#lt]
+            [#list s.variants as tuple]
+                [@builder_constructor_fun tuple "${domain.kotlinName}.${s.kotlinName}.${tuple.kotlinName}"/]
 
-        [/#list]
+            [/#list]
         [/#list]
     [/@indent]
 }
 
-private object ${domain.kotlinName}Builder : Builder {
-    [@indent count = 4]
-        [#if domain.tuples?size > 0]
-        // Tuples
-        [#list domain.tuples as tuple]
-        [@builder_constructor_fun tuple "${domain.kotlinName}.${tuple.kotlinName}"/]
-
-        [/#list]
-        [/#if]
-        [#list domain.sums as s]
-        [#-- Not sure why the [#lt] below is needed to emit the correct indentation. --]
-        // Variants for Sum: ${s.kotlinName} [#lt]
-        [#list s.variants as tuple]
-        [@builder_constructor_fun tuple "${domain.kotlinName}.${s.kotlinName}.${tuple.kotlinName}"/]
-
-        [/#list]
-        [/#list]
-    [/@indent]
-}
+/** Default implementation of [Builder] that uses all default method implementations. */
+private object ${domain.kotlinName}Builder : Builder
 
 /** Base class for all ${domain.kotlinName} types. */
 abstract class ${domain.kotlinName}Node : DomainNode {


### PR DESCRIPTION
There's a number of different interesting applications of this, one purpose would be to assign unique identifiers to each node, or to provide a default `metas` collection for every node, other than the empty one that was previously the only choice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
