### PR TITLE
Upgrade dokka to 1.6.10 following gradle upgrade

### DIFF
--- a/pig-runtime/build.gradle
+++ b/pig-runtime/build.gradle
@@ -20,7 +20,7 @@ plugins {
     id 'java-library'
     // https://docs.gradle.org/5.0/userguide/publishing_maven.html#header
     id 'maven-publish'
-    id 'org.jetbrains.dokka' version '0.9.18'
+    id 'org.jetbrains.dokka' version '1.6.10'
     id 'org.jetbrains.kotlin.jvm'
     id 'signing'
 }
@@ -48,9 +48,8 @@ test {
     useJUnitPlatform()
 }
 
-dokka {
-    outputFormat = "html"
-    outputDirectory = "$buildDir/javadoc"
+tasks.dokkaHtml.configure {
+    outputDirectory.set(file("$buildDir/javadoc"))
     //todo: includes = ["path/to/module.md"]
 }
 
@@ -60,8 +59,8 @@ task sourcesJar(type: Jar) {
 }
 
 task javadocJar(type: Jar) {
-    from dokka
-    classifier = "javadoc"
+    from dokkaHtml
+    archiveClassifier.set("javadoc")
 }
 
 publishing {

--- a/pig/build.gradle
+++ b/pig/build.gradle
@@ -18,7 +18,7 @@
 plugins {
     id 'application'
     id 'maven-publish'
-    id 'org.jetbrains.dokka' version '0.9.18'
+    id 'org.jetbrains.dokka' version '1.6.10'
     id 'org.jetbrains.kotlin.jvm'
     id 'signing'
 }
@@ -54,12 +54,10 @@ test {
     useJUnitPlatform()
 }
 
-dokka {
-    outputFormat = "html"
-    outputDirectory = "$buildDir/javadoc"
+tasks.dokkaHtml.configure {
+    outputDirectory.set(file("$buildDir/javadoc"))
     //todo: includes = ["path/to/module.md"]
 }
-
 
 //create a single Jar with all dependencies
 jar {
@@ -77,8 +75,8 @@ task sourcesJar(type: Jar) {
 }
 
 task javadocJar(type: Jar) {
-    from dokka
-    classifier = "javadoc"
+    from dokkaHtml
+    archiveClassifier.set("javadoc")
 }
 
 build {


### PR DESCRIPTION
Tried publishing a new version of PIG to maven, but got the following error:

```
> Task :pig:dokka FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Some problems were found with the configuration of task ':pig:dokka' (type 'DokkaTask').
  - In plugin 'org.jetbrains.dokka' type 'org.jetbrains.dokka.gradle.DokkaTask' property 'dokkaRuntime' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#missing_annotation for more details about this problem.
  - In plugin 'org.jetbrains.dokka' type 'org.jetbrains.dokka.gradle.DokkaTask' property 'outputDirectory' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#missing_annotation for more details about this problem.
  - In plugin 'org.jetbrains.dokka' type 'org.jetbrains.dokka.gradle.DokkaTask' property 'reportNotDocumented' is missing an input or output annotation.

    Reason: A property without annotation isn't considered during up-to-date checking.

    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.

    Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#missing_annotation for more details about this problem.
```

Upgrading the gradle version to 7 causes the above dokka error when publishing. I had to do something similar when publishing `partiql-isl-kotlin`: https://github.com/partiql/partiql-isl-kotlin/pull/4.

Tested by publishing to maven local:

```
❯ ./gradlew publishToMavenLocal

> Task :pig:dokkaHtml
Initializing plugins
Dokka is performing: documentation for pig
Validity check
Creating documentation models
Transforming documentation model before merging
Merging documentation models
Transforming documentation model after merging
Creating pages
Transforming pages
Rendering
Running post-actions


> Task :pig-runtime:dokkaHtml
Initializing plugins
Dokka is performing: documentation for pig-runtime
Validity check
Creating documentation models
Transforming documentation model before merging
Merging documentation models
Transforming documentation model after merging
Creating pages
Transforming pages
Rendering
Running post-actions


Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 24s
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
