### PR TITLE
V0.5.1

### DIFF
--- a/buildSrc/src/main/kotlin/pig.publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/pig.publish.gradle.kts
@@ -30,14 +30,24 @@ java {
     withSourcesJar()
 }
 
+fun String.mavenName(): String = when (this) {
+    "pig-runtime" -> "PartiQL I.R. Generator (a.k.a P.I.G.) Runtime Library"
+    else -> "PartiQL I.R. Generator (a.k.a P.I.G.)"
+}
+
+fun String.artifactId(): String = name.replace("pig", "partiql-ir-generator")
+
 publishing {
     publications {
         create<MavenPublication>(name) {
-            artifactId = name.replace("pig", "partiql-ir-generator")
+            val module = name
+            artifactId = module.artifactId()
             from(components["java"])
             pom {
                 url.set("https://partiql.org/")
                 packaging = "jar"
+                name.set(module.mavenName())
+                description.set("The P.I.G. is a code generator for domain models such ASTs and execution plans.")
                 scm {
                     connection.set("scm:git@github.com:partiql/partiql-ir-generator.git")
                     developerConnection.set("scm:git@github.com:partiql/partiql-ir-generator.git")


### PR DESCRIPTION
*Description of changes:*

While publishing, validation failed because `name` and `description` were not set in the POM. This change has been verified with
```
./gradlew generatePomFileForPigPublication generatePomFileForPig-runtimePublication  
```

**POM**
```
# pig
   9   │   <groupId>org.partiql</groupId>
  10   │   <artifactId>partiql-ir-generator</artifactId>
  11   │   <version>0.5.1</version>
  12   │   <name>PartiQL I.R. Generator (a.k.a P.I.G.)</name>
  13   │   <description>The P.I.G. is a code generator for domain models such ASTs and execution plans.</description>
  14   │   <url>https://partiql.org/</url>

# pig-runtime
   9   │   <groupId>org.partiql</groupId>
  10   │   <artifactId>partiql-ir-generator-runtime</artifactId>
  11   │   <version>0.5.1</version>
  12   │   <name>PartiQL I.R. Generator (a.k.a P.I.G.) Runtime Library</name>
  13   │   <description>The P.I.G. is a code generator for domain models such ASTs and execution plans.</description>
  14   │   <url>https://partiql.org/</url>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
