### PR TITLE
Downgrade from Dokka 1.9 to 1.6

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 
 object Versions {
     const val detekt = "1.20.0-RC1"
-    const val dokka = "1.9.20"
+    const val dokka = "1.6.10"
     const val kotlin = "1.5.+"
     const val ktlint = "10.2.1"
 }


### PR DESCRIPTION
*Description of changes:*

Dokka 1.9 includes an external CDN script for the Kotlin Playground. It is not possible to disable this (at the time of writing) so I have downgraded the dokka plugin to a version before this feature.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
