### PR TITLE
Prepare 0.6.3 release w/ corrected `artifactId`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To obtain the `pig` executable:
 
 - Clone this repository.
 - Check out the tag of the [release](https://github.com/partiql/partiql-ir-generator/releases) you wish to utilize,
-  e.g. `git checkout v0.6.1`
+  e.g. `git checkout v0.6.3`
 - Execute `./gradlew assemble`
 
 After the build completes, the `pig` executable and dependencies will be located

--- a/pig-runtime/build.gradle.kts
+++ b/pig-runtime/build.gradle.kts
@@ -23,6 +23,6 @@ dependencies {
 }
 
 publish {
-    artifactId = "pig-runtime"
+    artifactId = "partiql-ir-generator-runtime"
     name = "PartiQL I.R. Generator (a.k.a P.I.G.) Runtime Library"
 }

--- a/pig/build.gradle.kts
+++ b/pig/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 publish {
-    artifactId = "pig"
+    artifactId = "partiql-ir-generator"
     name = "PartiQL I.R. Generator (a.k.a P.I.G.)"
 }
 


### PR DESCRIPTION
Previous https://github.com/partiql/partiql-ir-generator/commit/fa0f3dc5e672f77fad92fb802673f95979732be5#diff-d1bdb9bf5128a41179d4be959d57576f4353bb03085f4be02340ff581264b664 commit changed the artifactIds for the PIG and PIG-runtime libraries published to Maven.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
