### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ allprojects {
 
 subprojects {
     group = 'org.partiql'
-    version = '0.3.2-SNAPSHOT'
+    version = '0.4.0'
 }
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 


### PR DESCRIPTION
Prepares PIG `v0.4.0` release

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
