### PR TITLE
Prepare v0.6.4-SNAPSHOT; update plugin to 0.6.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.partiql
-version=0.6.3
+version=0.6.4-SNAPSHOT
 # Required for the maven publish plugin--these properties must be present even if they contain placeholder values.
 ossrhUsername=EMPTY
 ossrhPassword=EMPTY

--- a/pig-gradle-plugin/build.gradle.kts
+++ b/pig-gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 object Versions {
-    const val pig = "0.6.2"
+    const val pig = "0.6.3"
     const val kotlinTarget = "1.4"
     const val javaTarget = "1.8"
 }

--- a/pig-tests/src/main/kotlin/org/partiql/pig/tests/generated/DomainA.generated.kt
+++ b/pig-tests/src/main/kotlin/org/partiql/pig/tests/generated/DomainA.generated.kt
@@ -501,7 +501,7 @@ class DomainA private constructor() {
         override fun toIonElement(): SexpElement {
             val elements = listOfNotNull(
                 ionSymbol("record_to_remove"),
-                irrelevant?.let { ionSexpOf(ionSymbol("irrelevant"), it.toIonElement()) }
+                ionSexpOf(ionSymbol("irrelevant"), irrelevant.toIonElement())
             )
     
             return ionSexpOf(elements, metas = metas)
@@ -611,8 +611,8 @@ class DomainA private constructor() {
         override fun toIonElement(): SexpElement {
             val elements = listOfNotNull(
                 ionSymbol("record_a"),
-                one?.let { ionSexpOf(ionSymbol("one"), it.toIonElement()) },
-                two?.let { ionSexpOf(ionSymbol("two"), it.toIonElement()) }
+                ionSexpOf(ionSymbol("one"), one.toIonElement()),
+                ionSexpOf(ionSymbol("two"), two.toIonElement())
             )
     
             return ionSexpOf(elements, metas = metas)
@@ -726,8 +726,8 @@ class DomainA private constructor() {
         override fun toIonElement(): SexpElement {
             val elements = listOfNotNull(
                 ionSymbol("unpermuted_record"),
-                foo?.let { ionSexpOf(ionSymbol("foo"), it.toIonElement()) },
-                bar?.let { ionSexpOf(ionSymbol("bar"), it.toIonElement()) }
+                ionSexpOf(ionSymbol("foo"), foo.toIonElement()),
+                ionSexpOf(ionSymbol("bar"), bar.toIonElement())
             )
     
             return ionSexpOf(elements, metas = metas)
@@ -1020,7 +1020,7 @@ class DomainA private constructor() {
             override fun toIonElement(): SexpElement {
                 val elements = listOfNotNull(
                     ionSymbol("noti"),
-                    a?.let { ionSexpOf(ionSymbol("a"), it.toIonElement()) }
+                    ionSexpOf(ionSymbol("a"), a.toIonElement())
                 )
         
                 return ionSexpOf(elements, metas = metas)
@@ -1284,8 +1284,8 @@ class DomainA private constructor() {
             override fun toIonElement(): SexpElement {
                 val elements = listOfNotNull(
                     ionSymbol("unpermuted_record_variant"),
-                    foo?.let { ionSexpOf(ionSymbol("foo"), it.toIonElement()) },
-                    bar?.let { ionSexpOf(ionSymbol("bar"), it.toIonElement()) }
+                    ionSexpOf(ionSymbol("foo"), foo.toIonElement()),
+                    ionSexpOf(ionSymbol("bar"), bar.toIonElement())
                 )
         
                 return ionSexpOf(elements, metas = metas)

--- a/pig-tests/src/main/kotlin/org/partiql/pig/tests/generated/DomainB.generated.kt
+++ b/pig-tests/src/main/kotlin/org/partiql/pig/tests/generated/DomainB.generated.kt
@@ -470,8 +470,8 @@ class DomainB private constructor() {
         override fun toIonElement(): SexpElement {
             val elements = listOfNotNull(
                 ionSymbol("unpermuted_record"),
-                foo?.let { ionSexpOf(ionSymbol("foo"), it.toIonElement()) },
-                bar?.let { ionSexpOf(ionSymbol("bar"), it.toIonElement()) }
+                ionSexpOf(ionSymbol("foo"), foo.toIonElement()),
+                ionSexpOf(ionSymbol("bar"), bar.toIonElement())
             )
     
             return ionSexpOf(elements, metas = metas)
@@ -574,7 +574,7 @@ class DomainB private constructor() {
         override fun toIonElement(): SexpElement {
             val elements = listOfNotNull(
                 ionSymbol("record_a"),
-                one?.let { ionSexpOf(ionSymbol("one"), it.toIonElement()) }
+                ionSexpOf(ionSymbol("one"), one.toIonElement())
             )
     
             return ionSexpOf(elements, metas = metas)
@@ -722,7 +722,7 @@ class DomainB private constructor() {
         override fun toIonElement(): SexpElement {
             val elements = listOfNotNull(
                 ionSymbol("new_record"),
-                foo?.let { ionSexpOf(ionSymbol("foo"), it.toIonElement()) }
+                ionSexpOf(ionSymbol("foo"), foo.toIonElement())
             )
     
             return ionSexpOf(elements, metas = metas)
@@ -844,8 +844,8 @@ class DomainB private constructor() {
             override fun toIonElement(): SexpElement {
                 val elements = listOfNotNull(
                     ionSymbol("unpermuted_record_variant"),
-                    foo?.let { ionSexpOf(ionSymbol("foo"), it.toIonElement()) },
-                    bar?.let { ionSexpOf(ionSymbol("bar"), it.toIonElement()) }
+                    ionSexpOf(ionSymbol("foo"), foo.toIonElement()),
+                    ionSexpOf(ionSymbol("bar"), bar.toIonElement())
                 )
         
                 return ionSexpOf(elements, metas = metas)

--- a/pig-tests/src/main/kotlin/org/partiql/pig/tests/generated/MultiWordDomain.generated.kt
+++ b/pig-tests/src/main/kotlin/org/partiql/pig/tests/generated/MultiWordDomain.generated.kt
@@ -383,8 +383,8 @@ class MultiWordDomain private constructor() {
             metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAad =
             MultiWordDomain.AabAad(
-                bField = bField?.asPrimitive(),
-                cField = cField?.asPrimitive(),
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
                 dField = dField.map { it.asPrimitive() },
                 metas = newMetaContainer() + metas
             )
@@ -458,8 +458,8 @@ class MultiWordDomain private constructor() {
             metas: MetaContainer = emptyMetaContainer()
         ): MultiWordDomain.AabAae =
             MultiWordDomain.AabAae(
-                bField = bField?.asPrimitive(),
-                cField = cField?.asPrimitive(),
+                bField = bField.asPrimitive(),
+                cField = cField.asPrimitive(),
                 dField = listOfPrimitives(dField0, dField1) + dField.map { it.asPrimitive() },
                 metas = newMetaContainer() + metas
             )
@@ -1175,8 +1175,8 @@ class MultiWordDomain private constructor() {
         override fun toIonElement(): SexpElement {
             val elements = listOfNotNull(
                 ionSymbol("rrr"),
-                aField?.let { ionSexpOf(ionSymbol("a_field"), it.toIonElement()) },
-                bbbField?.let { ionSexpOf(ionSymbol("b_field"), it.toIonElement()) }
+                ionSexpOf(ionSymbol("a_field"), aField.toIonElement()),
+                ionSexpOf(ionSymbol("b_field"), bbbField.toIonElement())
             )
     
             return ionSexpOf(elements, metas = metas)

--- a/pig-tests/src/main/kotlin/org/partiql/pig/tests/generated/PartiqlBasic.generated.kt
+++ b/pig-tests/src/main/kotlin/org/partiql/pig/tests/generated/PartiqlBasic.generated.kt
@@ -799,7 +799,7 @@ class PartiqlBasic private constructor() {
             metas: MetaContainer = emptyMetaContainer()
         ): PartiqlBasic.Expr.Call =
             PartiqlBasic.Expr.Call(
-                name = name?.asPrimitive(),
+                name = name.asPrimitive(),
                 args = listOf(args0) + args.toList(),
                 metas = newMetaContainer() + metas
             )
@@ -3302,8 +3302,8 @@ class PartiqlBasic private constructor() {
                 val elements = listOfNotNull(
                     ionSymbol("select"),
                     setq?.let { ionSexpOf(ionSymbol("setq"), it.toIonElement()) },
-                    project?.let { ionSexpOf(ionSymbol("project"), it.toIonElement()) },
-                    from?.let { ionSexpOf(ionSymbol("from"), it.toIonElement()) },
+                    ionSexpOf(ionSymbol("project"), project.toIonElement()),
+                    ionSexpOf(ionSymbol("from"), from.toIonElement()),
                     where?.let { ionSexpOf(ionSymbol("where"), it.toIonElement()) },
                     group?.let { ionSexpOf(ionSymbol("group"), it.toIonElement()) },
                     having?.let { ionSexpOf(ionSymbol("having"), it.toIonElement()) },

--- a/pig-tests/src/main/kotlin/org/partiql/pig/tests/generated/TestDomain.generated.kt
+++ b/pig-tests/src/main/kotlin/org/partiql/pig/tests/generated/TestDomain.generated.kt
@@ -773,7 +773,7 @@ class TestDomain private constructor() {
             metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.ElementVariadic =
             TestDomain.ElementVariadic(
-                name = name?.asPrimitive(),
+                name = name.asPrimitive(),
                 ints = ints.map { it.asPrimitive() },
                 metas = newMetaContainer() + metas
             )
@@ -838,7 +838,7 @@ class TestDomain private constructor() {
             metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.RequiredVariadic =
             TestDomain.RequiredVariadic(
-                first = first?.asPrimitive(),
+                first = first.asPrimitive(),
                 second = second.map { it.asPrimitive() },
                 metas = newMetaContainer() + metas
             )
@@ -973,7 +973,7 @@ class TestDomain private constructor() {
             metas: MetaContainer = emptyMetaContainer()
         ): TestDomain.RequiredOptionalVariadic =
             TestDomain.RequiredOptionalVariadic(
-                first = first?.asPrimitive(),
+                first = first.asPrimitive(),
                 second = second?.asPrimitive(),
                 third = third.map { it.asPrimitive() },
                 metas = newMetaContainer() + metas
@@ -1047,7 +1047,7 @@ class TestDomain private constructor() {
         ): TestDomain.OptionalRequiredVariadic =
             TestDomain.OptionalRequiredVariadic(
                 first = first?.asPrimitive(),
-                second = second?.asPrimitive(),
+                second = second.asPrimitive(),
                 third = third.map { it.asPrimitive() },
                 metas = newMetaContainer() + metas
             )
@@ -3335,8 +3335,8 @@ class TestDomain private constructor() {
         override fun toIonElement(): SexpElement {
             val elements = listOfNotNull(
                 ionSymbol("domain_level_record"),
-                someField?.let { ionSexpOf(ionSymbol("some_field"), it.toIonElement()) },
-                anotherField?.let { ionSexpOf(ionSymbol("another_field"), it.toIonElement()) },
+                ionSexpOf(ionSymbol("some_field"), someField.toIonElement()),
+                ionSexpOf(ionSymbol("another_field"), anotherField.toIonElement()),
                 optionalField?.let { ionSexpOf(ionSymbol("optional_field"), it.toIonElement()) }
             )
     
@@ -4375,9 +4375,9 @@ class TestDomain private constructor() {
             override fun toIonElement(): SexpElement {
                 val elements = listOfNotNull(
                     ionSymbol("human"),
-                    firstName?.let { ionSexpOf(ionSymbol("first_name"), it.toIonElement()) },
+                    ionSexpOf(ionSymbol("first_name"), firstName.toIonElement()),
                     if(middleNames.any()) { ionSexpOf(ionSymbol("middle_names"), *middleNames.map { it.toIonElement() }.toTypedArray()) } else { null },
-                    lastName?.let { ionSexpOf(ionSymbol("last_name"), it.toIonElement()) },
+                    ionSexpOf(ionSymbol("last_name"), lastName.toIonElement()),
                     title?.let { ionSexpOf(ionSymbol("title"), it.toIonElement()) },
                     parent?.let { ionSexpOf(ionSymbol("parent"), it.toIonElement()) }
                 )


### PR DESCRIPTION
Prepares the next snapshot version. Updates the plugin dependency on PIG to 0.6.3.

Updating the plugin dependency also updated the generated sources in `pig-tests`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
