### PR TITLE
Add mode to generate canonical PIG domains

### DIFF
--- a/pig/src/org/partiql/pig/cmdline/CommandLineParser.kt
+++ b/pig/src/org/partiql/pig/cmdline/CommandLineParser.kt
@@ -33,7 +33,8 @@ class CommandLineParser {
     ) {
         KOTLIN(requireNamespace = true, requireTemplateFile = false, requireOutputFile = false, requireOutputDirectory = true),
         CUSTOM(requireNamespace = false, requireTemplateFile = true, requireOutputFile = true, requireOutputDirectory = false),
-        HTML(requireNamespace = false, requireTemplateFile = false, requireOutputFile = true, requireOutputDirectory = false)
+        HTML(requireNamespace = false, requireTemplateFile = false, requireOutputFile = true, requireOutputDirectory = false),
+        ION(requireNamespace = false, requireTemplateFile = false, requireOutputFile = true, requireOutputDirectory = false)
     }
 
     private object LanguageTargetTypeValueConverter : ValueConverter<LanguageTargetType> {
@@ -63,6 +64,7 @@ class CommandLineParser {
                 |   --target=kotlin requires --namespace=<ns> and --output-directory=<out-dir>
                 |   --target=custom requires --template=<path-to-template> and --output-file=<generated-file>
                 |   --target=html   requires --output-file=<output-html-file>
+                |   --target=ion    requires --output-file=<output-ion-file>
                 |
                 |Notes:
                 |
@@ -80,6 +82,11 @@ class CommandLineParser {
                 |      --output-file=example.txt \
                 |      --template=template.ftl 
                 |     
+                |  pig --target=ion \
+                |      --universe=universe.ion \ 
+                |      --output-file=example.ion
+                |     
+        ""${'"'}.trimMargin()
         """.trimMargin()
         }
     }
@@ -195,6 +202,9 @@ class CommandLineParser {
                         )
                         LanguageTargetType.CUSTOM -> TargetLanguage.Custom(
                             templateFile = optSet.valueOf(templateOpt),
+                            outputFile = optSet.valueOf(outputFileOpt) as File
+                        )
+                        LanguageTargetType.ION -> TargetLanguage.Ion(
                             outputFile = optSet.valueOf(outputFileOpt) as File
                         )
                     }

--- a/pig/src/org/partiql/pig/cmdline/CommandLineParser.kt
+++ b/pig/src/org/partiql/pig/cmdline/CommandLineParser.kt
@@ -54,6 +54,20 @@ class CommandLineParser {
         }
     }
 
+    private object DomainFilterValueConverter : ValueConverter<Set<String>> {
+        override fun convert(value: String?): Set<String> {
+            if (value.isNullOrBlank()) throw ValueConversionException("Value was empty")
+            return value.split(',').map(String::trim).toSet()
+        }
+
+        override fun valueType(): Class<out Set<String>>? = null
+
+        override fun valuePattern(): String {
+            return "<domain 1>,<domain 2>,..."
+        }
+    }
+
+
     private val formatter = object : BuiltinHelpFormatter(120, 2) {
         override fun format(options: MutableMap<String, out OptionDescriptor>?): String {
             return """PartiQL I.R. Generator
@@ -120,6 +134,10 @@ class CommandLineParser {
     private val templateOpt = optParser.acceptsAll(listOf("template", "e"), "Path to an Apache FreeMarker template")
         .withOptionalArg()
         .ofType(File::class.java)
+
+    private val domainsOpt = optParser.acceptsAll(listOf("domains", "f"), "List of domains to generate (comma separated)")
+        .withOptionalArg()
+        .withValuesConvertedBy(DomainFilterValueConverter)
 
     /**
      * Prints help to the specified [PrintStream].
@@ -194,18 +212,26 @@ class CommandLineParser {
                         )
                     }
 
+                    val domains = optSet.valueOf(domainsOpt)
+
                     val target = when (targetType) {
-                        LanguageTargetType.HTML -> TargetLanguage.Html(optSet.valueOf(outputFileOpt) as File)
+                        LanguageTargetType.HTML -> TargetLanguage.Html(
+                            outputFile = optSet.valueOf(outputFileOpt) as File,
+                            domains = domains
+                        )
                         LanguageTargetType.KOTLIN -> TargetLanguage.Kotlin(
                             namespace = optSet.valueOf(namespaceOpt) as String,
-                            outputDirectory = optSet.valueOf(outputDirectoryOpt) as File
+                            outputDirectory = optSet.valueOf(outputDirectoryOpt) as File,
+                            domains = domains
                         )
                         LanguageTargetType.CUSTOM -> TargetLanguage.Custom(
                             templateFile = optSet.valueOf(templateOpt),
-                            outputFile = optSet.valueOf(outputFileOpt) as File
+                            outputFile = optSet.valueOf(outputFileOpt) as File,
+                            domains = domains
                         )
                         LanguageTargetType.ION -> TargetLanguage.Ion(
-                            outputFile = optSet.valueOf(outputFileOpt) as File
+                            outputFile = optSet.valueOf(outputFileOpt) as File,
+                            domains = domains
                         )
                     }
 

--- a/pig/src/org/partiql/pig/cmdline/TargetLanguage.kt
+++ b/pig/src/org/partiql/pig/cmdline/TargetLanguage.kt
@@ -18,8 +18,8 @@ package org.partiql.pig.cmdline
 import java.io.File
 
 sealed class TargetLanguage {
-    data class Kotlin(val namespace: String, val outputDirectory: File) : TargetLanguage()
-    data class Custom(val templateFile: File, val outputFile: File) : TargetLanguage()
-    data class Html(val outputFile: File) : TargetLanguage()
-    data class Ion(val outputFile: File) : TargetLanguage()
+    data class Kotlin(val namespace: String, val outputDirectory: File, val domains: Set<String>? = null) : TargetLanguage()
+    data class Custom(val templateFile: File, val outputFile: File, val domains: Set<String>? = null) : TargetLanguage()
+    data class Html(val outputFile: File, val domains: Set<String>? = null) : TargetLanguage()
+    data class Ion(val outputFile: File, val domains: Set<String>? = null) : TargetLanguage()
 }

--- a/pig/src/org/partiql/pig/cmdline/TargetLanguage.kt
+++ b/pig/src/org/partiql/pig/cmdline/TargetLanguage.kt
@@ -21,4 +21,5 @@ sealed class TargetLanguage {
     data class Kotlin(val namespace: String, val outputDirectory: File) : TargetLanguage()
     data class Custom(val templateFile: File, val outputFile: File) : TargetLanguage()
     data class Html(val outputFile: File) : TargetLanguage()
+    data class Ion(val outputFile: File) : TargetLanguage()
 }

--- a/pig/src/org/partiql/pig/domain/Util.kt
+++ b/pig/src/org/partiql/pig/domain/Util.kt
@@ -1,0 +1,57 @@
+package org.partiql.pig.domain.model
+
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.ionSexpOf
+import com.amazon.ionelement.api.ionSymbol
+import com.amazon.ionelement.api.withAnnotations
+
+/*
+ * The [toIonElement] functions below generate an s-expression representation of a [TypeUniverse].
+ */
+
+fun TypeDomain.toIonElement(): IonElement =
+    ionSexpOf(
+        ionSymbol("define"),
+        ionSymbol(tag),
+        ionSexpOf(
+            ionSymbol("domain"),
+            *userTypes
+                .filterNot { it.isDifferent }
+                .map { it.toIonElement(includeTypeTag = true) }.toTypedArray()
+        )
+    )
+
+fun DataType.toIonElement(includeTypeTag: Boolean): IonElement = when (this) {
+    DataType.Ion -> ionSymbol("ion")
+    DataType.Bool -> ionSymbol("bool")
+    DataType.Int -> ionSymbol("int")
+    DataType.Symbol -> ionSymbol("symbol")
+    is DataType.UserType.Tuple ->
+        ionSexpOf(
+            listOfNotNull(
+                if (includeTypeTag) ionSymbol(tupleType.toString().toLowerCase()) else null,
+                ionSymbol(tag),
+                *namedElements.map { it.toIonElement(this.tupleType) }.toTypedArray()
+            )
+        )
+    is DataType.UserType.Sum ->
+        ionSexpOf(
+            ionSymbol("sum"),
+            ionSymbol(tag),
+            *variants
+                .filterNot { it.isDifferent }
+                .map { it.toIonElement(includeTypeTag = false) }.toTypedArray()
+        )
+}
+
+fun NamedElement.toIonElement(tupleType: TupleType) =
+    when (tupleType) {
+        TupleType.PRODUCT -> typeReference.toIonElement().withAnnotations(identifier)
+        TupleType.RECORD ->
+            ionSexpOf(ionSymbol(tag), typeReference.toIonElement()).let {
+                when {
+                    tag != identifier -> it.withAnnotations(identifier)
+                    else -> it
+                }
+            }
+    }

--- a/pig/src/org/partiql/pig/domain/Utils.kt
+++ b/pig/src/org/partiql/pig/domain/Utils.kt
@@ -1,12 +1,22 @@
-package org.partiql.pig.domain.model
+package org.partiql.pig.domain
 
 import com.amazon.ionelement.api.IonElement
 import com.amazon.ionelement.api.ionSexpOf
 import com.amazon.ionelement.api.ionSymbol
 import com.amazon.ionelement.api.withAnnotations
+import org.partiql.pig.domain.model.DataType
+import org.partiql.pig.domain.model.NamedElement
+import org.partiql.pig.domain.model.TupleType
+import org.partiql.pig.domain.model.TypeDomain
+
+/**
+ *  Filter a [List]<[TypeDomain]> to only contain [TypeDomain]s that are present in [domains]
+ */
+fun List<TypeDomain>.filterDomains(domains: Set<String>?) =
+    domains?.let { this.filter { domain -> domain.tag in it } } ?: this
 
 /*
- * The [toIonElement] functions below generate an s-expression representation of a [TypeUniverse].
+ * The [toIonElement] functions below generate an s-expression representation of a [TypeDomain].
  */
 
 fun TypeDomain.toIonElement(): IonElement =

--- a/pig/src/org/partiql/pig/generator/ion/generator.kt
+++ b/pig/src/org/partiql/pig/generator/ion/generator.kt
@@ -1,0 +1,11 @@
+package org.partiql.pig.generator.ion
+
+import org.partiql.pig.domain.model.TypeDomain
+import org.partiql.pig.domain.toIonElement
+import java.io.PrintWriter
+
+/**
+ * Generate an Ion representation of each type domain and write it to [output]
+ */
+fun generateIon(domains: List<TypeDomain>, output: PrintWriter) =
+    domains.map(TypeDomain::toIonElement).forEach(output::println)

--- a/pig/src/org/partiql/pig/main.kt
+++ b/pig/src/org/partiql/pig/main.kt
@@ -16,10 +16,13 @@
 package org.partiql.pig
 
 import com.amazon.ion.system.IonReaderBuilder
+import com.amazon.ionelement.api.ionSexpOf
+import com.amazon.ionelement.api.ionSymbol
 import org.partiql.pig.cmdline.Command
 import org.partiql.pig.cmdline.CommandLineParser
 import org.partiql.pig.cmdline.TargetLanguage
 import org.partiql.pig.domain.model.TypeUniverse
+import org.partiql.pig.domain.model.toIonElement
 import org.partiql.pig.domain.parser.parseTypeUniverse
 import org.partiql.pig.errors.PigException
 import org.partiql.pig.generator.custom.applyCustomTemplate
@@ -94,6 +97,17 @@ fun generateCode(command: Command.Generate) {
             progress("applying the HTML template")
             PrintWriter(command.target.outputFile).use { printWriter ->
                 applyHtmlTemplate(typeUniverse.computeTypeDomains(), printWriter)
+            }
+        }
+        is TargetLanguage.Ion -> {
+            progress("output file  : ${command.target.outputFile}")
+
+            PrintWriter(command.target.outputFile).use { printWriter ->
+                val universe = ionSexpOf(
+                    ionSymbol("universe"),
+                    *typeUniverse.computeTypeDomains().map { it.toIonElement() }.toTypedArray()
+                )
+                printWriter.println(universe)
             }
         }
     }

--- a/pig/test/org/partiql/pig/cmdline/CommandLineParserTests.kt
+++ b/pig/test/org/partiql/pig/cmdline/CommandLineParserTests.kt
@@ -86,6 +86,18 @@ class CommandLineParserTests {
                 "-u=input.ion", "-t=kotlin", "-d=out_dir", "-n=some.package"
             ),
 
+            // accepts --domains to filter for specific domains
+            TestCase(
+                Command.Generate(File("input.ion"), TargetLanguage.Kotlin("some.package", File("out_dir"), domains = setOf("foo", "bar"))),
+                "--universe=input.ion", "--target=kotlin", "--output-directory=out_dir", "--namespace=some.package", "--domains=foo,bar"
+            ),
+
+            // accepts -f to filter for specific domains
+            TestCase(
+                Command.Generate(File("input.ion"), TargetLanguage.Kotlin("some.package", File("out_dir"), domains = setOf("foo", "bar"))),
+                "-u=input.ion", "-t=kotlin", "-d=out_dir", "-n=some.package", "-f=foo,bar"
+            ),
+
             // missing the --namespace argument
             TestCase(
                 Command.InvalidCommandLineArguments("The selected language target requires the --namespace argument"),
@@ -107,6 +119,18 @@ class CommandLineParserTests {
                 "-u=input.ion", "-target=html", "--output-file=output.html"
             ),
 
+            // accepts --domains to filter for specific domains
+            TestCase(
+                Command.Generate(File("input.ion"), TargetLanguage.Html(File("output.html"), domains = setOf("foo", "bar"))),
+                "--universe=input.ion", "--target=html", "--output-file=output.html", "--domains=foo,bar"
+            ),
+
+            // accepts -f to filter for specific domains
+            TestCase(
+                Command.Generate(File("input.ion"), TargetLanguage.Html(File("output.html"), domains = setOf("foo", "bar"))),
+                "-u=input.ion", "-target=html", "--output-file=output.html", "-f=foo,bar"
+            ),
+
             // //////////////////////////////////////////////////////
             // Ion target
             // //////////////////////////////////////////////////////
@@ -122,6 +146,18 @@ class CommandLineParserTests {
                 "-u=input.ion", "-target=ion", "--output-file=output.ion"
             ),
 
+            // accepts --domains to filter for specific domains
+            TestCase(
+                Command.Generate(File("input.ion"), TargetLanguage.Ion(File("output.ion"), domains = setOf("foo", "bar"))),
+                "--universe=input.ion", "--target=ion", "--output-file=output.ion", "--domains=foo,bar"
+            ),
+
+            // accepts -f to filter for specific domains
+            TestCase(
+                Command.Generate(File("input.ion"), TargetLanguage.Ion(File("output.ion"), domains = setOf("foo", "bar"))),
+                "-u=input.ion", "-target=ion", "--output-file=output.ion", "-f=foo,bar"
+            ),
+
             // //////////////////////////////////////////////////////
             // Custom target
             // //////////////////////////////////////////////////////
@@ -135,6 +171,18 @@ class CommandLineParserTests {
             TestCase(
                 Command.Generate(File("input.ion"), TargetLanguage.Custom(File("template.ftl"), File("output.txt"))),
                 "-u=input.ion", "-t=custom", "-o=output.txt", "-e=template.ftl"
+            ),
+
+            // accepts --domains to filter for specific domains
+            TestCase(
+                Command.Generate(File("input.ion"), TargetLanguage.Custom(File("template.ftl"), File("output.txt"), domains = setOf("foo", "bar"))),
+                "--universe=input.ion", "--target=custom", "--output-file=output.txt", "--template=template.ftl", "--domains=foo,bar"
+            ),
+
+            // accepts -f to filter for specific domains
+            TestCase(
+                Command.Generate(File("input.ion"), TargetLanguage.Custom(File("template.ftl"), File("output.txt"), domains = setOf("foo", "bar"))),
+                "-u=input.ion", "-target=custom", "--output-file=output.txt", "-e=template.ftl", "-f=foo,bar"
             ),
 
             // missing the --template argument

--- a/pig/test/org/partiql/pig/cmdline/CommandLineParserTests.kt
+++ b/pig/test/org/partiql/pig/cmdline/CommandLineParserTests.kt
@@ -108,6 +108,21 @@ class CommandLineParserTests {
             ),
 
             // //////////////////////////////////////////////////////
+            // Ion target
+            // //////////////////////////////////////////////////////
+            // long parameter names
+            TestCase(
+                Command.Generate(File("input.ion"), TargetLanguage.Ion(File("output.ion"))),
+                "--universe=input.ion", "--target=ion", "--output-file=output.ion"
+            ),
+
+            // short parameter names
+            TestCase(
+                Command.Generate(File("input.ion"), TargetLanguage.Ion(File("output.ion"))),
+                "-u=input.ion", "-target=ion", "--output-file=output.ion"
+            ),
+
+            // //////////////////////////////////////////////////////
             // Custom target
             // //////////////////////////////////////////////////////
             // long parameter names

--- a/pig/test/org/partiql/pig/generator/ion/GenerateIonTest.kt
+++ b/pig/test/org/partiql/pig/generator/ion/GenerateIonTest.kt
@@ -1,0 +1,74 @@
+package org.partiql.pig.generator.ion
+
+import com.amazon.ion.system.IonReaderBuilder
+import org.junit.jupiter.api.Test
+import org.partiql.pig.domain.parser.parseTypeUniverse
+import java.io.PrintWriter
+import java.io.StringWriter
+import kotlin.test.assertEquals
+
+class GenerateIonTest {
+    @Test
+    fun `should generate canonical Ion domains`() {
+        // Typical type universe (contains domain definitions, permutations, etc.)
+        val typeUniverseWithExtensions = """        
+        (define test_domain
+            (domain 
+                (product pair first::ion second::ion)
+                (product other_pair first::symbol second::symbol)
+                (sum thing
+                    (a x::pair)
+                    (b y::symbol)
+                    (c z::int))))
+
+        (define permuted_domain 
+            (permute_domain test_domain
+                (exclude pair)
+                (include
+                    (product pair n::int t::int)
+                    (product new_pair m::symbol n::int))
+                (with thing
+                    (exclude a)
+                    (include
+                        (d a::pair)
+                        (e b::symbol)))))
+        """
+
+        // The expected type universe should only contain pure domain definitions (i.e. no permutations)
+        val expectedDomains = """
+        (define test_domain
+            (domain 
+                (product pair first::ion second::ion)
+                (product other_pair first::symbol second::symbol)
+                (sum thing
+                    (a x::pair)
+                    (b y::symbol)
+                    (c z::int))))
+
+        (define permuted_domain 
+            (domain
+                (product other_pair first::symbol second::symbol)
+                (sum thing
+                    (b y::symbol)
+                    (c z::int)
+                    (d a::pair)
+                    (e b::symbol))
+                (product pair n::int t::int)
+                (product new_pair m::symbol n::int)))
+        """
+
+        val td = IonReaderBuilder.standard().build(typeUniverseWithExtensions).use { parseTypeUniverse(it) }
+
+        val concretes = td.computeTypeDomains()
+
+        val writer = StringWriter()
+        generateIon(concretes, PrintWriter(writer))
+        val output = writer.toString()
+
+        val actual = IonReaderBuilder.standard().build(output).use { parseTypeUniverse(it) }
+
+        val expected = IonReaderBuilder.standard().build(expectedDomains).use { parseTypeUniverse(it) }
+
+        assertEquals(expected, actual, "Computed domains should match")
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This adds two new features:
1. Adds a new `Ion` target that spits out the computed type domains in a canonical Ion form (i.e. all output domains are pure definitions, there are no permutations or transforms)
2. Adds a `--domains`/`-f` command line argument that allows you to specify a subset of domains to generate (rather than requiring all of them)

This makes it much easier to work with and post-process PIG domains outside of PIG while still leveraging PIG to do validation and type resolution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
