### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ allprojects {
 
 subprojects {
     group = 'org.partiql'
-    version = '0.4.1-SNAPSHOT'
+    version = '0.5.0'
 }
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 


### PR DESCRIPTION
Prepares PIG `v0.5.0` release. This is a new major version since https://github.com/partiql/partiql-ir-generator/commit/fdec2ef8a761072bccb845ad3c0dc59cd27d3796 splits the PIG-generated code into multiple files, which can break clients. From the commit summary:

> This includes breaking changes to the API used by Gradle clients and to the CLI's command-line options.

Part of https://github.com/partiql/partiql-ir-generator/issues/112 release request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
