### PR TITLE
Prepare v0.3.3 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ allprojects {
 
 subprojects {
     group = 'org.partiql'
-    version = '0.3.0'
+    version = '0.3.3'
 }
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 


### PR DESCRIPTION
Prepares PIG `v0.3.3` release. Base branch is `v0.3.3`, which uses `v0.3.0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
