### PR TITLE
Fix GitHub Actions to run on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,5 @@
 name: "Build and run tests"
-on:
-  push:
-  pull_request:
-    branches:
-      # Branches from forks have the form 'user:branch-name' so we only run
-      # this job on pull_request events for branches that look like fork
-      # branches. Without this we would end up running this job twice for non
-      # forked PRs, once for the push and then once for opening the PR.
-      # Taken from https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/10
-      - '**:**'
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Removes the GitHub Actions 'on' restriction so GitHub Actions will run forks again. Related to https://github.com/partiql/partiql-lang-kotlin/issues/561. 

There was a followup to the github community question saying that the previous approach didn't work anymore to prevent duplicate builds: https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/13.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
