### PR TITLE
Update maven publishing name and email

### DIFF
--- a/pig-runtime/build.gradle
+++ b/pig-runtime/build.gradle
@@ -92,8 +92,8 @@ publishing {
                 }
                 developers {
                     developer {
-                        name = "Amazon Ion Team"
-                        email = "ion-team@amazon.com"
+                        name = "PartiQL Team"
+                        email = "partiql-team@amazon.com"
                         organization = "PartiQL"
                         organizationUrl = "https://github.com/partiql"
                     }

--- a/pig/build.gradle
+++ b/pig/build.gradle
@@ -113,8 +113,8 @@ publishing {
                 }
                 developers {
                     developer {
-                        name = "Amazon Ion Team"
-                        email = "ion-team@amazon.com"
+                        name = "PartiQL Team"
+                        email = "partiql-team@amazon.com"
                         organization = "PartiQL"
                         organizationUrl = "https://github.com/partiql"
                     }


### PR DESCRIPTION
Previous Maven publishing would include the Ion team's name and email as the developers (e.g. [v0.4.0 release on Maven](https://search.maven.org/artifact/org.partiql/partiql-ir-generator/0.4.0/jar) and similarly for [v0.4.0 runtime](https://search.maven.org/artifact/org.partiql/partiql-ir-generator-runtime/0.4.0/jar)). Updates to use the PartiQL team's info.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
