### PR TITLE
(#41) Adds asAnyElement for List<IonElement>

### DIFF
--- a/pig-runtime/src/main/kotlin/org/partiql/pig/runtime/IonElementHelpers.kt
+++ b/pig-runtime/src/main/kotlin/org/partiql/pig/runtime/IonElementHelpers.kt
@@ -82,3 +82,5 @@ val List<AnyElement>.head: AnyElement
 
 /** Returns a copy of the list with the first element removed. */
 val List<AnyElement>.tail: List<AnyElement> get() = this.subList(1, this.size)
+
+fun List<IonElement>.asAnyElement() = this.map { it.asAnyElement() }

--- a/pig-runtime/src/main/kotlin/org/partiql/pig/runtime/IonElementHelpers.kt
+++ b/pig-runtime/src/main/kotlin/org/partiql/pig/runtime/IonElementHelpers.kt
@@ -83,4 +83,7 @@ val List<AnyElement>.head: AnyElement
 /** Returns a copy of the list with the first element removed. */
 val List<AnyElement>.tail: List<AnyElement> get() = this.subList(1, this.size)
 
-fun List<IonElement>.asAnyElement() = this.map { it.asAnyElement() }
+/**
+ * Returns a copy of the list with each element as AnyElement
+ */
+fun List<IonElement>.asAnyElement(): List<AnyElement> = this.map { it.asAnyElement() }


### PR DESCRIPTION
*Issue #, if available:*

#41 

*Description of changes:*

Adds an `asAnyElement` for `List<IonElement` to pig-runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
