### PR TITLE
Fix non-nullable type w/ `?` warnings

### DIFF
--- a/pig/src/main/kotlin/org/partiql/pig/generator/kotlin/KTypeDomainConverter.kt
+++ b/pig/src/main/kotlin/org/partiql/pig/generator/kotlin/KTypeDomainConverter.kt
@@ -241,7 +241,16 @@ private class KTypeDomainConverter(
                 val elementIsKotlinPrimitive = isKotlinPrimitive(element)
                 val elementKotlinName = element.identifier.snakeToCamelCase()
                 when (element.typeReference.arity) {
-                    is Arity.Required, Arity.Optional -> {
+                    is Arity.Required -> {
+                        KConstructorArgument(
+                            kotlinName = elementKotlinName,
+                            value = elementKotlinName + when {
+                                elementIsKotlinPrimitive && useKotlinPrimitives -> ".asPrimitive()"
+                                else -> ""
+                            }
+                        )
+                    }
+                    is Arity.Optional -> {
                         KConstructorArgument(
                             kotlinName = elementKotlinName,
                             value = elementKotlinName + when {

--- a/pig/src/main/resources/org/partiql/pig/templates/kotlin-domain.ftl
+++ b/pig/src/main/resources/org/partiql/pig/templates/kotlin-domain.ftl
@@ -58,7 +58,11 @@ class ${t.kotlinName}(
             [#if p.variadic]
             if(${p.kotlinName}.any()) { ionSexpOf(ionSymbol("${p.tag}"), *${p.kotlinName}.map { it.toIonElement() }.toTypedArray()) } else { null }[#sep],[/#sep]
             [#else]
+            [#if p.nullable]
             ${p.kotlinName}?.let { ionSexpOf(ionSymbol("${p.tag}"), it.toIonElement()) }[#sep],[/#sep]
+            [#else]
+            ionSexpOf(ionSymbol("${p.tag}"), ${p.kotlinName}.toIonElement())[#sep],[/#sep]
+            [/#if]
             [/#if]
         [/#list]
         )


### PR DESCRIPTION
*Issue #, if available:* fixes https://github.com/partiql/partiql-ir-generator/issues/154

*Description of changes:* PIG-generated code was previously always adding a `?` to non-nullable values for builder function constructor and `.toIonElement` calls in which there was a variadic list of parameters. This is currently a warning in Kotlin 1.6 but causes in error in Kotlin 1.7 and later.

Example for builder function constructor:
```kotlin
        /**
         * Creates an instance of [PartiqlBasic.Expr.Call].
         */
        fun call(
            name: String,
            args0: Expr,
            vararg args: Expr,
            metas: MetaContainer = emptyMetaContainer()
        ): PartiqlBasic.Expr.Call =
            PartiqlBasic.Expr.Call(
                name = name?.asPrimitive(),   <- `name` is not nullable
                args = listOf(args0) + args.toList(),
                metas = newMetaContainer() + metas
            )
```

With the fix, this will now be:
```kotlin
        /**
         * Creates an instance of [PartiqlBasic.Expr.Call].
         */
        fun call(
            name: String,
            args0: Expr,
            vararg args: Expr,
            metas: MetaContainer = emptyMetaContainer()
        ): PartiqlBasic.Expr.Call =
            PartiqlBasic.Expr.Call(
                name = name.asPrimitive(),
                args = listOf(args0) + args.toList(),
                metas = newMetaContainer() + metas
            )
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
